### PR TITLE
fix: add range check on paddedInLength of shaBytesDynamic

### DIFF
--- a/circuits/circuits/utils/crypto/hasher/shaBytes/shaBytesDynamic.circom
+++ b/circuits/circuits/utils/crypto/hasher/shaBytes/shaBytesDynamic.circom
@@ -3,6 +3,8 @@ pragma circom 2.1.9;
 include "./dynamic/sha1Bytes.circom";
 include "./dynamic/sha224Bytes.circom";
 include "@openpassport/zk-email-circuits/lib/sha.circom";
+include "@openpassport/zk-email-circuits/utils/array.circom";
+include "circomlib/circuits/bitify.circom";
 include "./dynamic/sha384Bytes.circom";
 include "./dynamic/sha512Bytes.circom";
 
@@ -19,6 +21,10 @@ template ShaBytesDynamic(hashLen, max_num_bytes) {
 
     signal output hash_bits[hashLen];
 
+    // Assert `in_len_padded_bytes` fits in `ceil(log2(max_num_bytes * 8))`
+    component rangeCheck = Num2Bits(log2Ceil(max_num_bytes * 8));
+    rangeCheck.in <== in_len_padded_bytes;
+
     if (hashLen == 512) {
         hash_bits <== Sha512Bytes(max_num_bytes)(in_padded, in_len_padded_bytes);
     }
@@ -28,7 +34,7 @@ template ShaBytesDynamic(hashLen, max_num_bytes) {
     if (hashLen == 256) {
         hash_bits <== Sha256Bytes(max_num_bytes)(in_padded, in_len_padded_bytes);
     }
-    if (hashLen == 224) { 
+    if (hashLen == 224) {
         hash_bits <== Sha224Bytes(max_num_bytes)(in_padded, in_len_padded_bytes);
     }
     if (hashLen == 160) {


### PR DESCRIPTION
This PR closes #578. The original author added range checks for Sha256Bytes and Sha1Bytes copied from zk-email. I've extended these checks to all SHA versions for safety.