### PR TITLE
Prevent mobile deploy on auto-closed PRs

### DIFF
--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -150,11 +150,16 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    # Guard against auto-closed PRs (GitHub leaves merge_commit_sha empty in that case)
+    # Guard against auto-closed PRs (GitHub reports merged == false when a PR closes without merging)
     if: |
-      (github.event_name != 'pull_request' ||
-        (github.event.pull_request.merged == true && github.event.pull_request.merge_commit_sha != null)) &&
-      !contains(github.event.pull_request.labels.*.name, 'deploy:skip')
+      (
+        github.event_name != 'pull_request' ||
+        (github.event.action == 'closed' && github.event.pull_request.merged == true)
+      ) &&
+      (
+        github.event_name != 'pull_request' ||
+        !contains(github.event.pull_request.labels.*.name, 'deploy:skip')
+      )
     outputs:
       version: ${{ steps.bump.outputs.version }}
       ios_build: ${{ steps.bump.outputs.ios_build }}
@@ -265,7 +270,7 @@ jobs:
       actions: write
     if: |
       (github.event_name != 'pull_request' ||
-        (github.event.pull_request.merged == true && github.event.pull_request.merge_commit_sha != null)) &&
+        (github.event.action == 'closed' && github.event.pull_request.merged == true)) &&
       (
         (inputs.platform == 'ios' || inputs.platform == 'both') ||
         (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'deploy:android'))
@@ -833,7 +838,7 @@ jobs:
       id-token: write
     if: |
       (github.event_name != 'pull_request' ||
-        (github.event.pull_request.merged == true && github.event.pull_request.merge_commit_sha != null)) &&
+        (github.event.action == 'closed' && github.event.pull_request.merged == true)) &&
       (
         (inputs.platform == 'android' || inputs.platform == 'both') ||
         (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'deploy:ios'))
@@ -1246,7 +1251,7 @@ jobs:
     if: |
       always() &&
       (github.event_name != 'pull_request' ||
-        (github.event.pull_request.merged == true && github.event.pull_request.merge_commit_sha != null)) &&
+        (github.event.action == 'closed' && github.event.pull_request.merged == true)) &&
       (needs.build-ios.result == 'success' || needs.build-android.result == 'success')
     env:
       APP_PATH: ${{ github.workspace }}/app


### PR DESCRIPTION
## Summary
- add guards to the mobile deploy workflow so it only runs when GitHub reports a real merge commit
- apply the same guard to the iOS build, Android build, and version bump jobs to keep them from starting when a PR auto-closes

## Testing
- not run (workflow-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691da8621fdc832db94cfd4893328093)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restricts mobile deploy workflow jobs to execute only on PRs closed by merge, applying consistent guards across bump, iOS, Android, and version-bump steps.
> 
> - **CI/Workflow (`.github/workflows/mobile-deploy.yml`)**:
>   - Tightens `if` guards to run only when a PR is closed via merge (`action == 'closed' && merged == true`).
>   - Applies to `bump-version`, `build-ios`, `build-android`, and `create-version-bump-pr` jobs.
>   - Preserves label-based skips (`deploy:skip`) and platform filters while restructuring conditions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56c3a527672cd98386d460055b5b92d219d2a9bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented accidental mobile deployments in edge cases where merges are auto-closed; deployment jobs now correctly skip to avoid erroneous releases.
  * Preserved existing label-based skip logic and other workflow behavior so release creation and version bumping remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->