### PR TITLE
Mobile SDK: add license

### DIFF
--- a/packages/mobile-sdk-alpha/LICENSE
+++ b/packages/mobile-sdk-alpha/LICENSE
@@ -1,0 +1,35 @@
+Business Source License 1.1
+
+Parameters
+
+Licensor: Social Connect Labs, Inc.
+
+Licensed Work: The code in this folder and all folders nested within it, including all files and components unless explicitly stated otherwise.
+
+Additional Use Grant: Any use for development, testing, and deployment on networks approved by Social Connect Labs, Inc., including internal business operations and academic research.
+
+Change Date: 2029-06-11
+
+Change License: Apache License, Version 2.0
+
+================================================================
+
+Business Source License 1.1
+
+Copyright (C) 2025 Social Connect Labs, Inc.
+
+The contents of this repository are licensed under the Business Source License 1.1 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:
+
+https://spdx.org/licenses/BUSL-1.1.html
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+Change Date
+
+The Change Date is the later of four years from the date this repository was published or 2029-06-11.
+
+Change License
+
+On the Change Date, the contents of this repository will be made available under the terms of the Apache License, Version 2.0, as published by the Apache Software Foundation.
+
+See the License for the specific language governing permissions and limitations under the Business Source License.

--- a/packages/mobile-sdk-alpha/package.json
+++ b/packages/mobile-sdk-alpha/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@selfxyz/mobile-sdk-alpha",
   "version": "0.0.1-alpha.1",
+  "license": "BUSL-1.1",
   "description": "Self SDK (alpha) for registering and proving",
   "keywords": [
     "self",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated mobile SDK alpha licensing to Business Source License 1.1, with automatic transition to Apache License 2.0 on June 11, 2029.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->