### PR TITLE
Limit recovery prompt allowlist to Home

### DIFF
--- a/app/src/consts/recoveryPrompts.ts
+++ b/app/src/consts/recoveryPrompts.ts
@@ -24,10 +24,4 @@ export const CRITICAL_RECOVERY_PROMPT_ROUTES = [
   'QRCodeTrouble',
 ] as const;
 
-export const RECOVERY_PROMPT_ALLOWED_ROUTES = [
-  'Home',
-  'ProofHistory',
-  'ProofHistoryDetail',
-  'ManageDocuments',
-  'Settings',
-] as const;
+export const RECOVERY_PROMPT_ALLOWED_ROUTES = ['Home'] as const;

--- a/app/src/hooks/useRecoveryPrompts.ts
+++ b/app/src/hooks/useRecoveryPrompts.ts
@@ -16,12 +16,10 @@ const DEFAULT_ALLOWED_ROUTES = RECOVERY_PROMPT_ALLOWED_ROUTES;
 
 type UseRecoveryPromptsOptions = {
   allowedRoutes?: readonly string[];
-  disallowedRoutes?: readonly string[];
 };
 
 export default function useRecoveryPrompts({
   allowedRoutes = DEFAULT_ALLOWED_ROUTES,
-  disallowedRoutes,
 }: UseRecoveryPromptsOptions = {}) {
   const { loginCount, cloudBackupEnabled, hasViewedRecoveryPhrase } =
     useSettingStore();
@@ -49,10 +47,6 @@ export default function useRecoveryPrompts({
     () => new Set(allowedRoutes),
     [allowedRoutes],
   );
-  const disallowedRouteSet = useMemo(
-    () => (disallowedRoutes ? new Set(disallowedRoutes) : null),
-    [disallowedRoutes],
-  );
 
   const isRouteEligible = useCallback(
     (routeName: string | undefined): routeName is string => {
@@ -62,12 +56,9 @@ export default function useRecoveryPrompts({
       if (!allowedRouteSet.has(routeName)) {
         return false;
       }
-      if (disallowedRouteSet?.has(routeName)) {
-        return false;
-      }
       return true;
     },
-    [allowedRouteSet, disallowedRouteSet],
+    [allowedRouteSet],
   );
 
   const maybePrompt = useCallback(async () => {

--- a/app/src/navigation/index.tsx
+++ b/app/src/navigation/index.tsx
@@ -198,7 +198,7 @@ const { trackScreenView } = analytics();
 const Navigation = createStaticNavigation(AppNavigation);
 
 const NavigationWithTracking = () => {
-  useRecoveryPrompts({ allowedRoutes: RECOVERY_PROMPT_ALLOWED_ROUTES });
+  useRecoveryPrompts();
   const selfClient = useSelfClient();
   const trackScreen = () => {
     const currentRoute = navigationRef.getCurrentRoute();

--- a/app/tests/src/hooks/useRecoveryPrompts.test.ts
+++ b/app/tests/src/hooks/useRecoveryPrompts.test.ts
@@ -4,10 +4,7 @@
 
 import { act, renderHook, waitFor } from '@testing-library/react-native';
 
-import {
-  CRITICAL_RECOVERY_PROMPT_ROUTES,
-  RECOVERY_PROMPT_ALLOWED_ROUTES,
-} from '@/consts/recoveryPrompts';
+import { CRITICAL_RECOVERY_PROMPT_ROUTES } from '@/consts/recoveryPrompts';
 import { useModal } from '@/hooks/useModal';
 import useRecoveryPrompts from '@/hooks/useRecoveryPrompts';
 import { usePassport } from '@/providers/passportDataProvider';
@@ -121,7 +118,7 @@ describe('useRecoveryPrompts', () => {
   });
 
   it.each([...CRITICAL_RECOVERY_PROMPT_ROUTES])(
-    'does not show modal when route %s is disallowed',
+    'does not show modal when route %s is not allowed',
     async routeName => {
       global.mockNavigationRef.getCurrentRoute.mockReturnValue({
         name: routeName,
@@ -141,9 +138,7 @@ describe('useRecoveryPrompts', () => {
     act(() => {
       useSettingStore.setState({ loginCount: 1 });
     });
-    renderHook(() =>
-      useRecoveryPrompts({ allowedRoutes: ['Settings'], disallowedRoutes: [] }),
-    );
+    renderHook(() => useRecoveryPrompts({ allowedRoutes: ['Settings'] }));
     await waitFor(() => {
       expect(showModal).not.toHaveBeenCalled();
     });
@@ -153,12 +148,7 @@ describe('useRecoveryPrompts', () => {
       name: 'Settings',
     });
 
-    renderHook(() =>
-      useRecoveryPrompts({
-        allowedRoutes: RECOVERY_PROMPT_ALLOWED_ROUTES,
-        disallowedRoutes: [],
-      }),
-    );
+    renderHook(() => useRecoveryPrompts({ allowedRoutes: ['Settings'] }));
 
     await waitFor(() => {
       expect(showModal).toHaveBeenCalled();

--- a/app/tests/src/navigation.test.tsx
+++ b/app/tests/src/navigation.test.tsx
@@ -5,8 +5,6 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
 
-import { RECOVERY_PROMPT_ALLOWED_ROUTES } from '@/consts/recoveryPrompts';
-
 jest.mock('@/hooks/useRecoveryPrompts', () => jest.fn());
 jest.mock('@selfxyz/mobile-sdk-alpha', () => ({
   useSelfClient: jest.fn(() => ({})),
@@ -97,8 +95,6 @@ describe('navigation', () => {
     const NavigationWithTracking = navigation.default;
     render(<NavigationWithTracking />);
 
-    expect(useRecoveryPrompts).toHaveBeenCalledWith({
-      allowedRoutes: RECOVERY_PROMPT_ALLOWED_ROUTES,
-    });
+    expect(useRecoveryPrompts).toHaveBeenCalledWith();
   });
 });


### PR DESCRIPTION
## Summary
- restrict the recovery prompt allowlist to the Home screen and remove disallowed route handling
- simplify recovery prompt hook wiring to use the default allowlist
- update navigation wiring and unit tests to reflect the home-only policy

## Testing
- yarn test tests/src/hooks/useRecoveryPrompts.test.ts --runInBand *(fails: other suites failed during full run)*
- yarn workspace @selfxyz/mobile-app jest tests/src/hooks/useRecoveryPrompts.test.ts --runInBand --runTestsByPath --silent *(fails: Flow parser error in react-native dependency)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692f61a38984832d845f49747ee37804)