### PR TITLE
fix SEL-750 system bar content color

### DIFF
--- a/app/src/components/NavBar/HomeNavBar.tsx
+++ b/app/src/components/NavBar/HomeNavBar.tsx
@@ -72,7 +72,7 @@ export const HomeNavBar = (props: NativeStackHeaderProps) => {
   return (
     <NavBar.Container
       backgroundColor={slate50}
-      barStyle={'light'}
+      barStyle={'dark'}
       padding={8}
       justifyContent="space-between"
       paddingTop={Math.max(insets.top, 15) + extraYPadding}

--- a/app/src/components/NavBar/IdDetailsNavBar.tsx
+++ b/app/src/components/NavBar/IdDetailsNavBar.tsx
@@ -19,7 +19,7 @@ export const IdDetailsNavBar = (props: NativeStackHeaderProps) => {
   return (
     <NavBar.Container
       backgroundColor={slate50}
-      barStyle={'light'}
+      barStyle={'dark'}
       justifyContent="space-between"
       paddingTop={Math.max(insets.top, 15) + extraYPadding}
     >


### PR DESCRIPTION
I noticed on my phone the system bar text is white on a light gray. so not readable. system nav bar was set to light which according to docs sets the content color. so i switched to dark on home and id screen since these both have light backgrounds.


should fix https://linear.app/selfprotocol/issue/SELF-750/homescreen-nav-bar-whiteout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated navigation bars to use a dark bar style on the Home and ID Details screens.
  - Enhances visual consistency and improves contrast for better readability in header areas.
  - Appearance-only update; layout, spacing, and background colors remain unchanged.
  - No impact on functionality or user flows.
  - No changes to public APIs or configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->