### PR TITLE
fix: add required permissions to mobile-deploy-auto workflow

### DIFF
--- a/.github/workflows/mobile-deploy-auto.yml
+++ b/.github/workflows/mobile-deploy-auto.yml
@@ -9,6 +9,10 @@ on:
       - '!app/**/*.md'
       - '!app/docs/**'
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   check-and-deploy:
     if: github.event.pull_request.merged == true && !contains(github.event.pull_request.labels.*.name, 'no-deploy')


### PR DESCRIPTION
- Add contents: write and pull-requests: write permissions
- This allows the workflow to call mobile-deploy.yml with proper permissions
- Fixes the startup failure when PR is merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow configuration to include explicit permissions for improved automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->