### PR TITLE
feat: improve layout on smaller screens

### DIFF
--- a/app/src/hooks/useCompactLayout.ts
+++ b/app/src/hooks/useCompactLayout.ts
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2025 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { useCallback } from 'react';
+import { useWindowDimensions } from 'react-native';
+
+export const DEFAULT_COMPACT_WIDTH = 360;
+export const DEFAULT_COMPACT_HEIGHT = 720;
+
+interface UseCompactLayoutOptions {
+  compactWidth?: number;
+  compactHeight?: number;
+}
+
+type ResponsiveDimension = 'width' | 'height' | 'any';
+
+interface ResponsivePaddingOptions {
+  min?: number;
+  max?: number;
+  percent?: number;
+}
+
+type ResponsiveValueConfig<T> = {
+  compact: T;
+  regular: T;
+  dimension?: ResponsiveDimension;
+};
+
+const useCompactLayout = (
+  options: UseCompactLayoutOptions = {},
+): {
+  width: number;
+  height: number;
+  isCompactWidth: boolean;
+  isCompactHeight: boolean;
+  isCompact: boolean;
+  selectResponsiveValue: <T>(
+    compactValue: T,
+    regularValue: T,
+    dimension?: ResponsiveDimension,
+  ) => T;
+  selectResponsiveValues: <TConfig extends Record<string, ResponsiveValueConfig<unknown>>>(
+    config: TConfig,
+  ) => {
+    [K in keyof TConfig]: TConfig[K] extends ResponsiveValueConfig<infer TValue>
+      ? TValue
+      : never;
+  };
+  getResponsiveHorizontalPadding: (options?: ResponsivePaddingOptions) => number;
+} => {
+  const { width, height } = useWindowDimensions();
+  const compactWidth = options.compactWidth ?? DEFAULT_COMPACT_WIDTH;
+  const compactHeight = options.compactHeight ?? DEFAULT_COMPACT_HEIGHT;
+
+  const isCompactWidth = width < compactWidth;
+  const isCompactHeight = height < compactHeight;
+  const selectResponsiveValue = useCallback(
+    <T>(
+      compactValue: T,
+      regularValue: T,
+      dimension: ResponsiveDimension = 'any',
+    ): T => {
+      if (dimension === 'width') {
+        return isCompactWidth ? compactValue : regularValue;
+      }
+
+      if (dimension === 'height') {
+        return isCompactHeight ? compactValue : regularValue;
+      }
+
+      return isCompactWidth || isCompactHeight ? compactValue : regularValue;
+    },
+    [isCompactHeight, isCompactWidth],
+  );
+
+  const selectResponsiveValues = useCallback(
+    <TConfig extends Record<string, ResponsiveValueConfig<unknown>>>(
+      config: TConfig,
+    ) => {
+      const entries = Object.entries(config) as Array<[
+        keyof TConfig,
+        ResponsiveValueConfig<unknown>,
+      ]>;
+      const result = {} as {
+        [K in keyof TConfig]: TConfig[K] extends ResponsiveValueConfig<infer TValue>
+          ? TValue
+          : never;
+      };
+
+      entries.forEach(([key, { compact, regular, dimension }]) => {
+        result[key] = selectResponsiveValue(compact, regular, dimension);
+      });
+
+      return result;
+    },
+    [selectResponsiveValue],
+  );
+
+  const getResponsiveHorizontalPadding = useCallback(
+    (paddingOptions: ResponsivePaddingOptions = {}): number => {
+      const { min = 16, max, percent = 0.06 } = paddingOptions;
+      const computed = width * percent;
+      const withMin = Math.max(min, computed);
+      return typeof max === 'number' ? Math.min(max, withMin) : withMin;
+    },
+    [width],
+  );
+
+  return {
+    width,
+    height,
+    isCompactWidth,
+    isCompactHeight,
+    isCompact: isCompactWidth || isCompactHeight,
+    selectResponsiveValue,
+    selectResponsiveValues,
+    getResponsiveHorizontalPadding,
+  };
+};
+
+export default useCompactLayout;

--- a/app/src/layouts/ExpandableBottomLayout.tsx
+++ b/app/src/layouts/ExpandableBottomLayout.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   Dimensions,
   PixelRatio,
@@ -17,6 +17,7 @@ import { View } from 'tamagui';
 
 import { black, white } from '@/utils/colors';
 import { extraYPadding } from '@/utils/constants';
+import useCompactLayout from '@/hooks/useCompactLayout';
 
 // Get the current font scale factor
 const fontScale = PixelRatio.getFontScale();
