### PR TITLE
Add / update ci retry logic

### DIFF
--- a/.github/actions/yarn-install/action.yml
+++ b/.github/actions/yarn-install/action.yml
@@ -27,26 +27,9 @@ runs:
         cache-dependency-path: yarn.lock
 
     - name: Install dependencies
-      shell: bash
-      run: |
-        # Retry up to 3 times with exponential backoff for transient Yarn Berry issues
-        max_attempts=3
-        attempt=1
-        while [ $attempt -le $max_attempts ]; do
-          echo "Attempt $attempt of $max_attempts..."
-          if yarn install --immutable; then
-            echo "✓ Dependencies installed successfully"
-            exit 0
-          else
-            exit_code=$?
-            if [ $attempt -lt $max_attempts ]; then
-              wait_time=$((2 ** attempt))
-              echo "✗ Install failed with exit code $exit_code. Retrying in ${wait_time}s..."
-              sleep $wait_time
-            else
-              echo "✗ Install failed after $max_attempts attempts"
-              exit $exit_code
-            fi
-          fi
-          attempt=$((attempt + 1))
-        done
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 10
+        max_attempts: 3
+        retry_wait_seconds: 5
+        command: yarn install --immutable

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -309,12 +309,14 @@ jobs:
           bundle install --jobs 4 --retry 3
         working-directory: ./app
       - name: Install iOS Dependencies
-        run: |
-          echo "Installing iOS dependencies..."
-          cd ios
-          # Reuse the same guarded flow as local to ensure reproducibility
-          bundle exec bash scripts/pod-install-with-cache-fix.sh
-        working-directory: ./app
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: |
+            cd app/ios
+            bundle exec bash scripts/pod-install-with-cache-fix.sh
         env:
           SELFXYZ_INTERNAL_REPO_PAT: ${{ secrets.SELFXYZ_INTERNAL_REPO_PAT }}
       - name: Resolve iOS workspace
@@ -436,12 +438,19 @@ jobs:
         with:
           accept-android-sdk-licenses: true
       - name: Cache NDK
+        id: ndk-cache
         uses: actions/cache@v4
         with:
           path: ${{ env.ANDROID_HOME }}/ndk/${{ env.ANDROID_NDK_VERSION }}
           key: ${{ runner.os }}-ndk-${{ env.ANDROID_NDK_VERSION }}
       - name: Install NDK
-        run: sdkmanager "ndk;${{ env.ANDROID_NDK_VERSION }}"
+        if: steps.ndk-cache.outputs.cache-hit != 'true'
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: sdkmanager "ndk;${{ env.ANDROID_NDK_VERSION }}"
       - name: Install Mobile Dependencies
         uses: ./.github/actions/yarn-install
       - name: Cache Built Dependencies

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -1057,51 +1057,23 @@ jobs:
         with:
           accept-android-sdk-licenses: true
 
-      - name: Install NDK and CMake
+      - name: Install NDK
         if: inputs.platform != 'ios' && steps.ndk-cache.outputs.cache-hit != 'true'
-        run: |
-          max_attempts=5
-          attempt=1
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 15
+          max_attempts: 5
+          retry_wait_seconds: 10
+          command: sdkmanager "ndk;${{ env.ANDROID_NDK_VERSION }}"
 
