### PR TITLE
Fix Android message share

### DIFF
--- a/app/src/utils/referralShare.ts
+++ b/app/src/utils/referralShare.ts
@@ -43,6 +43,16 @@ export const shareViaSMS = async (message: string): Promise<void> => {
     if (canOpen) {
       await Linking.openURL(url);
     } else {
+      if (Platform.OS === 'android') {
+        try {
+          await Linking.openURL(url);
+
+          return;
+        } catch {
+          // same as for WhatsApp, we try anyway and show alert if it fails
+        }
+      }
+
       Alert.alert('Error', 'Unable to open Messages app');
     }
   } catch (error) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an Android-specific fallback to open the SMS intent even if canOpenURL returns false, improving reliability of message sharing.
> 
> - **Utils**
>   - **`app/src/utils/referralShare.ts`**:
>     - SMS sharing: when `Linking.canOpenURL` returns false on Android, attempt `Linking.openURL` anyway with early return on success; otherwise show existing alert.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20cd686dd1e175a55cc4b8d60ab83f5cb367d606. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->