### PR TITLE
Simplify Metro resolver for workspace packages

### DIFF
--- a/app/metro.config.cjs
+++ b/app/metro.config.cjs
@@ -5,203 +5,33 @@
 const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
 const path = require('node:path');
 
-const defaultConfig = getDefaultConfig(__dirname);
-const { assetExts, sourceExts } = defaultConfig.resolver;
+const projectRoot = __dirname;
+const monorepoRoot = path.resolve(projectRoot, '..');
+const nodeModules = path.join(monorepoRoot, 'node_modules');
 
-const monorepoRoot = path.resolve(__dirname, '../');
-const commonPath = path.join(__dirname, '/../common');
-const sdkAlphaPath = path.join(__dirname, '/../packages/mobile-sdk-alpha');
-const trueMonorepoNodeModules = path.resolve(__dirname, '../node_modules');
+const watchFolders = [
+  path.join(monorepoRoot, 'common'),
+  path.join(monorepoRoot, 'packages/mobile-sdk-alpha'),
+];
+
 const extraNodeModules = {
   stream: require.resolve('stream-browserify'),
   buffer: require.resolve('buffer'),
   util: require.resolve('util'),
   assert: require.resolve('assert'),
-  '@babel/runtime': path.join(trueMonorepoNodeModules, '@babel/runtime'),
-  // Pin React and React Native to monorepo root
-  react: path.join(trueMonorepoNodeModules, 'react'),
-  'react-native': path.join(trueMonorepoNodeModules, 'react-native'),
-  '@': path.join(__dirname, 'src'),
-  '@selfxyz/common': path.resolve(commonPath, 'dist'),
-  '@selfxyz/mobile-sdk-alpha': path.resolve(sdkAlphaPath, 'dist'),
-  '@selfxyz/mobile-sdk-alpha/constants/analytics': path.resolve(
-    sdkAlphaPath,
-    'dist/esm/constants/analytics.js',
-  ),
-  '@selfxyz/mobile-sdk-alpha/stores': path.resolve(
-    sdkAlphaPath,
-    'dist/esm/stores.js',
-  ),
-  // Main exports
-  '@selfxyz/common/utils': path.resolve(
-    commonPath,
-    'dist/esm/src/utils/index.js',
-  ),
-  '@selfxyz/common/types': path.resolve(
-    commonPath,
-    'dist/esm/src/types/index.js',
-  ),
-  '@selfxyz/common/constants': path.resolve(
-    commonPath,
-    'dist/esm/src/constants/index.js',
-  ),
-  // Constants subpaths
-  '@selfxyz/common/constants/countries': path.resolve(
-    commonPath,
-    'dist/esm/src/constants/countries.js',
-  ),
-  '@selfxyz/common/constants/vkey': path.resolve(
-    commonPath,
-    'dist/esm/src/constants/vkey.js',
-  ),
-  '@selfxyz/common/constants/skiPem': path.resolve(
-    commonPath,
-    'dist/esm/src/constants/skiPem.js',
-  ),
-  '@selfxyz/common/constants/mockCerts': path.resolve(
-    commonPath,
-    'dist/esm/src/constants/mockCertificates.js',
-  ),
-  '@selfxyz/common/constants/hashes': path.resolve(
-    commonPath,
-    'dist/esm/src/constants/sampleDataHashes.js',
-  ),
-  // Utils subpaths
-  '@selfxyz/common/utils/hash': path.resolve(
-    commonPath,
-    'dist/esm/src/utils/hash.js',
-  ),
-  '@selfxyz/common/utils/attest': path.resolve(
-    commonPath,
-    'dist/esm/src/utils/attest.js',
-  ),
-  '@selfxyz/common/utils/bytes': path.resolve(
-    commonPath,
-    'dist/esm/src/utils/bytes.js',
-  ),
-  '@selfxyz/common/utils/trees': path.resolve(
-    commonPath,
-    'dist/esm/src/utils/trees.js',
-  ),
-  '@selfxyz/common/utils/scope': path.resolve(
-    commonPath,
-    'dist/esm/src/utils/scope.js',
-  ),
-  '@selfxyz/common/utils/proving': path.resolve(
-    commonPath,
-    'dist/esm/src/utils/proving.js',
-  ),
-  '@selfxyz/common/utils/appType': path.resolve(
-    commonPath,
-    'dist/esm/src/utils/appType.js',
-  ),
-  '@selfxyz/common/utils/date': path.resolve(
-    commonPath,
-    'dist/esm/src/utils/date.js',
-  ),
-  '@selfxyz/common/utils/arrays': path.resolve(
-    commonPath,
-    'dist/esm/src/utils/arrays.js',
-  ),
-  '@selfxyz/common/utils/passports': path.resolve(
-    commonPath,
-    'dist/esm/src/utils/passports/index.js',
-  ),
-  '@selfxyz/common/utils/passportFormat': path.resolve(
-    commonPath,
-    'dist/esm/src/utils/passports/format.js',
-  ),
-  '@selfxyz/common/utils/passports/validate': path.resolve(
-    commonPath,
-    'dist/esm/src/utils/passports/validate.js',
-  ),
-  '@selfxyz/common/utils/passportMock': path.resolve(
-    commonPath,
-    'dist/esm/src/utils/passports/mock.js',
-  ),
-  '@selfxyz/common/utils/passportDg1': path.resolve(
-    commonPath,
-    'dist/esm/src/utils/passports/dg1.js',
-  ),
-  '@selfxyz/common/utils/certificates': path.resolve(
-    commonPath,
-    'dist/esm/src/utils/certificate_parsing/index.js',
-  ),
-  '@selfxyz/common/utils/elliptic': path.resolve(
-    commonPath,
-    'dist/esm/src/utils/certificate_parsing/elliptic.js',
-  ),
-  '@selfxyz/common/utils/curves': path.resolve(
-    commonPath,
-    'dist/esm/src/utils/certificate_parsing/curves.js',
-  ),
-  '@selfxyz/common/utils/oids': path.resolve(
-    commonPath,
-    'dist/esm/src/utils/certificate_parsing/oids.js',
-  ),
-  '@selfxyz/common/utils/circuits': path.resolve(
-    commonPath,
-    'dist/esm/src/utils/circuits/index.js',
-  ),
-  '@selfxyz/common/utils/circuitNames': path.resolve(
-    commonPath,
-    'dist/esm/src/utils/circuits/circuitsName.js',
-  ),
-  '@selfxyz/common/utils/circuitFormat': path.resolve(
-    commonPath,
-    'dist/esm/src/utils/circuits/formatOutputs.js',
-  ),
-  '@selfxyz/common/utils/uuid': path.resolve(
-    commonPath,
-    'dist/esm/src/utils/circuits/uuid.js',
-  ),
-  '@selfxyz/common/utils/contracts': path.resolve(
-    commonPath,
-    'dist/esm/src/utils/contracts/index.js',
-  ),
-  '@selfxyz/common/utils/sanctions': path.resolve(
-    commonPath,
-    'dist/esm/src/utils/contracts/forbiddenCountries.js',
-  ),
-  '@selfxyz/common/utils/csca': path.resolve(
-    commonPath,
-    'dist/esm/src/utils/csca.js',
-  ),
-  '@selfxyz/common/utils/ofac': path.resolve(
-    commonPath,
-    'dist/esm/src/utils/ofac.js',
-  ),
-  // Types subpaths
-  '@selfxyz/common/types/passport': path.resolve(
-    commonPath,
-    'dist/esm/src/types/passport.js',
-  ),
-  '@selfxyz/common/types/app': path.resolve(
-    commonPath,
-    'dist/esm/src/types/app.js',
-  ),
-  '@selfxyz/common/types/certificates': path.resolve(
-    commonPath,
-    'dist/esm/src/types/certificates.js',
-  ),
-  '@selfxyz/common/types/circuits': path.resolve(
-    commonPath,
-    'dist/esm/src/types/circuits.js',
+  '@babel/runtime': path.join(nodeModules, '@babel/runtime'),
+  react: path.join(nodeModules, 'react'),
+  'react-native': path.join(nodeModules, 'react-native'),
+  '@': path.join(projectRoot, 'src'),
+  '@selfxyz/common': path.join(monorepoRoot, 'common'),
+  '@selfxyz/mobile-sdk-alpha': path.join(
+    monorepoRoot,
+    'packages/mobile-sdk-alpha',
   ),
 };
-const watchFolders = [
-  path.resolve(commonPath),
-  trueMonorepoNodeModules,
-  path.join(__dirname, 'src'),
-  path.resolve(sdkAlphaPath),
-];
 
-/**
- * Metro configuration
- * https://facebook.github.io/metro/docs/configuration
- *
- * @type {import('metro-config').MetroConfig}
- */
+const { assetExts, sourceExts } = getDefaultConfig(projectRoot).resolver;
+
 const config = {
   transformer: {
     babelTransformerPath: require.resolve(
@@ -212,46 +42,28 @@ const config = {
   },
   resolver: {
     extraNodeModules,
-    nodeModulesPaths: [
-      path.resolve(__dirname, 'node_modules'), // App's own node_modules
-      path.resolve(monorepoRoot, 'node_modules'), // Monorepo root node_modules
-      trueMonorepoNodeModules,
-      // Add paths to other package workspaces if needed
-    ],
+    nodeModulesPaths: [path.join(projectRoot, 'node_modules'), nodeModules],
     assetExts: assetExts.filter(ext => ext !== 'svg'),
     sourceExts: [...sourceExts, 'svg'],
-
-    // Custom resolver to handle Node.js modules elegantly
-    resolveRequest: (context, moduleName, platform) => {
-      // Handle problematic Node.js modules that don't work in React Native
-      const nodeModuleRedirects = {
+    unstable_enablePackageExports: true,
+    resolveRequest: (ctx, moduleName, platform) => {
+      const polyfills = {
         crypto: require.resolve('crypto-browserify'),
-        fs: false, // Disable filesystem access
-        os: false, // Disable OS-specific modules
-        readline: false, // Disable readline module
+        fs: false,
+        os: false,
+        readline: false,
         constants: require.resolve('constants-browserify'),
         path: require.resolve('path-browserify'),
       };
-
-      if (
-        Object.prototype.hasOwnProperty.call(nodeModuleRedirects, moduleName)
-      ) {
-        if (nodeModuleRedirects[moduleName] === false) {
-          // Return empty module for disabled modules
-          return { type: 'empty' };
-        }
-        // Redirect to polyfill
-        return {
-          type: 'sourceFile',
-          filePath: nodeModuleRedirects[moduleName],
-        };
+      if (Object.prototype.hasOwnProperty.call(polyfills, moduleName)) {
+        return polyfills[moduleName]
+          ? { type: 'sourceFile', filePath: polyfills[moduleName] }
+          : { type: 'empty' };
       }
-
-      // Fall back to default Metro resolver for all other modules
-      return context.resolveRequest(context, moduleName, platform);
+      return ctx.resolveRequest(ctx, moduleName, platform);
     },
   },
   watchFolders,
 };
 
-module.exports = mergeConfig(defaultConfig, config);
+module.exports = mergeConfig(getDefaultConfig(projectRoot), config);

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -7,19 +7,10 @@
     "esModuleInterop": true,
     "paths": {
       "@env": ["./env.ts"],
-      "@selfxyz/common": ["../common"],
-      "@selfxyz/common/*": ["../common/*"],
-      "@selfxyz/common/utils/passports/*": ["../common/utils/passports/*"],
-      "@selfxyz/mobile-sdk-alpha": [
-        "../packages/mobile-sdk-alpha/src",
-        "../packages/mobile-sdk-alpha/dist"
-      ],
-      "@selfxyz/mobile-sdk-alpha/constants/analytics": [
-        "../packages/mobile-sdk-alpha/dist/esm/constants/analytics.js"
-      ],
-      "@selfxyz/mobile-sdk-alpha/stores": [
-        "../packages/mobile-sdk-alpha/dist/esm/stores.js"
-      ],
+      "@selfxyz/common": ["../common/src"],
+      "@selfxyz/common/*": ["../common/src/*"],
+      "@selfxyz/mobile-sdk-alpha": ["../packages/mobile-sdk-alpha/src"],
+      "@selfxyz/mobile-sdk-alpha/*": ["../packages/mobile-sdk-alpha/src/*"],
       "@/*": ["./src/*"]
     }
   },


### PR DESCRIPTION
## Summary
- streamline Metro resolver to point at workspace roots and enable package exports
- simplify TypeScript paths to source folders for common and mobile-sdk-alpha

## Testing
- `yarn workspaces foreach -p -v --topological-dev --since=HEAD run nice --if-present` *(fails: Unexpected any in app utils)*
- `yarn lint` *(fails: Unexpected any in app utils)*
- `yarn build` *(fails: Cannot find module '@anon-aadhaar/core')*
- `yarn workspace @selfxyz/contracts build` *(fails: Couldn't find a script named "hardhat")*
- `yarn types` *(fails: Cannot find module '@anon-aadhaar/core')*
- `yarn test` *(fails: multiple workspace test failures)*

------
https://chatgpt.com/codex/tasks/task_b_68c3233727c4832db0f93916a065f23e