### PR TITLE
fix: update Lottie component usage in QR code SDK

### DIFF
--- a/sdk/qrcode/README.md
+++ b/sdk/qrcode/README.md
@@ -15,7 +15,7 @@ yarn add @selfxyz/qrcode
 ### 1. Import the SelfQRcodeWrapper component
 
 ```tsx
-import SelfQRcodeWrapper, { SelfAppBuilder } from '@selfxyz/qrcode';
+import { SelfQRcodeWrapper, SelfAppBuilder } from '@selfxyz/qrcode';
 import type { SelfApp } from '@selfxyz/qrcode';
 import { v4 as uuidv4 } from 'uuid';
 ```

--- a/sdk/qrcode/components/SelfQRcode.tsx
+++ b/sdk/qrcode/components/SelfQRcode.tsx
@@ -95,7 +95,7 @@ const SelfQRcode = ({
               return <BounceLoader loading={true} size={200} color="#94FBAB" />;
             case QRcodeSteps.PROOF_GENERATION_FAILED:
               return (
-                <Lottie.default
+                <Lottie
                   animationData={X_ANIMATION}
                   style={{ width: 200, height: 200 }}
                   onComplete={() => {
@@ -106,7 +106,7 @@ const SelfQRcode = ({
               );
             case QRcodeSteps.PROOF_VERIFIED:
               return (
-                <Lottie.default
+                <Lottie
                   animationData={CHECK_ANIMATION}
                   style={{ width: 200, height: 200 }}
                   onComplete={() => {


### PR DESCRIPTION
I noticed that the `SelfQRcode` component's render method returns `undefined` when it reached the `PROOF_VERIFIED` or `PROOF_GENERATION_FAILED` states. Locally patching the component to use `Lottie` instead of `Lottie.default` fixed the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * SelfQRcodeWrapper is now a named export from the SDK. This is a breaking change; update your import syntax accordingly.

* **Documentation**
  * Updated README examples to reflect the new named import for SelfQRcodeWrapper.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->