@@ -57,7 +58,17 @@ const TopSection: React.FC<TopSectionProps> = ({
   ...props
 }) => {
   const { top } = useSafeAreaInsets();
-  const { roundTop, ...restProps } = props;
+  const { roundTop, style: incomingStyle, ...restProps } = props;
+  const { selectResponsiveValue } = useCompactLayout({
+    compactHeight: 760,
+  });
+  const spacingStyle = useMemo(
+    () => ({
+      paddingHorizontal: selectResponsiveValue(16, 20, 'width'),
+      paddingVertical: selectResponsiveValue(16, 20, 'height'),
+    }),
+    [selectResponsiveValue],
+  );
   return (
     <View
       {...restProps}
@@ -66,7 +77,9 @@ const TopSection: React.FC<TopSectionProps> = ({
         styles.topSection,
         roundTop && styles.roundTop,
         roundTop ? { marginTop: top } : { paddingTop: top },
+        spacingStyle,
         { backgroundColor },
+        incomingStyle,
       ]}
     >
       {children}
@@ -108,6 +121,16 @@ const BottomSection: React.FC<BottomSectionProps> = ({
   const minBottom = safeAreaBottom + extraYPadding;
   const totalBottom =
     typeof incomingBottom === 'number' ? minBottom + incomingBottom : minBottom;
+  const { selectResponsiveValue } = useCompactLayout({
+    compactHeight: 760,
+  });
+  const spacingStyle = useMemo(
+    () => ({
+      paddingHorizontal: selectResponsiveValue(16, 20, 'width'),
+      paddingTop: selectResponsiveValue(18, 30, 'height'),
+    }),
+    [selectResponsiveValue],
+  );
 
   let panelHeight: number | 'auto' = 'auto';
   // set bottom section height to 38% of screen height
@@ -129,7 +152,7 @@ const BottomSection: React.FC<BottomSectionProps> = ({
     <View
       {...props}
       height={panelHeight}
-      style={[styles.bottomSection, style]}
+      style={[styles.bottomSection, spacingStyle, style]}
       paddingBottom={totalBottom}
     >
       {children}

--- a/app/src/screens/account/recovery/AccountRecoveryScreen.tsx
+++ b/app/src/screens/account/recovery/AccountRecoveryScreen.tsx
@@ -12,10 +12,12 @@ import {
   Title,
 } from '@selfxyz/mobile-sdk-alpha/components';
 import { BackupEvents } from '@selfxyz/mobile-sdk-alpha/constants/analytics';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import useHapticNavigation from '@/hooks/useHapticNavigation';
 import RestoreAccountSvg from '@/images/icons/restore_account.svg';
 import { ExpandableBottomLayout } from '@/layouts/ExpandableBottomLayout';
+import useCompactLayout from '@/hooks/useCompactLayout';
 import { black, slate600, white } from '@/utils/colors';
 
 const AccountRecoveryScreen: React.FC = () => {
@@ -25,6 +27,30 @@ const AccountRecoveryScreen: React.FC = () => {
       nextScreen: 'SaveRecoveryPhrase',
     },
   });
+  const { selectResponsiveValues, getResponsiveHorizontalPadding } = useCompactLayout();
+  const { bottom } = useSafeAreaInsets();
+
+  const {
+    iconSize,
+    iconPadding,
+    contentGap,
+    descriptionSize,
+    titleSize,
+    buttonStackGap,
+    buttonPaddingTop,
+    extraBottomPadding,
+  } = selectResponsiveValues({
+    iconSize: { compact: 64, regular: 80 },
+    iconPadding: { compact: '$4', regular: '$5' },
+    contentGap: { compact: '$2', regular: '$2.5' },
+    descriptionSize: { compact: 15, regular: 16 },
+    titleSize: { compact: 26, regular: 32 },
+    buttonStackGap: { compact: '$2', regular: '$2.5' },
+    buttonPaddingTop: { compact: '$4', regular: '$6' },
+    extraBottomPadding: { compact: 16, regular: 24 },
+  });
+  const horizontalPadding = getResponsiveHorizontalPadding({ percent: 0.06 });
+  const bottomPadding = bottom + extraBottomPadding;
 
   return (
     <ExpandableBottomLayout.Layout backgroundColor={black}>
@@ -33,20 +59,28 @@ const AccountRecoveryScreen: React.FC = () => {
           borderColor={slate600}
           borderWidth="$1"
           borderRadius="$10"
-          padding="$5"
+          padding={iconPadding}
         >
-          <RestoreAccountSvg height={80} width={80} color={white} />
+          <RestoreAccountSvg height={iconSize} width={iconSize} color={white} />
         </View>
       </ExpandableBottomLayout.TopSection>
-      <ExpandableBottomLayout.BottomSection backgroundColor={white}>
-        <YStack alignItems="center" gap="$2.5" paddingBottom="$2.5">
-          <Title>Restore your Self account</Title>
-          <Description>
+      <ExpandableBottomLayout.BottomSection
+        backgroundColor={white}
+        paddingBottom={bottomPadding}
+        paddingHorizontal={horizontalPadding}
+      >
+        <YStack alignItems="center" gap={contentGap} paddingBottom="$2">
+          <Title style={{ fontSize: titleSize, textAlign: 'center' }}>
+            Restore your Self account
+          </Title>
+          <Description
+            style={{ fontSize: descriptionSize, textAlign: 'center' }}
+          >
             By continuing, you certify that this passport belongs to you and is
             not stolen or forged.
           </Description>
 
-          <YStack gap="$2.5" width="100%" paddingTop="$6">
+          <YStack gap={buttonStackGap} width="100%" paddingTop={buttonPaddingTop}>
             <PrimaryButton
               trackEvent={BackupEvents.ACCOUNT_RECOVERY_STARTED}
               onPress={onRestoreAccountPress}

--- a/app/src/screens/app/LaunchScreen.tsx
+++ b/app/src/screens/app/LaunchScreen.tsx
@@ -18,6 +18,7 @@ import { AppEvents } from '@selfxyz/mobile-sdk-alpha/constants/analytics';
 import { privacyUrl, termsUrl } from '@/consts/links';
 import useConnectionModal from '@/hooks/useConnectionModal';
 import useHapticNavigation from '@/hooks/useHapticNavigation';
+import useCompactLayout from '@/hooks/useCompactLayout';
 import IDCardPlaceholder from '@/images/icons/id_card_placeholder.svg';
 import {
   black,
@@ -34,6 +35,33 @@ const LaunchScreen: React.FC = () => {
   const onPress = useHapticNavigation('CountryPicker');
   const createMock = useHapticNavigation('CreateMock');
   const { bottom } = useSafeAreaInsets();
+  const {
+    width: screenWidth,
+    height: screenHeight,
+    selectResponsiveValues,
+    getResponsiveHorizontalPadding,
+  } = useCompactLayout();
+  const cardWidth = Math.min(screenWidth * 0.8, 320);
+  const cardHeight = cardWidth * (180 / 300);
+  const {
+    titleSize,
+    bodySize,
+    heroSpacing,
+    baseTopPadding,
+    ctaPaddingTop,
+  } = selectResponsiveValues({
+    titleSize: { compact: 30, regular: 38, dimension: 'width' },
+    bodySize: { compact: 15, regular: 16, dimension: 'width' },
+    heroSpacing: { compact: 24, regular: 40, dimension: 'width' },
+    baseTopPadding: { compact: 32, regular: 60, dimension: 'width' },
+    ctaPaddingTop: { compact: 20, regular: 30, dimension: 'width' },
+  });
+  const bodyHorizontalMargin = getResponsiveHorizontalPadding({
+    percent: 0.08,
+    min: 20,
+  });
+  const topPadding = Math.max(screenHeight * 0.08, baseTopPadding);
+  const ctaPaddingHorizontal = getResponsiveHorizontalPadding({ percent: 0.07 });
 
   const devModeTap = Gesture.Tap()
     .numberOfTaps(5)
@@ -43,7 +71,7 @@ const LaunchScreen: React.FC = () => {
 
   return (
     <YStack backgroundColor={black} flex={1} alignItems="center">
-      <View style={styles.container}>
+      <View style={[styles.container, { paddingTop: topPadding }]}>
         <YStack flex={1} justifyContent="center" alignItems="center">
           <GestureDetector gesture={devModeTap}>
             <YStack
@@ -51,13 +79,13 @@ const LaunchScreen: React.FC = () => {
               borderRadius={14}
               overflow="hidden"
             >
-              <IDCardPlaceholder width={300} height={180} />
+              <IDCardPlaceholder width={cardWidth} height={cardHeight} />
             </YStack>
           </GestureDetector>
         </YStack>
         <Text
           color={white}
-          fontSize={38}
+          fontSize={titleSize}
           fontFamily={advercase}
           fontWeight="500"
           textAlign="center"
@@ -68,10 +96,10 @@ const LaunchScreen: React.FC = () => {
         <BodyText
           style={{
             color: slate300,
-            fontSize: 16,
+            fontSize: bodySize,
             textAlign: 'center',
-            marginHorizontal: 40,
-            marginBottom: 40,
+            marginHorizontal: bodyHorizontalMargin,
+            marginBottom: heroSpacing,
           }}
         >
           Self is the easiest way to verify your identity safely wherever you
@@ -83,9 +111,9 @@ const LaunchScreen: React.FC = () => {
         gap="$3"
         width="100%"
         alignItems="center"
-        paddingHorizontal={20}
-        paddingBottom={bottom}
-        paddingTop={30}
+        paddingHorizontal={ctaPaddingHorizontal}
+        paddingBottom={bottom + 12}
+        paddingTop={ctaPaddingTop}
         backgroundColor={zinc800}
       >
         <AbstractButton
@@ -122,7 +150,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     width: '102%',
-    paddingTop: '30%',
   },
   card: {
     width: '100%',

--- a/app/src/screens/documents/selection/CountryPickerScreen.tsx
+++ b/app/src/screens/documents/selection/CountryPickerScreen.tsx
@@ -3,12 +3,7 @@
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
 import { memo, useCallback } from 'react';
-import {
-  ActivityIndicator,
-  FlatList,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import { ActivityIndicator, FlatList, TouchableOpacity, View } from 'react-native';
 
 import { commonNames } from '@selfxyz/common/constants/countries';
 import {
@@ -24,6 +19,7 @@ import {
 } from '@selfxyz/mobile-sdk-alpha/components';
 
 import { DocumentFlowNavBar } from '@/components/NavBar/DocumentFlowNavBar';
+import useCompactLayout from '@/hooks/useCompactLayout';
 import { black, slate100, slate500 } from '@/utils/colors';
 import { advercase, dinot } from '@/utils/fonts';
 import { buttonTap } from '@/utils/haptic';
@@ -65,6 +61,16 @@ CountryItem.displayName = 'CountryItem';
 
 const CountryPickerScreen: React.FC = () => {
   const selfClient = useSelfClient();
+  const { selectResponsiveValues, getResponsiveHorizontalPadding } =
+    useCompactLayout();
+  const { headingSize, subheadingSize, verticalSpacing, sectionSpacing } =
+    selectResponsiveValues({
+      headingSize: { compact: 22, regular: 29, dimension: 'width' },
+      subheadingSize: { compact: 15, regular: 16, dimension: 'width' },
+      verticalSpacing: { compact: 16, regular: 24, dimension: 'width' },
+      sectionSpacing: { compact: '$4', regular: '$6', dimension: 'width' },
+    });
+  const paddingHorizontal = getResponsiveHorizontalPadding({ percent: 0.05 });
 
   const { countryData, countryList, loading, userCountryCode, showSuggestion } =
     useCountries();
@@ -132,12 +138,22 @@ const CountryPickerScreen: React.FC = () => {
   return (
     <YStack flex={1} backgroundColor={slate100}>
       <DocumentFlowNavBar title="GETTING STARTED" />
-      <YStack flex={1} paddingTop="$4" paddingHorizontal="$4">
-        <YStack marginTop="$4" marginBottom="$6">
-          <BodyText style={{ fontSize: 29, fontFamily: advercase }}>
+      <YStack
+        flex={1}
+        paddingTop="$4"
+        paddingHorizontal={paddingHorizontal}
+      >
+        <YStack marginTop="$4" marginBottom={sectionSpacing}>
+          <BodyText style={{ fontSize: headingSize, fontFamily: advercase }}>
             Select the country that issued your ID
           </BodyText>
-          <BodyText style={{ fontSize: 16, color: slate500, marginTop: 20 }}>
+          <BodyText
+            style={{
+              fontSize: subheadingSize,
+              color: slate500,
+              marginTop: verticalSpacing,
+            }}
+          >
             Self has support for over 300 ID types. You can select the type of
             ID in the next step
           </BodyText>
@@ -150,7 +166,7 @@ const CountryPickerScreen: React.FC = () => {
               <YStack marginBottom="$2">
                 <BodyText
                   style={{
-                    fontSize: 16,
+                    fontSize: subheadingSize,
                     color: black,
                     fontFamily: dinot,
                     letterSpacing: 0.8,
@@ -167,11 +183,11 @@ const CountryPickerScreen: React.FC = () => {
                 />
                 <BodyText
                   style={{
-                    fontSize: 16,
+                    fontSize: subheadingSize,
                     color: black,
                     fontFamily: dinot,
                     letterSpacing: 0.8,
-                    marginTop: 20,
+                    marginTop: verticalSpacing,
                   }}
                 >
                   SELECT AN ISSUING COUNTRY

--- a/app/src/screens/documents/selection/IDPickerScreen.tsx
+++ b/app/src/screens/documents/selection/IDPickerScreen.tsx
@@ -21,6 +21,7 @@ import PlusIcon from '@selfxyz/mobile-sdk-alpha/svgs/icons/plus.svg';
 import SelfLogo from '@selfxyz/mobile-sdk-alpha/svgs/logo.svg';
 
 import { DocumentFlowNavBar } from '@/components/NavBar/DocumentFlowNavBar';
+import useCompactLayout from '@/hooks/useCompactLayout';
 import type { RootStackParamList } from '@/navigation';
 import { black, slate100, slate300, slate400, white } from '@/utils/colors';
 import { extraYPadding } from '@/utils/constants';
@@ -85,7 +86,26 @@ const IDPickerScreen: React.FC = () => {
   const route = useRoute<IDPickerScreenRouteProp>();
   const { countryCode = '', documentTypes = [] } = route.params || {};
   const bottom = useSafeAreaInsets().bottom;
+  const { selectResponsiveValues, getResponsiveHorizontalPadding } =
+    useCompactLayout();
   const selfClient = useSelfClient();
+
+  const {
+    heroSpacing,
+    headingSize,
+    cardTitleSize,
+    descriptionSize,
+    helperTextSize,
+    sectionMarginBottom,
+  } = selectResponsiveValues({
+    heroSpacing: { compact: 32, regular: 48, dimension: 'width' },
+    headingSize: { compact: 24, regular: 29, dimension: 'width' },
+    cardTitleSize: { compact: 20, regular: 24, dimension: 'width' },
+    descriptionSize: { compact: 13, regular: 14, dimension: 'width' },
+    helperTextSize: { compact: 16, regular: 18, dimension: 'width' },
+    sectionMarginBottom: { compact: '$4', regular: '$6', dimension: 'width' },
+  });
+  const paddingHorizontal = getResponsiveHorizontalPadding({ percent: 0.05 });
 
   const onSelectDocumentType = (docType: string) => {
     buttonTap();
@@ -106,14 +126,14 @@ const IDPickerScreen: React.FC = () => {
       backgroundColor={slate100}
       paddingBottom={bottom + extraYPadding + 24}
     >
-      <DocumentFlowNavBar title="GETTING STARTED" />
-      <YStack
-        flex={1}
-        paddingTop="$4"
-        paddingHorizontal="$4"
-        justifyContent="center"
-      >
-        <YStack marginTop="$4" marginBottom="$6">
+        <DocumentFlowNavBar title="GETTING STARTED" />
+        <YStack
+          flex={1}
+          paddingTop="$4"
+          paddingHorizontal={paddingHorizontal}
+          justifyContent="center"
+        >
+          <YStack marginTop="$4" marginBottom={sectionMarginBottom}>
           <XStack
             justifyContent="center"
             alignItems="center"
@@ -137,8 +157,8 @@ const IDPickerScreen: React.FC = () => {
           </XStack>
           <BodyText
             style={{
-              marginTop: 48,
-              fontSize: 29,
+              marginTop: heroSpacing,
+              fontSize: headingSize,
               fontFamily: advercase,
               textAlign: 'center',
             }}
@@ -166,13 +186,17 @@ const IDPickerScreen: React.FC = () => {
                 {getDocumentLogo(docType)}
                 <YStack gap={'$1'}>
                   <BodyText
-                    style={{ fontSize: 24, fontFamily: dinot, color: black }}
+                    style={{
+                      fontSize: cardTitleSize,
+                      fontFamily: dinot,
+                      color: black,
+                    }}
                   >
                     {getDocumentName(docType)}
                   </BodyText>
                   <BodyText
                     style={{
-                      fontSize: 14,
+                      fontSize: descriptionSize,
                       fontFamily: dinot,
                       color: slate400,
                     }}
@@ -185,7 +209,7 @@ const IDPickerScreen: React.FC = () => {
           ))}
           <BodyText
             style={{
-              fontSize: 18,
+              fontSize: helperTextSize,
               fontFamily: dinot,
               color: slate400,
               textAlign: 'center',

--- a/app/src/screens/onboarding/AccountVerifiedSuccessScreen.tsx
+++ b/app/src/screens/onboarding/AccountVerifiedSuccessScreen.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { YStack } from 'tamagui';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import {
   Description,
@@ -17,6 +18,7 @@ import { BackupEvents } from '@selfxyz/mobile-sdk-alpha/constants/analytics';
 import proofSuccessAnimation from '@/assets/animations/proof_success.json';
 import { DelayedLottieView } from '@/components/DelayedLottieView';
 import { ExpandableBottomLayout } from '@/layouts/ExpandableBottomLayout';
+import useCompactLayout from '@/hooks/useCompactLayout';
 import type { RootStackParamList } from '@/navigation';
 import { styles } from '@/screens/verification/ProofRequestStatusScreen';
 import { black, white } from '@/utils/colors';
@@ -25,6 +27,28 @@ import { buttonTap } from '@/utils/haptic';
 const AccountVerifiedSuccessScreen: React.FC = ({}) => {
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const { selectResponsiveValues, getResponsiveHorizontalPadding } = useCompactLayout();
+  const { bottom } = useSafeAreaInsets();
+
+  const {
+    topPadding,
+    gap,
+    stackMarginBottom,
+    titleSize,
+    descriptionSize,
+    bottomPaddingOffset,
+    contentBottomPadding,
+  } = selectResponsiveValues({
+    topPadding: { compact: 24, regular: 40 },
+    gap: { compact: 8, regular: 10 },
+    stackMarginBottom: { compact: 12, regular: 20 },
+    titleSize: { compact: 28, regular: 32 },
+    descriptionSize: { compact: 15, regular: 16 },
+    bottomPaddingOffset: { compact: 16, regular: 24 },
+    contentBottomPadding: { compact: 12, regular: 20 },
+  });
+  const horizontalPadding = getResponsiveHorizontalPadding({ percent: 0.06 });
+  const bottomPadding = bottom + bottomPaddingOffset;
 
   return (
     <ExpandableBottomLayout.Layout backgroundColor={white}>
@@ -38,18 +62,23 @@ const AccountVerifiedSuccessScreen: React.FC = ({}) => {
           renderMode="HARDWARE"
         />
       </ExpandableBottomLayout.TopSection>
-      <ExpandableBottomLayout.BottomSection backgroundColor={white}>
+      <ExpandableBottomLayout.BottomSection
+        backgroundColor={white}
+        paddingBottom={bottomPadding}
+      >
         <YStack
-          paddingTop={40}
-          paddingHorizontal={10}
-          paddingBottom={20}
+          paddingTop={topPadding}
+          paddingHorizontal={horizontalPadding}
+          paddingBottom={contentBottomPadding}
           justifyContent="center"
           alignItems="center"
-          marginBottom={20}
-          gap={10}
+          marginBottom={stackMarginBottom}
+          gap={gap}
         >
-          <Title size="large">ID Verified</Title>
-          <Description>
+          <Title size="large" style={{ fontSize: titleSize }}>
+            ID Verified
+          </Title>
+          <Description style={{ fontSize: descriptionSize, textAlign: 'center' }}>
             Your document's information is now protected by Self ID. Just scan a
             participating partner's QR code to prove your identity.
           </Description>

--- a/app/src/screens/onboarding/DisclaimerScreen.tsx
+++ b/app/src/screens/onboarding/DisclaimerScreen.tsx
@@ -18,6 +18,7 @@ import { AppEvents } from '@selfxyz/mobile-sdk-alpha/constants/analytics';
 import warningAnimation from '@/assets/animations/warning.json';
 import { DelayedLottieView } from '@/components/DelayedLottieView';
 import { ExpandableBottomLayout } from '@/layouts/ExpandableBottomLayout';
+import useCompactLayout from '@/hooks/useCompactLayout';
 import type { RootStackParamList } from '@/navigation';
 import { useSettingStore } from '@/stores/settingStore';
 import { black, white } from '@/utils/colors';
@@ -27,6 +28,12 @@ const DisclaimerScreen: React.FC = () => {
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const { dismissPrivacyNote } = useSettingStore();
+  const { selectResponsiveValues } = useCompactLayout({ compactHeight: 760 });
+  const { animationSize, buttonMargin, cautionSpacing } = selectResponsiveValues({
+    animationSize: { compact: '110%', regular: '125%', dimension: 'height' },
+    buttonMargin: { compact: 20, regular: 30, dimension: 'height' },
+    cautionSpacing: { compact: 6, regular: 10, dimension: 'height' },
+  });
 
   useEffect(() => {
     notificationWarning();
@@ -39,7 +46,7 @@ const DisclaimerScreen: React.FC = () => {
           autoPlay
           loop={false}
           source={warningAnimation}
-          style={styles.animation}
+          style={[styles.animation, { width: animationSize, height: animationSize }]}
           cacheComposition={true}
           renderMode="HARDWARE"
         />
@@ -54,12 +61,12 @@ const DisclaimerScreen: React.FC = () => {
             (like passwords, Social Security numbers, or financial details)
             should be trusted only if they're secure and necessary.
           </Caution>
-          <Caution style={{ marginTop: 10 }}>
+          <Caution style={{ marginTop: cautionSpacing }}>
             Always verify an app's legitimacy before sharing your data.
           </Caution>
           <PrimaryButton
             trackEvent={AppEvents.DISMISS_PRIVACY_DISCLAIMER}
-            style={{ marginVertical: 30 }}
+            style={{ marginVertical: buttonMargin }}
             onPress={() => {
               confirmTap();
               dismissPrivacyNote();

--- a/app/src/screens/onboarding/SaveRecoveryPhraseScreen.tsx
+++ b/app/src/screens/onboarding/SaveRecoveryPhraseScreen.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
 import {
   Caption,
@@ -16,6 +16,7 @@ import Mnemonic from '@/components/Mnemonic';
 import useHapticNavigation from '@/hooks/useHapticNavigation';
 import useMnemonic from '@/hooks/useMnemonic';
 import { ExpandableBottomLayout } from '@/layouts/ExpandableBottomLayout';
+import useCompactLayout from '@/hooks/useCompactLayout';
 import { useSettingStore } from '@/stores/settingStore';
 import { STORAGE_NAME } from '@/utils/cloudBackup';
 import { black, slate400, white } from '@/utils/colors';
@@ -24,6 +25,43 @@ const SaveRecoveryPhraseScreen: React.FC = () => {
   const [userHasSeenMnemonic, setUserHasSeenMnemonic] = useState(false);
   const { mnemonic, loadMnemonic } = useMnemonic();
   const { cloudBackupEnabled } = useSettingStore();
+  const { selectResponsiveValues } = useCompactLayout({
+    compactHeight: 780,
+  });
+  const {
+    topPadding,
+    bottomPadding,
+    sectionGap,
+    titleFontSize,
+    titleLineHeight,
+    descriptionFontSize,
+    descriptionLineHeight,
+  } = selectResponsiveValues({
+    topPadding: { compact: 12, regular: 20, dimension: 'height' },
+    bottomPadding: { compact: 6, regular: 10, dimension: 'height' },
+    sectionGap: { compact: 6, regular: 10, dimension: 'height' },
+    titleFontSize: { compact: 26, regular: 28, dimension: 'width' },
+    titleLineHeight: { compact: 32, regular: 35, dimension: 'width' },
+    descriptionFontSize: { compact: 16, regular: 18, dimension: 'width' },
+    descriptionLineHeight: { compact: 21, regular: 23, dimension: 'width' },
+  });
+  const titleStyle = useMemo(
+    () => ({
+      paddingTop: topPadding,
+      textAlign: 'center',
+      fontSize: titleFontSize,
+      lineHeight: titleLineHeight,
+    }),
+    [titleFontSize, titleLineHeight, topPadding],
+  );
+  const descriptionStyle = useMemo(
+    () => ({
+      paddingBottom: bottomPadding,
+      fontSize: descriptionFontSize,
+      lineHeight: descriptionLineHeight,
+    }),
+    [bottomPadding, descriptionFontSize, descriptionLineHeight],
+  );
 
   const onRevealWords = useCallback(async () => {
     await loadMnemonic();
@@ -43,12 +81,12 @@ const SaveRecoveryPhraseScreen: React.FC = () => {
         roundTop
         backgroundColor={white}
         justifyContent="space-between"
-        gap={10}
+        gap={sectionGap}
       >
-        <Title style={{ paddingTop: 20, textAlign: 'center' }}>
+        <Title style={titleStyle}>
           Save your recovery phrase
         </Title>
-        <Description style={{ paddingBottom: 10 }}>
+        <Description style={descriptionStyle}>
           This phrase is the only way to recover your account. Keep it secret,
           keep it safe.
         </Description>

--- a/app/src/screens/shared/ComingSoonScreen.tsx
+++ b/app/src/screens/shared/ComingSoonScreen.tsx
@@ -5,6 +5,7 @@
 import React, { useEffect, useMemo } from 'react';
 import { XStack, YStack } from 'tamagui';
 import type { RouteProp } from '@react-navigation/native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { countryCodes } from '@selfxyz/common/constants';
 import type { DocumentCategory } from '@selfxyz/common/types';
@@ -23,6 +24,7 @@ import { PassportEvents } from '@selfxyz/mobile-sdk-alpha/constants/analytics';
 
 import useHapticNavigation from '@/hooks/useHapticNavigation';
 import { ExpandableBottomLayout } from '@/layouts/ExpandableBottomLayout';
+import useCompactLayout from '@/hooks/useCompactLayout';
 import analytics from '@/utils/analytics';
 import { black, slate500, white } from '@/utils/colors';
 import { sendCountrySupportNotification } from '@/utils/email';
@@ -48,6 +50,17 @@ const ComingSoonScreen: React.FC<ComingSoonScreenProps> = ({ route }) => {
   const selfClient = useSelfClient();
   const navigateToLaunch = useHapticNavigation('Launch');
   const navigateToHome = useHapticNavigation('Home');
+  const { selectResponsiveValues, getResponsiveHorizontalPadding } = useCompactLayout();
+  const { bottom } = useSafeAreaInsets();
+
+  const { topMargin, headlineSize, bodyFontSize, supportingSpacing } =
+    selectResponsiveValues({
+      topMargin: { compact: 48, regular: 100 },
+      headlineSize: { compact: 26, regular: 32 },
+      bodyFontSize: { compact: 15, regular: 17 },
+      supportingSpacing: { compact: 24, regular: 40 },
+    });
+  const sidePadding = getResponsiveHorizontalPadding({ percent: 0.06 });
 
   const { countryName, countryCode, documentTypeText } = useMemo(() => {
     try {
@@ -124,7 +137,7 @@ const ComingSoonScreen: React.FC<ComingSoonScreenProps> = ({ route }) => {
           flex={1}
           justifyContent="center"
           alignItems="center"
-          marginTop={100}
+          marginTop={topMargin}
         >
           <XStack
             justifyContent="center"
@@ -138,7 +151,7 @@ const ComingSoonScreen: React.FC<ComingSoonScreenProps> = ({ route }) => {
           </XStack>
           <Title
             style={{
-              fontSize: 32,
+              fontSize: headlineSize,
               textAlign: 'center',
               color: black,
               marginBottom: 16,
@@ -148,11 +161,11 @@ const ComingSoonScreen: React.FC<ComingSoonScreenProps> = ({ route }) => {
           </Title>
           <BodyText
             style={{
-              fontSize: 17,
+              fontSize: bodyFontSize,
               textAlign: 'center',
               color: black,
               marginBottom: 10,
-              paddingHorizontal: 10,
+              paddingHorizontal: sidePadding,
             }}
           >
             {documentTypeText
@@ -161,11 +174,11 @@ const ComingSoonScreen: React.FC<ComingSoonScreenProps> = ({ route }) => {
           </BodyText>
           <BodyText
             style={{
-              fontSize: 17,
+              fontSize: bodyFontSize,
               textAlign: 'center',
               color: slate500,
-              marginBottom: 40,
-              paddingHorizontal: 10,
+              marginBottom: supportingSpacing,
+              paddingHorizontal: sidePadding,
             }}
           >
             Sign up for live updates.
@@ -175,8 +188,9 @@ const ComingSoonScreen: React.FC<ComingSoonScreenProps> = ({ route }) => {
       <ExpandableBottomLayout.BottomSection
         gap={16}
         backgroundColor={white}
-        paddingHorizontal={20}
-        paddingVertical={20}
+        paddingHorizontal={sidePadding}
+        paddingTop={20}
+        paddingBottom={bottom + 20}
       >
         <PrimaryButton
           onPress={onNotifyMe}


### PR DESCRIPTION
## Summary
- add a selectResponsiveValues helper to `useCompactLayout` to compute multiple responsive values at once
- update compact-aware screens and components to consume the helper for consistent sizing logic
- simplify mnemonic spacing by reusing the shared selector instead of repeating inline calculations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68eebf896864832d9480ccc839ea9595

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Responsive/compact layouts across onboarding, recovery, documents, and shared screens with adaptive typography, spacing, and horizontal padding.
  * Safe-area aware top/bottom padding.
  * Dynamic sizing for icons, cards, and buttons.
  * Improved keyboard handling on “Recover with Phrase.”
  * Mnemonic display gains compact styling and refined copy/reveal button padding.
  * Disclaimer screen now navigates to Home after dismissing the privacy note.

* **Refactor**
  * Replaced hard-coded paddings, margins, and font sizes with responsive values; restructured sections for flexibility.

* **Style**
  * Visual polish for readability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->