### PR TITLE
fix: mark document as registered after restoring secret

### DIFF
--- a/app/src/screens/account/recovery/AccountRecoveryChoiceScreen.tsx
+++ b/app/src/screens/account/recovery/AccountRecoveryChoiceScreen.tsx
@@ -8,7 +8,10 @@ import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import { isUserRegisteredWithAlternativeCSCA } from '@selfxyz/common/utils/passports/validate';
-import { useSelfClient } from '@selfxyz/mobile-sdk-alpha';
+import {
+  markCurrentDocumentAsRegistered,
+  useSelfClient,
+} from '@selfxyz/mobile-sdk-alpha';
 import {
   Caption,
   Description,
@@ -98,6 +101,7 @@ const AccountRecoveryChoiceScreen: React.FC = () => {
         toggleCloudBackupEnabled();
       }
       reStorePassportDataWithRightCSCA(passportData, csca as string);
+      await markCurrentDocumentAsRegistered(selfClient);
       trackEvent(BackupEvents.CLOUD_RESTORE_SUCCESS);
       trackEvent(BackupEvents.ACCOUNT_RECOVERY_COMPLETED);
       onRestoreFromCloudNext();
@@ -117,6 +121,7 @@ const AccountRecoveryChoiceScreen: React.FC = () => {
     navigation,
     toggleCloudBackupEnabled,
     useProtocolStore,
+    selfClient,
   ]);
 
   const handleManualRecoveryPress = useCallback(() => {

--- a/app/src/screens/account/recovery/RecoverWithPhraseScreen.tsx
+++ b/app/src/screens/account/recovery/RecoverWithPhraseScreen.tsx
@@ -11,7 +11,10 @@ import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import { isUserRegisteredWithAlternativeCSCA } from '@selfxyz/common/utils/passports/validate';
-import { useSelfClient } from '@selfxyz/mobile-sdk-alpha';
+import {
+  markCurrentDocumentAsRegistered,
+  useSelfClient,
+} from '@selfxyz/mobile-sdk-alpha';
 import {
   Description,
   SecondaryButton,
@@ -100,12 +103,14 @@ const RecoverWithPhraseScreen: React.FC = () => {
     }
 
     setRestoring(false);
+    await markCurrentDocumentAsRegistered(selfClient);
     trackEvent(BackupEvents.ACCOUNT_RECOVERY_COMPLETED);
     navigation.navigate('AccountVerifiedSuccess');
   }, [
     mnemonic,
     navigation,
     restoreAccountFromMnemonic,
+    selfClient,
     trackEvent,
     useProtocolStore,
   ]);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documents are now automatically registered upon successful account recovery, whether using cloud restore or recovery phrase methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->