### PR TITLE
remove [skip ci] from bump version prs

### DIFF
--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -1347,7 +1347,7 @@ jobs:
             exit 0
           fi
 
-          git commit -m "chore: bump mobile app version to $VERSION [skip ci]"
+          git commit -m "chore: bump mobile app version to $VERSION"
 
           # Create new branch from current HEAD (bump target branch with version bump)
           git checkout -b ${BRANCH_NAME}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated mobile deployment workflow so CI runs on automated version bump commits, ensuring builds and tests execute for those releases.
  * Improves traceability of release builds through standard CI runs.
  * No user-facing functionality changes; this affects the release process only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->