### PR TITLE
Recognize Turnkey backups on recovery phrase screen

### DIFF
--- a/app/src/screens/onboarding/SaveRecoveryPhraseScreen.tsx
+++ b/app/src/screens/onboarding/SaveRecoveryPhraseScreen.tsx
@@ -23,7 +23,7 @@ import { black, slate400, white } from '@/utils/colors';
 const SaveRecoveryPhraseScreen: React.FC = () => {
   const [userHasSeenMnemonic, setUserHasSeenMnemonic] = useState(false);
   const { mnemonic, loadMnemonic } = useMnemonic();
-  const { cloudBackupEnabled } = useSettingStore();
+  const { cloudBackupEnabled, backedUpWithTurnKey } = useSettingStore();
 
   const onRevealWords = useCallback(async () => {
     await loadMnemonic();
@@ -60,13 +60,14 @@ const SaveRecoveryPhraseScreen: React.FC = () => {
       >
         <Mnemonic words={mnemonic} onRevealWords={onRevealWords} />
         <Caption style={{ color: slate400 }}>
-          You can reveal your recovery phrase in settings.
+          You can reveal your recovery phrase or manage your backups in
+          settings.
         </Caption>
         <PrimaryButton onPress={onCloudBackupPress}>
-          Manage {STORAGE_NAME} backups
+          Manage {STORAGE_NAME} or Turnkey backups
         </PrimaryButton>
         <SecondaryButton onPress={onSkipPress}>
-          {userHasSeenMnemonic || cloudBackupEnabled
+          {userHasSeenMnemonic || cloudBackupEnabled || backedUpWithTurnKey
             ? 'Continue'
             : 'Skip making a backup'}
         </SecondaryButton>


### PR DESCRIPTION
## Summary
- read the Turnkey backup flag when rendering the save recovery phrase screen
- allow continuing when the account has either a cloud or Turnkey backup and update the copy accordingly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6913b801f5f0832dba9fee7dc992bc04)