### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/actions/mobile-setup/action.yml
+++ b/.github/actions/mobile-setup/action.yml
@@ -35,7 +35,7 @@ runs:
         sudo update-locale LANG=en_US.UTF-8
 
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Ruby environment
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: development
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Circom installation from https://github.com/erhant/circomkit/blob/main/.github/workflows/tests.yml
       - name: Install dependencies

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,7 +15,7 @@ jobs:
       core_changed: ${{ steps.check-version.outputs.core_changed }}
       qrcode_changed: ${{ steps.check-version.outputs.qrcode_changed }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
       
@@ -38,7 +38,7 @@ jobs:
     if: needs.detect-changes.outputs.core_changed == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Set up Node.js
         uses: actions/setup-node@v3
@@ -70,7 +70,7 @@ jobs:
     if: needs.detect-changes.outputs.qrcode_changed == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Set up Node.js
         uses: actions/setup-node@v3


### PR DESCRIPTION
Hey ! GitHub‑hosted runners now use Node 20, so checkout v4 is required
This PR updates all workflows to actions/checkout@v4 , no functional changes expected