### PR TITLE
SELF-726: fix generate mock document button

### DIFF
--- a/app/src/screens/settings/ManageDocumentsScreen.tsx
+++ b/app/src/screens/settings/ManageDocumentsScreen.tsx
@@ -283,7 +283,6 @@ const ManageDocumentsScreen: React.FC = () => {
   };
 
   const handleGenerateMock = () => {
-    if (!__DEV__) return;
     impactLight();
     trackEvent(DocumentEvents.ADD_NEW_MOCK_SELECTED);
     navigation.navigate('CreateMock');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now generate a mock document directly from Manage Documents. Selecting “Add New Mock” will immediately open the Create Mock flow for all users, not just in test builds. This makes it easier to try out document features without real data and speeds up setup for new or exploratory use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->