### PR TITLE
Prefer allow list for recovery prompts

### DIFF
--- a/app/src/consts/recoveryPrompts.ts
+++ b/app/src/consts/recoveryPrompts.ts
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2025 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+/**
+ * Screens where we intentionally show the recovery reminder. This allow list is
+ * intentionally short so that new product surfaces do not accidentally inherit
+ * the prompt without design review.
+ */
+export const RECOVERY_PROMPT_ALLOWED_ROUTES = [
+  'Home',
+  'ProofHistory',
+  'ProofHistoryDetail',
+  'ManageDocuments',
+  'Settings',
+] as const;
+
+/**
+ * Capture and scanning flows that should never be interrupted by a modal. We
+ * keep this block list both for documentation and to use in tests.
+ */
+export const CRITICAL_RECOVERY_PROMPT_ROUTES = [
+  'DocumentCamera',
+  'DocumentCameraTrouble',
+  'DocumentNFCMethodSelection',
+  'DocumentNFCScan',
+  'DocumentNFCTrouble',
+  'QRCodeViewFinder',
+  'QRCodeTrouble',
+] as const;
+
+export type RecoveryPromptAllowedRoute =
+  (typeof RECOVERY_PROMPT_ALLOWED_ROUTES)[number];

--- a/app/src/navigation/index.tsx
+++ b/app/src/navigation/index.tsx
@@ -16,6 +16,8 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useSelfClient } from '@selfxyz/mobile-sdk-alpha';
 
 import { DefaultNavBar } from '@/components/NavBar';
+import { RECOVERY_PROMPT_ALLOWED_ROUTES } from '@/consts/recoveryPrompts';
+import useRecoveryPrompts from '@/hooks/useRecoveryPrompts';
 import AppLayout from '@/layouts/AppLayout';
 import accountScreens from '@/navigation/account';
 import appScreens from '@/navigation/app';
