### PR TITLE
SELF-1159: Show gratification screen after notifications and backup enabling

### DIFF
--- a/app/src/components/NavBar/Points.tsx
+++ b/app/src/components/NavBar/Points.tsx
@@ -178,15 +178,8 @@ const Points: React.FC = () => {
             setIsGeneralSubscribed(true);
             selfClient.trackEvent(PointEvents.EARN_NOTIFICATION_SUCCESS);
 
-            const callbackId = registerModalCallbacks({
-              onButtonPress: () => {},
-              onModalDismiss: () => {},
-            });
-            navigation.navigate('Modal', {
-              titleText: 'Success!',
-              bodyText: `Push notifications enabled! You earned ${POINT_VALUES.notification} points.\n\nPoints will be distributed to your wallet on the next Sunday at noon UTC.`,
-              buttonText: 'OK',
-              callbackId,
+            navigation.navigate('Gratification', {
+              points: POINT_VALUES.notification,
             });
           } else {
             selfClient.trackEvent(PointEvents.EARN_NOTIFICATION_FAILED, {
@@ -279,15 +272,8 @@ const Points: React.FC = () => {
           setBackupForPointsCompleted();
           selfClient.trackEvent(PointEvents.EARN_BACKUP_SUCCESS);
 
-          const callbackId = registerModalCallbacks({
-            onButtonPress: () => {},
-            onModalDismiss: () => {},
-          });
-          navigation.navigate('Modal', {
-            titleText: 'Success!',
-            bodyText: `Account backed up successfully! You earned ${POINT_VALUES.backup} points.\n\nPoints will be distributed to your wallet on the next Sunday at noon UTC.`,
-            buttonText: 'OK',
-            callbackId,
+          navigation.navigate('Gratification', {
+            points: POINT_VALUES.backup,
           });
         } else {
           selfClient.trackEvent(PointEvents.EARN_BACKUP_FAILED);


### PR DESCRIPTION
**Overview**

This PR shows gratification screen instead of modal when user enables notifications and backup from points screen.

**Tested**

Fresh install of the app, generated a mock document, enabled notifications and was able to see the gratification screen. Same for enabling cloud backup:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces success modals with a gratification screen (passing earned points) after enabling notifications or completing backup, retaining modals for failure cases.
> 
> - **Points NavBar (`app/src/components/NavBar/Points.tsx`)**:
>   - **Success flow updates**:
>     - On notification enable success: navigate to `Gratification` with `points: POINT_VALUES.notification` (replaces success modal).
>     - On backup completion success: navigate to `Gratification` with `points: POINT_VALUES.backup` (replaces success modal).
>   - **Failure handling**: Unchanged—continues to show `Modal` with appropriate error messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cda31a1c240f0d568240dfa66e9db2267bf302f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Point confirmations now display a dedicated gratification screen when you earn points through enabling notifications, completing account backups, and backup-related activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->