### PR TITLE
Fix yarn publish token

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -66,6 +66,7 @@ jobs:
           yarn npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-qrcode:
     needs: detect-changes
@@ -93,6 +94,7 @@ jobs:
           yarn npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-common:
     needs: detect-changes
@@ -119,3 +121,4 @@ jobs:
           yarn npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- fix workflow for npm publishing by adding the token env var Yarn expects

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_b_68506b120d7c8330bedc69de4d7a6352