### PR TITLE
feat(dsc-sod): detect RSA-signed SOD with RSA-PSS DSC

### DIFF
--- a/common/src/utils/passports/passport_parsing/brutForcePassportSignature.ts
+++ b/common/src/utils/passports/passport_parsing/brutForcePassportSignature.ts
@@ -40,6 +40,14 @@ export function brutforceSignatureAlgorithm(passportData: PassportData) {
       };
     }
   }
+  const hashAlgorithm = brutforceHashAlgorithm(passportData, 'rsa');
+  if (hashAlgorithm) {
+    return {
+      signatureAlgorithm: 'rsa',
+      hashAlgorithm: hashAlgorithm,
+      saltLength: 0,
+    };
+  }
 }
 
 function brutforceHashAlgorithm(


### PR DESCRIPTION
### Description
This PR adds logic to detect cases where the SOD is signed using normal RSA while the DSC certificate is RSA-PSS. This behavior was observed when working with Turkish IDs, where the DSC uses RSA-PSS but the SOD must be processed with legacy RSA.

### Changes
- Updated `brutforceSignatureAlgorithm` to detect cases where the SOD is signed with normal RSA while the DSC certificate is RSA-PSS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved passport document verification by extending signature validation to handle additional algorithm combinations, ensuring better compatibility with various passport formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->