-          # Install NDK
-          while [ $attempt -le $max_attempts ]; do
-            echo "Attempt $attempt of $max_attempts to install NDK..."
-            if sdkmanager "ndk;${{ env.ANDROID_NDK_VERSION }}"; then
-              echo "Successfully installed NDK"
-              break
-            fi
-            echo "Failed to install NDK on attempt $attempt"
-            if [ $attempt -eq $max_attempts ]; then
-              echo "All attempts to install NDK failed"
-              exit 1
-            fi
-            # Exponential backoff: 2^attempt seconds
-            wait_time=$((2 ** attempt))
-            echo "Waiting $wait_time seconds before retrying..."
-            sleep $wait_time
-            attempt=$((attempt + 1))
-          done
-
-          # Install CMake (required for native module builds)
-          echo "Installing CMake..."
-          attempt=1
-          while [ $attempt -le $max_attempts ]; do
-            echo "Attempt $attempt of $max_attempts to install CMake..."
-            if sdkmanager "cmake;3.22.1"; then
-              echo "Successfully installed CMake"
-              break
-            fi
-            echo "Failed to install CMake on attempt $attempt"
-            if [ $attempt -eq $max_attempts ]; then
-              echo "All attempts to install CMake failed"
-              exit 1
-            fi
-            # Exponential backoff: 2^attempt seconds
-            wait_time=$((2 ** attempt))
-            echo "Waiting $wait_time seconds before retrying..."
-            sleep $wait_time
-            attempt=$((attempt + 1))
-          done
+      - name: Install CMake
+        if: inputs.platform != 'ios' && steps.ndk-cache.outputs.cache-hit != 'true'
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 5
+          retry_wait_seconds: 10
+          command: sdkmanager "cmake;3.22.1"
 
       - name: Set Gradle JVM options
         if: inputs.platform != 'ios' # Apply to CI builds (not just ACT)

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -69,54 +69,22 @@ jobs:
         run: echo "YARN_ENABLE_HARDENED_MODE=0" >> $GITHUB_ENV
       - name: Install deps (internal PRs and protected branches)
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
-        run: |
-          # Retry up to 3 times with exponential backoff for transient Yarn Berry issues
-          max_attempts=3
-          attempt=1
-          while [ $attempt -le $max_attempts ]; do
-            echo "Attempt $attempt of $max_attempts..."
-            if yarn install --immutable --silent; then
-              echo "✓ Dependencies installed successfully"
-              exit 0
-            else
-              exit_code=$?
-              if [ $attempt -lt $max_attempts ]; then
-                wait_time=$((2 ** attempt))
-                echo "✗ Install failed with exit code $exit_code. Retrying in ${wait_time}s..."
-                sleep $wait_time
-              else
-                echo "✗ Install failed after $max_attempts attempts"
-                exit $exit_code
-              fi
-            fi
-            attempt=$((attempt + 1))
-          done
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 5
+          command: yarn install --immutable --silent
         env:
           SELFXYZ_INTERNAL_REPO_PAT: ${{ secrets.SELFXYZ_INTERNAL_REPO_PAT }}
       - name: Install deps (forked PRs - no secrets)
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
-        run: |
-          # Retry up to 3 times with exponential backoff for transient Yarn Berry issues
-          max_attempts=3
-          attempt=1
-          while [ $attempt -le $max_attempts ]; do
-            echo "Attempt $attempt of $max_attempts..."
-            if yarn install --immutable --silent; then
-              echo "✓ Dependencies installed successfully"
-              exit 0
-            else
-              exit_code=$?
-              if [ $attempt -lt $max_attempts ]; then
-                wait_time=$((2 ** attempt))
-                echo "✗ Install failed with exit code $exit_code. Retrying in ${wait_time}s..."
-                sleep $wait_time
-              else
-                echo "✗ Install failed after $max_attempts attempts"
-                exit $exit_code
-              fi
-            fi
-            attempt=$((attempt + 1))
-          done
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 5
+          command: yarn install --immutable --silent
       - name: Validate Maestro test file
         if: false # Skip for build-only test - keep logic for future E2E
         run: |
@@ -148,7 +116,12 @@ jobs:
         with:
           accept-android-sdk-licenses: true
       - name: Install NDK
-        run: sdkmanager "ndk;${{ env.ANDROID_NDK_VERSION }}"
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: sdkmanager "ndk;${{ env.ANDROID_NDK_VERSION }}"
       - name: Build dependencies (outside emulator)
         run: |
           echo "Building dependencies..."
@@ -271,54 +244,22 @@ jobs:
         run: echo "YARN_ENABLE_HARDENED_MODE=0" >> $GITHUB_ENV
       - name: Install deps (internal PRs and protected branches)
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
-        run: |
-          # Retry up to 3 times with exponential backoff for transient Yarn Berry issues
-          max_attempts=3
-          attempt=1
-          while [ $attempt -le $max_attempts ]; do
-            echo "Attempt $attempt of $max_attempts..."
-            if yarn install --immutable --silent; then
-              echo "✓ Dependencies installed successfully"
-              exit 0
-            else
-              exit_code=$?
-              if [ $attempt -lt $max_attempts ]; then
-                wait_time=$((2 ** attempt))
-                echo "✗ Install failed with exit code $exit_code. Retrying in ${wait_time}s..."
-                sleep $wait_time
-              else
-                echo "✗ Install failed after $max_attempts attempts"
-                exit $exit_code
-              fi
-            fi
-            attempt=$((attempt + 1))
-          done
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 5
+          command: yarn install --immutable --silent
         env:
           SELFXYZ_INTERNAL_REPO_PAT: ${{ secrets.SELFXYZ_INTERNAL_REPO_PAT }}
       - name: Install deps (forked PRs - no secrets)
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
-        run: |
-          # Retry up to 3 times with exponential backoff for transient Yarn Berry issues
-          max_attempts=3
-          attempt=1
-          while [ $attempt -le $max_attempts ]; do
-            echo "Attempt $attempt of $max_attempts..."
-            if yarn install --immutable --silent; then
-              echo "✓ Dependencies installed successfully"
-              exit 0
-            else
-              exit_code=$?
-              if [ $attempt -lt $max_attempts ]; then
-                wait_time=$((2 ** attempt))
-                echo "✗ Install failed with exit code $exit_code. Retrying in ${wait_time}s..."
-                sleep $wait_time
-              else
-                echo "✗ Install failed after $max_attempts attempts"
-                exit $exit_code
-              fi
-            fi
-            attempt=$((attempt + 1))
-          done
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 5
+          command: yarn install --immutable --silent
       - name: Validate Maestro test file
         run: |
           [ -f app/tests/e2e/launch.ios.flow.yaml ] || { echo "❌ iOS E2E test file missing"; exit 1; }
