### PR TITLE
fix: correct Android AAB path and iOS TestFlight distribution settings

### DIFF
--- a/app/fastlane/Fastfile
+++ b/app/fastlane/Fastfile
@@ -38,7 +38,7 @@ SIGNING_CERTIFICATE = ENV["IOS_SIGNING_CERTIFICATE"]
 # Environment setup
 package_version = JSON.parse(File.read("../package.json"))["version"]
 # most of these values are for local development
-android_aab_path = "../android/app/build/outputs/bundle/release/app-release.aab"
+android_aab_path = "android/app/build/outputs/bundle/release/app-release.aab"
 android_gradle_file_path = "../android/app/build.gradle"
 android_keystore_path = "../android/app/upload-keystore.jks"
 android_play_store_json_key_path = "../android/app/play-store-key.json"
@@ -135,9 +135,7 @@ platform :ios do
     elsif deployment_track == 'internal'
       upload_to_testflight(
         api_key: result[:api_key],
-        distribute_external: true,
-        groups: ENV["IOS_TESTFLIGHT_GROUPS"].split(","),
-        changelog: "",
+        distribute_external: false,
         skip_waiting_for_build_processing: false,
       ) if result[:should_upload]
     elsif deployment_track == 'production'


### PR DESCRIPTION
Android fix:
- Change AAB path from '../android/...' to 'android/...'
- The gradle task runs with project_dir: 'android/' from app/ directory
- So the AAB is created at app/android/app/build/outputs/bundle/release/
- The path should be relative to app/ not app/fastlane/

iOS fix:
- Remove distribute_external: true and groups for internal track
- Internal TestFlight builds cannot use external distribution
- Internal testers are managed in App Store Connect, not via groups
- This fixes 'Cannot add internal group to a build' error

Both issues were preventing successful deployments after PR merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Android build artifact path for improved build handling.
  * Modified internal iOS TestFlight uploads to disable external distribution and remove group targeting and changelog submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->