### PR TITLE
refactor: update notification permission handling and improve Info.pl…

### DIFF
--- a/app/ios/OpenPassport/AppDelegate.mm
+++ b/app/ios/OpenPassport/AppDelegate.mm
@@ -19,23 +19,10 @@
     UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
     center.delegate = self;
 
-    // Request permission for notifications
-    [center requestAuthorizationWithOptions:(UNAuthorizationOptionSound | UNAuthorizationOptionAlert | UNAuthorizationOptionBadge)
-                          completionHandler:^(BOOL granted, NSError * _Nullable error) {
-      if (error) {
-        NSLog(@"Failed to request notification authorization: %@", error.localizedDescription);
-        return;
-      }
-
-      if (granted) {
-        NSLog(@"Notification authorization granted");
-        dispatch_async(dispatch_get_main_queue(), ^{
-          [[UIApplication sharedApplication] registerForRemoteNotifications];
-        });
-      } else {
-        NSLog(@"Notification authorization denied by user");
-      }
-    }];
+    // NOTE: Notification permission request removed from app launch
+    // Permission is now requested only when user explicitly enables notifications
+    // (e.g., in Points screen or settings)
+    // The auto-request was causing unwanted permission prompts on first app launch
   }
 
   self.moduleName = @"OpenPassport";

--- a/app/ios/OpenPassport/Info.plist
+++ b/app/ios/OpenPassport/Info.plist
@@ -59,7 +59,7 @@
 	<key>NSCameraUsageDescription</key>
 	<string>Needed to scan the passport MRZ.</string>
 	<key>NSFaceIDUsageDescription</key>
-	<string>Needed to secure the secret</string>
+	<string>Personal information is only stored in the secure element of your device.</string>
 	<key>NSHumanReadableCopyright</key>
 	<string></string>
 	<key>NSLocationWhenInUseUsageDescription</key>


### PR DESCRIPTION
…ist descriptions

- Removed automatic notification permission request during app launch to prevent unwanted prompts; permissions will now be requested only when the user explicitly enables notifications.
- Updated NSFaceIDUsageDescription in Info.plist for clarity on personal information storage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Notification permission requests are now deferred until you explicitly enable notifications in settings, rather than at app launch.

* **Documentation**
  * Updated Face ID permission description text for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->