@@ -90,6 +92,7 @@ const { trackScreenView } = analytics();
 const Navigation = createStaticNavigation(AppNavigation);
 
 const NavigationWithTracking = () => {
+  useRecoveryPrompts({ allowedRoutes: RECOVERY_PROMPT_ALLOWED_ROUTES });
   const selfClient = useSelfClient();
   const trackScreen = () => {
     const currentRoute = navigationRef.getCurrentRoute();

--- a/app/tests/src/hooks/useRecoveryPrompts.test.ts
+++ b/app/tests/src/hooks/useRecoveryPrompts.test.ts
@@ -4,29 +4,82 @@
 
 import { act, renderHook, waitFor } from '@testing-library/react-native';
 
+const navigationStateListeners: Array<() => void> = [];
+let isNavigationReady = true;
+const navigationRef = {
+  isReady: jest.fn(() => isNavigationReady),
+  navigate: jest.fn(),
+  addListener: jest.fn((_: string, callback: () => void) => {
+    navigationStateListeners.push(callback);
+    return () => {
+      const index = navigationStateListeners.indexOf(callback);
+      if (index >= 0) {
+        navigationStateListeners.splice(index, 1);
+      }
+    };
+  }),
+  getCurrentRoute: jest.fn(() => ({ name: 'Home' })),
+} as any;
+
+const appStateListeners: Array<(state: string) => void> = [];
+
+jest.mock('@/hooks/useModal');
+jest.mock('@/providers/passportDataProvider');
+jest.mock('@/navigation', () => ({
+  navigationRef,
+}));
+jest.mock('react-native', () => {
+  const actual = jest.requireActual('react-native');
+  return {
+    ...actual,
+    AppState: {
+      currentState: 'active',
+      addEventListener: jest.fn((_: string, handler: (state: string) => void) => {
+        appStateListeners.push(handler);
+        return {
+          remove: () => {
+            const index = appStateListeners.indexOf(handler);
+            if (index >= 0) {
+              appStateListeners.splice(index, 1);
+            }
+          },
+        };
+      }),
+    },
+  };
+});
+
+import {
+  CRITICAL_RECOVERY_PROMPT_ROUTES,
+  RECOVERY_PROMPT_ALLOWED_ROUTES,
+} from '@/consts/recoveryPrompts';
 import { useModal } from '@/hooks/useModal';
 import useRecoveryPrompts from '@/hooks/useRecoveryPrompts';
 import { usePassport } from '@/providers/passportDataProvider';
 import { useSettingStore } from '@/stores/settingStore';
 
-jest.mock('@/hooks/useModal');
-jest.mock('@/providers/passportDataProvider');
-jest.mock('@/navigation', () => ({
-  navigationRef: {
-    isReady: jest.fn(() => true),
-    navigate: jest.fn(),
-  },
-}));
-
 const showModal = jest.fn();
 const getAllDocuments = jest.fn();
 (usePassport as jest.Mock).mockReturnValue({ getAllDocuments });
 
+const getAppState = () =>
+  require('react-native').AppState as unknown as {
+    currentState: string;
+    addEventListener: jest.Mock;
+  };
+
 describe('useRecoveryPrompts', () => {
   beforeEach(() => {
-    showModal.mockClear();
+    jest.clearAllMocks();
+    navigationStateListeners.length = 0;
+    appStateListeners.length = 0;
+    isNavigationReady = true;
+    navigationRef.isReady.mockImplementation(() => isNavigationReady);
+    navigationRef.getCurrentRoute.mockReturnValue({ name: 'Home' });
     (useModal as jest.Mock).mockReturnValue({ showModal, visible: false });
     getAllDocuments.mockResolvedValue({ doc1: {} as any });
+    const AppState = getAppState();
+    AppState.currentState = 'active';
     act(() => {
       useSettingStore.setState({
         loginCount: 0,
@@ -36,11 +89,87 @@ describe('useRecoveryPrompts', () => {
     });
   });
 
-  it('shows modal on first login', async () => {
+  it('shows modal on first login for eligible route', async () => {
     act(() => {
       useSettingStore.setState({ loginCount: 1 });
     });
     renderHook(() => useRecoveryPrompts());
+    await waitFor(() => {
+      expect(showModal).toHaveBeenCalled();
+    });
+  });
+
+  it('waits for navigation readiness before prompting', async () => {
+    isNavigationReady = false;
+    navigationRef.isReady.mockImplementation(() => isNavigationReady);
+    act(() => {
+      useSettingStore.setState({ loginCount: 1 });
+    });
+    renderHook(() => useRecoveryPrompts());
+    await waitFor(() => {
+      expect(showModal).not.toHaveBeenCalled();
+    });
+
+    isNavigationReady = true;
+    navigationStateListeners.forEach((listener) => listener());
+
+    await waitFor(() => {
+      expect(showModal).toHaveBeenCalled();
+    });
+  });
+
+  it.each([...CRITICAL_RECOVERY_PROMPT_ROUTES])(
+    'does not show modal when route %s is disallowed',
+    async (routeName) => {
+      navigationRef.getCurrentRoute.mockReturnValue({ name: routeName });
+      act(() => {
+        useSettingStore.setState({ loginCount: 1 });
+      });
+      const { unmount } = renderHook(() => useRecoveryPrompts());
+      await waitFor(() => {
+        expect(showModal).not.toHaveBeenCalled();
+      });
+      unmount();
+    },
+  );
+
+  it('respects custom allow list overrides', async () => {
+    act(() => {
+      useSettingStore.setState({ loginCount: 1 });
+    });
+    renderHook(() =>
+      useRecoveryPrompts({ allowedRoutes: ['Settings'], disallowedRoutes: [] }),
+    );
+    await waitFor(() => {
+      expect(showModal).not.toHaveBeenCalled();
+    });
+
+    showModal.mockClear();
+    navigationRef.getCurrentRoute.mockReturnValue({ name: 'Settings' });
+
+    renderHook(() =>
+      useRecoveryPrompts({
+        allowedRoutes: RECOVERY_PROMPT_ALLOWED_ROUTES,
+        disallowedRoutes: [],
+      }),
+    );
+
+    await waitFor(() => {
+      expect(showModal).toHaveBeenCalled();
+    });
+  });
+
+  it('prompts when returning from background on eligible route', async () => {
+    const AppState = getAppState();
+    AppState.currentState = 'background';
+    act(() => {
+      useSettingStore.setState({ loginCount: 1 });
+    });
+    renderHook(() => useRecoveryPrompts());
+    expect(showModal).not.toHaveBeenCalled();
+
+    appStateListeners.forEach((listener) => listener('active'));
+
     await waitFor(() => {
       expect(showModal).toHaveBeenCalled();
     });
@@ -69,18 +198,6 @@ describe('useRecoveryPrompts', () => {
   it('does not show modal if backup already enabled', async () => {
     act(() => {
       useSettingStore.setState({ loginCount: 1, cloudBackupEnabled: true });
-    });
-    renderHook(() => useRecoveryPrompts());
-    await waitFor(() => {
-      expect(showModal).not.toHaveBeenCalled();
-    });
-  });
-
-  it('does not show modal when navigation is not ready', async () => {
-    const navigationRef = require('@/navigation').navigationRef;
-    navigationRef.isReady.mockReturnValueOnce(false);
-    act(() => {
-      useSettingStore.setState({ loginCount: 1 });
     });
     renderHook(() => useRecoveryPrompts());
     await waitFor(() => {

--- a/app/tests/src/navigation.test.ts
+++ b/app/tests/src/navigation.test.ts
@@ -2,56 +2,113 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+import { RECOVERY_PROMPT_ALLOWED_ROUTES } from '@/consts/recoveryPrompts';
+
+const mockNavigationRef = {
+  isReady: jest.fn(() => true),
+  navigate: jest.fn(),
+  addListener: jest.fn(() => jest.fn()),
+  getCurrentRoute: jest.fn(() => ({ name: 'Home' })),
+} as any;
+
+jest.mock('@/hooks/useRecoveryPrompts', () => jest.fn());
+jest.mock('@selfxyz/mobile-sdk-alpha', () => ({
+  useSelfClient: jest.fn(() => ({})),
+}));
+jest.mock('@/utils/deeplinks', () => ({
+  setupUniversalLinkListenerInNavigation: jest.fn(() => jest.fn()),
+}));
+jest.mock('@/utils/analytics', () => jest.fn(() => ({
+  trackScreenView: jest.fn(),
+})));
+jest.mock('react-native-gesture-handler', () => ({
+  GestureHandlerRootView: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+jest.mock('@react-navigation/native', () => {
+  const React = require('react');
+  return {
+    createNavigationContainerRef: jest.fn(() => mockNavigationRef),
+    createStaticNavigation: jest.fn(() =>
+      React.forwardRef((props: any) => <>{props.children}</>),
+    ),
+  };
+});
+jest.mock('@react-navigation/native-stack', () => ({
+  createNativeStackNavigator: jest.fn((config) => config),
+}));
+
 describe('navigation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should have the correct navigation screens', () => {
-    const navigationScreens = require('@/navigation').navigationScreens;
-    const listOfScreens = Object.keys(navigationScreens).sort();
-    expect(listOfScreens).toEqual([
-      'AadhaarUpload',
-      'AadhaarUploadError',
-      'AadhaarUploadSuccess',
-      'AccountRecovery',
-      'AccountRecoveryChoice',
-      'AccountVerifiedSuccess',
-      'CloudBackupSettings',
-      'ComingSoon',
-      'ConfirmBelonging',
-      'CountryPicker',
-      'CreateMock',
-      'DeferredLinkingInfo',
-      'DevFeatureFlags',
-      'DevHapticFeedback',
-      'DevLoadingScreen',
-      'DevPrivateKey',
-      'DevSettings',
-      'Disclaimer',
-      'DocumentCamera',
-      'DocumentCameraTrouble',
-      'DocumentDataInfo',
-      'DocumentDataNotFound',
-      'DocumentNFCMethodSelection',
-      'DocumentNFCScan',
-      'DocumentNFCTrouble',
-      'DocumentOnboarding',
-      'Home',
-      'IDPicker',
-      'IdDetails',
-      'Launch',
-      'Loading',
-      'ManageDocuments',
-      'MockDataDeepLink',
-      'Modal',
-      'ProofHistory',
-      'ProofHistoryDetail',
-      'ProofRequestStatus',
-      'Prove',
-      'QRCodeTrouble',
-      'QRCodeViewFinder',
-      'RecoverWithPhrase',
-      'SaveRecoveryPhrase',
-      'Settings',
-      'ShowRecoveryPhrase',
-      'Splash',
-    ]);
+    jest.isolateModules(() => {
+      const navigationScreens = require('@/navigation').navigationScreens;
+      const listOfScreens = Object.keys(navigationScreens).sort();
+      expect(listOfScreens).toEqual([
+        'AadhaarUpload',
+        'AadhaarUploadError',
+        'AadhaarUploadSuccess',
+        'AccountRecovery',
+        'AccountRecoveryChoice',
+        'AccountVerifiedSuccess',
+        'CloudBackupSettings',
+        'ComingSoon',
+        'ConfirmBelonging',
+        'CountryPicker',
+        'CreateMock',
+        'DeferredLinkingInfo',
+        'DevFeatureFlags',
+        'DevHapticFeedback',
+        'DevLoadingScreen',
+        'DevPrivateKey',
+        'DevSettings',
+        'Disclaimer',
+        'DocumentCamera',
+        'DocumentCameraTrouble',
+        'DocumentDataInfo',
+        'DocumentDataNotFound',
+        'DocumentNFCMethodSelection',
+        'DocumentNFCScan',
+        'DocumentNFCTrouble',
+        'DocumentOnboarding',
+        'Home',
+        'IDPicker',
+        'IdDetails',
+        'Launch',
+        'Loading',
+        'ManageDocuments',
+        'MockDataDeepLink',
+        'Modal',
+        'ProofHistory',
+        'ProofHistoryDetail',
+        'ProofRequestStatus',
+        'Prove',
+        'QRCodeTrouble',
+        'QRCodeViewFinder',
+        'RecoverWithPhrase',
+        'SaveRecoveryPhrase',
+        'Settings',
+        'ShowRecoveryPhrase',
+        'Splash',
+      ]);
+    });
+  });
+
+  it('wires recovery prompts hook into navigation', () => {
+    const useRecoveryPrompts = require('@/hooks/useRecoveryPrompts') as jest.Mock;
+    jest.isolateModules(() => {
+      const NavigationWithTracking = require('@/navigation').default;
+      render(<NavigationWithTracking />);
+    });
+    expect(useRecoveryPrompts).toHaveBeenCalledWith({
+      allowedRoutes: RECOVERY_PROMPT_ALLOWED_ROUTES,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- introduce a concise recovery prompt allow list so reminders only show on vetted surfaces
- update the recovery prompt hook to default to the allow list while still permitting extra exclusions
- wire navigation and tests to the new allow list and cover override behavior

## Testing
- `CI=1 yarn test --runTestsByPath app/tests/src/hooks/useRecoveryPrompts.test.ts app/tests/src/navigation.test.ts` *(fails: Jest cannot parse other suites in the workspace)*

------
https://chatgpt.com/codex/tasks/task_b_68e8055399d0832d918538ebf2198d2d