### PR TITLE
smart dev screen selector

### DIFF
--- a/app/src/screens/dev/DevSettingsScreen.tsx
+++ b/app/src/screens/dev/DevSettingsScreen.tsx
@@ -240,7 +240,11 @@ const ScreenSelector = ({}) => {
           <Select.Group>
             {useMemo(
               () =>
-                (Object.keys(navigationScreens) as (keyof RootStackParamList)[])
+                (
+                  Object.keys(
+                    navigationScreens,
+                  ) as (keyof typeof navigationScreens)[]
+                )
                   .sort()
                   .map((item, i) => {
                     return (


### PR DESCRIPTION
use the actual navigation object instead of an array of strings so that any time we add a screen its automatically available from dev settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Dev settings now build the list of available navigation screens at runtime instead of relying on a fixed, hard-coded list. The settings UI will automatically show newly added screens without manual updates, keeping the selection options current and reducing maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->