@@ -330,7 +271,12 @@ jobs:
           key: ${{ runner.os }}-maestro-${{ env.MAESTRO_VERSION }}
       - name: Install Maestro
         if: steps.cache-maestro.outputs.cache-hit != 'true'
-        run: curl -Ls "https://get.maestro.mobile.dev" | bash
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: curl -Ls "https://get.maestro.mobile.dev" | bash
       - name: Add Maestro to path
         run: echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
       - name: Set up Xcode
@@ -388,11 +334,15 @@ jobs:
           yarn workspace @selfxyz/mobile-app run build:deps || { echo "❌ Dependency build failed"; exit 1; }
           echo "✅ Dependencies built successfully"
       - name: Install iOS dependencies
-        run: |
-          echo "Installing iOS dependencies..."
-          cd app/ios
-          echo "📦 Installing pods via centralized script…"
-          BUNDLE_GEMFILE=../Gemfile bundle exec bash scripts/pod-install-with-cache-fix.sh || { echo "❌ Pod install failed"; exit 1; }
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: |
+            cd app/ios
+            echo "📦 Installing pods via centralized script…"
+            BUNDLE_GEMFILE=../Gemfile bundle exec bash scripts/pod-install-with-cache-fix.sh
         env:
           SELFXYZ_INTERNAL_REPO_PAT: ${{ secrets.SELFXYZ_INTERNAL_REPO_PAT }}
       - name: Setup iOS Simulator

--- a/.github/workflows/mobile-sdk-demo-e2e.yml
+++ b/.github/workflows/mobile-sdk-demo-e2e.yml
@@ -71,54 +71,22 @@ jobs:
         run: echo "YARN_ENABLE_HARDENED_MODE=0" >> $GITHUB_ENV
       - name: Install deps (internal PRs and protected branches)
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
-        run: |
-          # Retry up to 3 times with exponential backoff for transient Yarn Berry issues
-          max_attempts=3
-          attempt=1
-          while [ $attempt -le $max_attempts ]; do
-            echo "Attempt $attempt of $max_attempts..."
-            if yarn install --immutable --silent; then
-              echo "✓ Dependencies installed successfully"
-              exit 0
-            else
-              exit_code=$?
-              if [ $attempt -lt $max_attempts ]; then
-                wait_time=$((2 ** attempt))
-                echo "✗ Install failed with exit code $exit_code. Retrying in ${wait_time}s..."
-                sleep $wait_time
-              else
-                echo "✗ Install failed after $max_attempts attempts"
-                exit $exit_code
-              fi
-            fi
-            attempt=$((attempt + 1))
-          done
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 5
+          command: yarn install --immutable --silent
         env:
           SELFXYZ_INTERNAL_REPO_PAT: ${{ secrets.SELFXYZ_INTERNAL_REPO_PAT }}
       - name: Install deps (forked PRs - no secrets)
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
-        run: |
-          # Retry up to 3 times with exponential backoff for transient Yarn Berry issues
-          max_attempts=3
-          attempt=1
-          while [ $attempt -le $max_attempts ]; do
-            echo "Attempt $attempt of $max_attempts..."
-            if yarn install --immutable --silent; then
-              echo "✓ Dependencies installed successfully"
-              exit 0
-            else
-              exit_code=$?
-              if [ $attempt -lt $max_attempts ]; then
-                wait_time=$((2 ** attempt))
-                echo "✗ Install failed with exit code $exit_code. Retrying in ${wait_time}s..."
-                sleep $wait_time
-              else
-                echo "✗ Install failed after $max_attempts attempts"
-                exit $exit_code
-              fi
-            fi
-            attempt=$((attempt + 1))
-          done
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 5
+          command: yarn install --immutable --silent
       - name: Validate Maestro test file
         if: false # Skip for build-only test - keep logic for future E2E
         run: |
@@ -150,7 +118,12 @@ jobs:
         with:
           accept-android-sdk-licenses: true
       - name: Install NDK
