### PR TITLE
bump version and fix ios build number v2.7.0

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -130,7 +130,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 108
-        versionName "2.6.9"
+        versionName "2.7.0"
         manifestPlaceholders = [appAuthRedirectScheme: 'com.proofofpassportapp']
         externalNativeBuild {
             cmake {

--- a/app/ios/OpenPassport/Info.plist
+++ b/app/ios/OpenPassport/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.9</string>
+	<string>2.7.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/app/ios/Self.xcodeproj/project.pbxproj
+++ b/app/ios/Self.xcodeproj/project.pbxproj
@@ -542,7 +542,7 @@
 					"$(PROJECT_DIR)",
 					"$(PROJECT_DIR)/MoproKit/Libs",
 				);
-				MARKETING_VERSION = 2.6.9;
+				MARKETING_VERSION = 2.7.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -682,7 +682,7 @@
 					"$(PROJECT_DIR)",
 					"$(PROJECT_DIR)/MoproKit/Libs",
 				);
-				MARKETING_VERSION = 2.6.9;
+				MARKETING_VERSION = 2.7.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/app/version.json
+++ b/app/version.json
@@ -1,6 +1,6 @@
 {
   "ios": {
-    "build": 181,
+    "build": 179,
     "lastDeployed": "2025-10-07T05:58:42Z"
   },
   "android": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the app version to 2.7.0 on Android and iOS. Users will see the new version number in app settings and app stores.
  - Refreshed iOS build metadata to align with the new release version.
  - No changes to features, performance, or UI in this release; functionality remains the same. Existing data and compatibility are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->