### PR TITLE
fix aadhaar register output after building the cpp circuit

### DIFF
--- a/circuits/scripts/build/build_cpp.sh
+++ b/circuits/scripts/build/build_cpp.sh
@@ -119,7 +119,7 @@ elif [[ $1 == "register_id" ]]; then
     basepath="./circuits/circuits/register_id/instances"
 elif [[ $1 == "register_aadhaar" ]]; then
     allowed_circuits=("${REGISTER_AADHAAR_CIRCUITS[@]}")
-    output="output/register_aadhaar"
+    output="output/register"
     mkdir -p $output
     basepath="./circuits/circuits/register/instances"
 elif [[ $1 == "dsc" ]]; then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Consolidated build output location for the register/Aadhaar flow into a unified “register” directory.
  - Aligns artifact structure to be consistent across related circuits.

- **Impact**
  - Build artifacts for this flow will now appear under the unified directory. Update any scripts, CI paths, or integrations that relied on the previous location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->