### PR TITLE
fix(passport-signature): guard ECDSA bruteforce returns and add safe fallbacks

### DIFF
--- a/common/src/utils/passports/passport_parsing/brutForceDscSignature.ts
+++ b/common/src/utils/passports/passport_parsing/brutForceDscSignature.ts
@@ -14,11 +14,13 @@ import { hash } from '../../hash.js';
 export function brutforceSignatureAlgorithmDsc(dsc: CertificateData, csca: CertificateData) {
   if (csca.signatureAlgorithm === 'ecdsa') {
     const hashAlgorithm = brutforceHashAlgorithmDsc(dsc, csca, 'ecdsa');
-    return {
-      signatureAlgorithm: 'ecdsa',
-      hashAlgorithm: hashAlgorithm,
-      saltLength: 0,
-    };
+    if (hashAlgorithm) {
+      return {
+        signatureAlgorithm: 'ecdsa',
+        hashAlgorithm: hashAlgorithm,
+        saltLength: 0,
+      };
+    }
   } else if (csca.signatureAlgorithm === 'rsa') {
     const hashAlgorithm = brutforceHashAlgorithmDsc(dsc, csca, 'rsa');
     if (hashAlgorithm) {

--- a/common/src/utils/passports/passport_parsing/brutForcePassportSignature.ts
+++ b/common/src/utils/passports/passport_parsing/brutForcePassportSignature.ts
@@ -14,11 +14,13 @@ export function brutforceSignatureAlgorithm(passportData: PassportData) {
   const parsedDsc = parseCertificateSimple(passportData.dsc);
   if (parsedDsc.signatureAlgorithm === 'ecdsa') {
     const hashAlgorithm = brutforceHashAlgorithm(passportData, 'ecdsa');
-    return {
-      signatureAlgorithm: 'ecdsa',
-      hashAlgorithm: hashAlgorithm,
-      saltLength: 0,
-    };
+    if (hashAlgorithm) {
+      return {
+        signatureAlgorithm: 'ecdsa',
+        hashAlgorithm: hashAlgorithm,
+        saltLength: 0,
+      };
+    }
   } else if (parsedDsc.signatureAlgorithm === 'rsa') {
     const hashAlgorithm = brutforceHashAlgorithm(passportData, 'rsa');
     if (hashAlgorithm) {

--- a/common/src/utils/passports/passport_parsing/parseDscCertificateData.ts
+++ b/common/src/utils/passports/passport_parsing/parseDscCertificateData.ts
@@ -35,11 +35,17 @@ export function parseDscCertificateData(
         cscaParsed = parseCertificateSimple(csca);
         const details = brutforceSignatureAlgorithmDsc(dscCert, cscaParsed);
         cscaFound = true;
-        cscaHashAlgorithm = details.hashAlgorithm;
-        cscaSignatureAlgorithm = details.signatureAlgorithm;
+        if (details && details.hashAlgorithm && details.signatureAlgorithm) {
+          cscaHashAlgorithm = details.hashAlgorithm;
+          cscaSignatureAlgorithm = details.signatureAlgorithm;
+          cscaSaltLength = details.saltLength;
+        } else if (cscaParsed) {
+          cscaHashAlgorithm = cscaParsed.hashAlgorithm;
+          cscaSignatureAlgorithm = cscaParsed.signatureAlgorithm;
+          cscaSaltLength = 0;
+        }
         cscaCurveOrExponent = getCurveOrExponent(cscaParsed);
         cscaSignatureAlgorithmBits = parseInt(cscaParsed.publicKeyDetails.bits);
-        cscaSaltLength = details.saltLength;
       }
     } catch (error) {}
   } else {

--- a/common/src/utils/passports/passport_parsing/parsePassportData.ts
+++ b/common/src/utils/passports/passport_parsing/parsePassportData.ts
@@ -111,8 +111,6 @@ export function parsePassportData(
     passportData.signedAttr
   );
 
-  const brutForcedPublicKeyDetails = brutforceSignatureAlgorithm(passportData);
-
   let parsedDsc = null;
   let dscSignatureAlgorithmBits = 0;
 
@@ -123,6 +121,20 @@ export function parsePassportData(
     dscSignatureAlgorithmBits = parseInt(parsedDsc.publicKeyDetails?.bits || '0');
 
     dscMetaData = parseDscCertificateData(parsedDsc, skiPem);
+  }
+
+  // Determine signature algorithm/hash with fallback if brute-force fails
+  const brutForcedPublicKeyDetails = brutforceSignatureAlgorithm(passportData);
+  let resolvedSignatureAlgorithm = brutForcedPublicKeyDetails?.signatureAlgorithm as string | undefined;
+  let resolvedSignedAttrHashFunction = brutForcedPublicKeyDetails?.hashAlgorithm as string | undefined;
+  let resolvedSaltLength = (brutForcedPublicKeyDetails?.saltLength as number | undefined) ?? undefined;
+
+  if (!resolvedSignatureAlgorithm || !resolvedSignedAttrHashFunction) {
+    if (parsedDsc) {
+      resolvedSignatureAlgorithm = parsedDsc.signatureAlgorithm;
+      resolvedSignedAttrHashFunction = parsedDsc.hashAlgorithm;
+      resolvedSaltLength = 0;
+    }
   }
 
   return {
@@ -141,9 +153,9 @@ export function parsePassportData(
     eContentHashFunction,
     eContentHashOffset,
     signedAttrSize: passportData.signedAttr?.length || 0,
-    signedAttrHashFunction: brutForcedPublicKeyDetails.hashAlgorithm,
-    signatureAlgorithm: brutForcedPublicKeyDetails.signatureAlgorithm,
-    saltLength: brutForcedPublicKeyDetails.saltLength,
+    signedAttrHashFunction: resolvedSignedAttrHashFunction,
+    signatureAlgorithm: resolvedSignatureAlgorithm,
+    saltLength: resolvedSaltLength || 0,
     curveOrExponent: parsedDsc ? getCurveOrExponent(parsedDsc) : 'unknown',
     signatureAlgorithmBits: dscSignatureAlgorithmBits,
     countryCode: passportData.mrz ? getCountryCodeFromMrz(passportData.mrz) : 'unknown',


### PR DESCRIPTION
- Guard ECDSA branches in brute-force functions to return only on successful hash detection.
- Add robust fallbacks in parsing functions when brute-force yields no result, using parsed DSC metadata with saltLength=0.
Rationale:
- Previously, ECDSA branches returned objects even if bruteforce failed, setting hashAlgorithm=false. This silently poisoned downstream metadata (padding and hashing), leading to incorrect proof inputs or runtime errors.
- RSA/RSAPSS branches already return conditionally on success; ECDSA behavior is now consistent.
- Callers expected “no result” to be possible (SDK guards), so parsing functions now fall back to parseCertificateSimple results, ensuring correctness and stability instead of propagating an invalid “false” algorithm.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Guards ECDSA brute-force to return only on successful hash detection and adds safe DSC/CSCA fallbacks in parsing to ensure valid signature/hash/salt metadata.
> 
> - **Signature detection**:
>   - Guard ECDSA paths in `brutForcePassportSignature.ts` and `brutForceDscSignature.ts` to return only when a `hashAlgorithm` is found.
>   - Keep RSA/RSAPSS logic unchanged; continue iterating salt lengths for `rsapss`.
> - **Parsing fallbacks**:
>   - `parsePassportData.ts`: resolve `signatureAlgorithm`, `signedAttrHashFunction`, and `saltLength` from brute-force; if missing, fall back to `parseCertificateSimple` outputs with `saltLength=0`.
>   - `parseDscCertificateData.ts`: after brute-force, if details are missing, fall back to parsed CSCA (`cscaParsed`) algorithms and set `saltLength=0`; ensure curve/exponent and bit-length derived from parsed CSCA.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af7ca24796f97a4f4f3e58d8e5f6b5466e292a5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of passport parsing and signature validation with enhanced fallback mechanisms for better handling of edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->