### PR TITLE
chore: fix mobile auto deploy v2.6.9 rd2

### DIFF
--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -135,7 +135,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: staging
+          # When triggered by PR merge, use the merge commit on staging
+          # This ensures we deploy exactly what landed on staging (including version.json from source + any conflict resolutions)
+          ref: ${{ github.event.pull_request.merge_commit_sha || 'staging' }}
       - name: Read and sanitize Node.js version
         shell: bash
         run: |
@@ -160,7 +162,11 @@ jobs:
           echo "Staging HEAD commit: $(git rev-parse origin/staging)"
           echo "Staging HEAD message: $(git log -1 --pretty=format:'%s' origin/staging)"
 
-          if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/staging)" ]; then
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "📌 Building from merge commit on staging (includes source + conflict resolutions)"
+            echo "PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}"
+            echo "Merge commit includes version.json from source branch with bumped build numbers"
+          elif [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/staging)" ]; then
             echo "⚠️ WARNING: Current commit differs from latest staging commit"
             echo "This might indicate we're not building from the latest staging branch"
             git log --oneline HEAD..origin/staging || true
@@ -656,7 +662,9 @@ jobs:
         if: inputs.platform != 'ios'
         with:
           fetch-depth: 0
-          ref: staging
+          # When triggered by PR merge, use the merge commit on staging
+          # This ensures we deploy exactly what landed on staging (including version.json from source + any conflict resolutions)
+          ref: ${{ github.event.pull_request.merge_commit_sha || 'staging' }}
       - uses: "google-github-actions/auth@v2"
         with:
           project_id: "plucky-tempo-454713-r0"
@@ -1128,7 +1136,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: staging
+          # When triggered by PR merge, use the merge commit on staging
+          # This ensures we tag exactly what landed on staging (including version.json from source + any conflict resolutions)
+          ref: ${{ github.event.pull_request.merge_commit_sha || 'staging' }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure Git


### PR DESCRIPTION
…224)

* chore: bump iOS build number to 179

* fix: use PR source commit for deployment to get correct version.json

When deploying from a PR merge (e.g., dev → staging), now uses the source branch's commit instead of always checking out staging. This ensures version.json has the correct bumped build number from the previous deployment's PR back to dev, preventing 'build number already exists' errors.

* downgrade to match store

* fix: use merge_commit_sha instead of head.sha for deployments

Use github.event.pull_request.merge_commit_sha instead of head.sha to ensure we deploy exactly what landed on staging after the merge, not just the source branch state. This correctly handles:
- Conflict resolutions made during merge
- Any staging-only changes
- The actual state of staging post-merge

The merge commit still includes the updated version.json from the source branch (e.g., dev), so build numbers remain correct while ensuring we deploy and tag the true staging state.



---------

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved mobile deployment workflow for PR-triggered builds to enhance reliability and traceability.
  * Standardized ref selection across build steps, ensuring consistent iOS and Android pipelines.
  * Enhanced logging to clearly indicate build source and PR details during staging builds.
  * Maintained existing validation and behavior for non-PR runs, with clearer warnings when refs differ.
  * Streamlined release tagging and version update paths for more predictable releases.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->