-        run: sdkmanager "ndk;${{ env.ANDROID_NDK_VERSION }}"
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: sdkmanager "ndk;${{ env.ANDROID_NDK_VERSION }}"
       - name: Enable KVM group perms
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -258,54 +231,22 @@ jobs:
         run: echo "YARN_ENABLE_HARDENED_MODE=0" >> $GITHUB_ENV
       - name: Install deps (internal PRs and protected branches)
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
-        run: |
-          # Retry up to 3 times with exponential backoff for transient Yarn Berry issues
-          max_attempts=3
-          attempt=1
-          while [ $attempt -le $max_attempts ]; do
-            echo "Attempt $attempt of $max_attempts..."
-            if yarn install --immutable --silent; then
-              echo "✓ Dependencies installed successfully"
-              exit 0
-            else
-              exit_code=$?
-              if [ $attempt -lt $max_attempts ]; then
-                wait_time=$((2 ** attempt))
-                echo "✗ Install failed with exit code $exit_code. Retrying in ${wait_time}s..."
-                sleep $wait_time
-              else
-                echo "✗ Install failed after $max_attempts attempts"
-                exit $exit_code
-              fi
-            fi
-            attempt=$((attempt + 1))
-          done
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 5
+          command: yarn install --immutable --silent
         env:
           SELFXYZ_INTERNAL_REPO_PAT: ${{ secrets.SELFXYZ_INTERNAL_REPO_PAT }}
       - name: Install deps (forked PRs - no secrets)
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
-        run: |
-          # Retry up to 3 times with exponential backoff for transient Yarn Berry issues
-          max_attempts=3
-          attempt=1
-          while [ $attempt -le $max_attempts ]; do
-            echo "Attempt $attempt of $max_attempts..."
-            if yarn install --immutable --silent; then
-              echo "✓ Dependencies installed successfully"
-              exit 0
-            else
-              exit_code=$?
-              if [ $attempt -lt $max_attempts ]; then
-                wait_time=$((2 ** attempt))
-                echo "✗ Install failed with exit code $exit_code. Retrying in ${wait_time}s..."
-                sleep $wait_time
-              else
-                echo "✗ Install failed after $max_attempts attempts"
-                exit $exit_code
-              fi
-            fi
-            attempt=$((attempt + 1))
-          done
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 5
+          command: yarn install --immutable --silent
       - name: Validate Maestro test file
         run: |
           [ -f packages/mobile-sdk-demo/tests/e2e/launch.ios.flow.yaml ] || { echo "❌ iOS E2E test file missing"; exit 1; }
@@ -317,7 +258,12 @@ jobs:
           key: ${{ runner.os }}-maestro-${{ env.MAESTRO_VERSION }}
       - name: Install Maestro
         if: steps.cache-maestro.outputs.cache-hit != 'true'
-        run: curl -Ls "https://get.maestro.mobile.dev" | bash
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: curl -Ls "https://get.maestro.mobile.dev" | bash
       - name: Add Maestro to path
         run: echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
       - name: Set up Xcode
@@ -368,17 +314,21 @@ jobs:
           yarn workspace mobile-sdk-demo run prebuild || { echo "❌ Dependency build failed"; exit 1; }
           echo "✅ Dependencies built successfully"
       - name: Install iOS dependencies
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: |
+            if [ -n "${SELFXYZ_INTERNAL_REPO_PAT}" ]; then
+              echo "🔑 Using SELFXYZ_INTERNAL_REPO_PAT for private pod access"
+              echo "::add-mask::${SELFXYZ_INTERNAL_REPO_PAT}"
+            fi
+            cd packages/mobile-sdk-demo/ios
+            pod install
         env:
           SELFXYZ_INTERNAL_REPO_PAT: ${{ secrets.SELFXYZ_INTERNAL_REPO_PAT }}
           GIT_TERMINAL_PROMPT: 0
-        run: |
-          echo "Installing iOS dependencies..."
-          if [ -n "${SELFXYZ_INTERNAL_REPO_PAT}" ]; then
-            echo "🔑 Using SELFXYZ_INTERNAL_REPO_PAT for private pod access"
-            echo "::add-mask::${SELFXYZ_INTERNAL_REPO_PAT}"
-          fi
-          cd packages/mobile-sdk-demo/ios
-          pod install
       - name: Setup iOS Simulator
         run: |
           echo "Setting up iOS Simulator..."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened CI/CD pipeline reliability across mobile development workflows with automatic retry mechanisms for dependency installation, Android NDK setup, CMake installation, iOS pod installation, and related build tool provisioning steps. Configured with timeout limits and retry attempts to reduce transient failures and improve overall build stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->