### PR TITLE
Add O1 flag to circom compilation

### DIFF
--- a/circuits/scripts/build_circuit.sh
+++ b/circuits/scripts/build_circuit.sh
@@ -23,7 +23,7 @@ fi
 cd ..
 
 echo "compiling circuit"
-circom circuits/proof_of_passport.circom -l node_modules --r1cs --wasm -c --output build
+circom circuits/proof_of_passport.circom -l node_modules --r1cs --O1 --wasm -c --output build
 
 echo "building zkey"
 yarn snarkjs groth16 setup build/proof_of_passport.r1cs build/powersOfTau28_hez_final_20.ptau build/proof_of_passport.zkey


### PR DESCRIPTION
Compiling with O1 flag is safer (no optimization of linear constraints)

Benchmark of current circuit with different optimization flags:
O2 (default) - 443351 constraints
O1 - 443771 constraints
O0 - 453270 constraints

Impact on performance looks minimal.