### PR TITLE
chore: export selfappbuilder

### DIFF
--- a/sdk/qrcode/index.ts
+++ b/sdk/qrcode/index.ts
@@ -1,5 +1,5 @@
 import type { SelfApp } from '@selfxyz/common';
-import { countries } from '@selfxyz/common';
+import { countries, SelfAppBuilder } from '@selfxyz/common';
 
 import { SelfQRcode, SelfQRcodeWrapper } from './components/SelfQRcode.js';
 import type { WebAppInfo } from './utils/websocket.js';
@@ -9,3 +9,4 @@ export type { WebAppInfo };
 
 export { SelfQRcode, SelfQRcodeWrapper };
 export { countries };
+export { SelfAppBuilder };

--- a/sdk/qrcode/package.json
+++ b/sdk/qrcode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@selfxyz/qrcode",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "repository": {
     "type": "git",
     "url": "https://github.com/selfxyz/self"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * QR Code SDK now exposes SelfAppBuilder in its public API, allowing direct import alongside existing exports. No changes to current behavior or breaking changes. Improves developer ergonomics with easier access to builder capabilities. No migration required.

* **Chores**
  * Bumped QR Code SDK version to 1.0.13 to reflect the new public export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->