### PR TITLE
SELF-1394: Fix/aadhaar registry

### DIFF
--- a/circuits/circuits/register/register_aadhaar.circom
+++ b/circuits/circuits/register/register_aadhaar.circom
@@ -113,12 +113,15 @@ template REGISTER_AADHAAR(n, k, maxDataLength){
     signal output nullifier <== nullifierHasher.out;
 
 
-    component qrDataHasher = PackBytesAndPoseidon(maxDataLength - 17);
+    component qrDataHasher = PackBytesAndPoseidon(maxDataLength);
     for (var i = 0; i < 9; i++){
         qrDataHasher.in[i] <== qrDataPadded[i];
     }
-    for (var i = 9; i < maxDataLength - 17; i++){
-        qrDataHasher.in[i] <== qrDataPadded[i + 17];
+    for (var i = 9; i < 26; i++) {
+        qrDataHasher.in[i] <== 0;
+    }
+    for (var i = 26; i < maxDataLength; i++){
+        qrDataHasher.in[i] <== qrDataPadded[i];
     }
 
     // Generate commitment

--- a/common/src/utils/aadhaar/mockData.ts
+++ b/common/src/utils/aadhaar/mockData.ts
@@ -576,7 +576,8 @@ export function processQRDataSimple(qrData: string) {
   // Calculate qrHash exclude timestamp (positions 9-25, 17 bytes)
   const qrDataWithoutTimestamp = [
     ...Array.from(qrDataPadded.slice(0, 9)),
-    ...Array.from(qrDataPadded.slice(26)), 
+    ...Array.from(qrDataPadded.slice(9, 26)).map((x) => 0),
+    ...Array.from(qrDataPadded.slice(26)),
   ];
   const qrHash = packBytesAndPoseidon(qrDataWithoutTimestamp);
   const photo = extractPhoto(Array.from(qrDataPadded), photoEOI + 1);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Exclude timestamp bytes from the QR data hash and use this value in commitment generation across circuit and utils.
> 
> - **Circuits (`circuits/circuits/register/register_aadhaar.circom`)**:
>   - Replace direct `PackBytesAndPoseidon(qrDataPadded)` with `qrDataHasher` that zeroes bytes `9–25` (timestamp) before hashing.
>   - Use `qrDataHasher.out` as `commitmentHasher.inputs[1]`.
> - **Utils (`common/src/utils/aadhaar/mockData.ts`)**:
>   - Compute `qrHash` from `qrDataPadded` with timestamp bytes `9–25` zeroed to match circuit logic.
>   - Minor cleanup of commented/debug code.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9866e4a8fbd1237da562f01ad79486ce4fb540c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved QR data hashing process for Aadhaar verification by restructuring data preparation workflow.
  * Modified hash calculation to exclude timestamp data, ensuring more accurate data processing.

* **Chores**
  * Removed unnecessary commented code and debug logging from utility functions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->