### PR TITLE
Allow cloning via https

### DIFF
--- a/app/ios/Podfile
+++ b/app/ios/Podfile
@@ -26,6 +26,18 @@ if linkage != nil
   use_frameworks! :linkage => linkage.to_sym
 end
 
+def using_https_git_auth?
+    begin
+      # backticks run command in shell and capture stdout, 2>&1 captures stderr as well
+      auth_data = `gh auth status 2>&1`
+      auth_data.include?('Logged in to github.com account') &&
+        auth_data.include?('Git operations protocol: https')
+    rescue => e
+      puts 'gh auth status failed, assuming no HTTPS auth -- will try SSH'
+      false
+    end
+  end
+
 target "Self" do
   config = use_native_modules!
 
@@ -44,6 +56,9 @@ target "Self" do
       # Running in selfxyz GitHub Actions with PAT available - use private repo with token
       nfc_repo_url = "https://#{ENV["SELFXYZ_INTERNAL_REPO_PAT"]}@github.com/selfxyz/NFCPassportReader.git"
       puts "📦 Using private NFCPassportReader with PAT (selfxyz GitHub Actions)"
+    elsif using_https_git_auth?
+      # Local development with HTTPS GitHub auth via gh - use HTTPS to private repo
+      nfc_repo_url = "https://github.com/selfxyz/NFCPassportReader.git"
     else
       # Local development in selfxyz repo - use SSH to private repo
       nfc_repo_url = "git@github.com:selfxyz/NFCPassportReader.git"
@@ -148,6 +163,9 @@ target "Self" do
     # update QKCutoutView.swift to hide OCR border
     qkCutoutView = "Pods/QKMRZScanner/QKMRZScanner/QKCutoutView.swift"
     if File.exist?(qkCutoutView)
+      # Ensure the file is writable
+      system("chmod u+w #{qkCutoutView}")
+      
       text = File.read(qkCutoutView)
       # Only modify if the line exists and is not already commented
       if text.include?("addBorderAroundCutout()") && !text.include?("// addBorderAroundCutout()")

--- a/app/scripts/setup-private-modules.cjs
+++ b/app/scripts/setup-private-modules.cjs
@@ -116,6 +116,22 @@ function removeExistingModule() {
     log(`Removed existing ${REPO_NAME}`, 'success');
   }
 }
+// some of us connect to github via SSH, others via HTTPS with gh auth
+function usingHTTPSGitAuth() {
+  try {
+    const authData = runCommand(`gh auth status`, { stdio: 'pipe' });
+    const authInfo = authData.toString();
+    return (
+      authInfo.includes('Logged in to github.com account') &&
+      authInfo.includes('Git operations protocol: https')
+    );
+  } catch {
+    console.info(
+      'gh auth status failed, assuming no HTTPS auth -- will try SSH',
+    );
+    return false;
+  }
+}
 
 function clonePrivateRepo() {
   log(`Setting up ${REPO_NAME}...`, 'info');
@@ -136,6 +152,8 @@ function clonePrivateRepo() {
       'info',
     );
     return false; // Return false to indicate clone was skipped
+  } else if (usingHTTPSGitAuth()) {
+    cloneUrl = `https://github.com/${GITHUB_ORG}/${REPO_NAME}.git`;
   } else {
     // Local development with SSH
     log('Local development: Using SSH for clone', 'info');


### PR DESCRIPTION
my system is set to authenticate via https. so i added a check for that in when cloning. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability of iOS setup by ensuring required files are writable during post-install operations, reducing edit-time errors.

- Chores
  - Enhanced private module setup to support HTTPS-based Git authentication for local development when available, with seamless fallback to existing methods.
  - Refined cloning logic to better handle CI vs. local environments with clearer logging and resilient error handling.

- Build
  - Adjusted dependency retrieval to prefer secure HTTPS access when authenticated, improving developer experience without affecting end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->