### PR TITLE
Fix missing DSC parsing for passport/id_card

### DIFF
--- a/packages/mobile-sdk-alpha/src/proving/provingMachine.ts
+++ b/packages/mobile-sdk-alpha/src/proving/provingMachine.ts
@@ -1053,6 +1053,15 @@ export const useProvingStore = create<ProvingState>((set, get) => {
         passportData.documentCategory === 'passport' || passportData.documentCategory === 'id_card';
       const hasParsedDsc = needsDscParsing && Boolean(passportData.dsc_parsed?.authorityKeyIdentifier);
 
+      if (circuitType === 'dsc' && !needsDscParsing) {
+        console.error(`DSC circuit is not supported for ${passportData.documentCategory} documents`);
+        selfClient.trackEvent(ProofEvents.PROOF_FAILED, {
+          message: `DSC circuit not supported for ${passportData.documentCategory}`,
+        });
+        actor.send({ type: 'ERROR' });
+        return;
+      }
+
       const shouldParseDocument = circuitType === 'dsc' || (needsDscParsing && !hasParsedDsc);
 
       if (shouldParseDocument) {
@@ -1163,13 +1172,14 @@ export const useProvingStore = create<ProvingState>((set, get) => {
           case 'passport':
           case 'id_card':
             if (!passportData?.dsc_parsed?.authorityKeyIdentifier) {
-              selfClient.logProofEvent('error', 'Missing parsed DSC', context, {
+              const docType = passportData.documentCategory;
+              selfClient.logProofEvent('error', `Missing parsed DSC in ${docType} data`, context, {
                 failure: 'PROOF_FAILED_DATA_FETCH',
                 duration_ms: Date.now() - startTime,
               });
-              console.error('Missing parsed DSC in passport data');
+              console.error(`Missing parsed DSC in ${docType} data`);
               selfClient.trackEvent(ProofEvents.FETCH_DATA_FAILED, {
-                message: 'Missing parsed DSC in passport data',
+                message: `Missing parsed DSC in ${docType} data`,
               });
               actor!.send({ type: 'FETCH_ERROR' });
               return;

--- a/packages/mobile-sdk-alpha/tests/proving/provingMachine.startFetchingData.test.ts
+++ b/packages/mobile-sdk-alpha/tests/proving/provingMachine.startFetchingData.test.ts
@@ -138,6 +138,20 @@ describe('init parsing decision', () => {
       expect(actorMock.send).not.toHaveBeenCalledWith({ type: 'PARSE_ID_DOCUMENT' });
     });
 
+    it('parses when dsc_parsed exists but authorityKeyIdentifier is missing', async () => {
+      const client = createMockSelfClient();
+      mockDocument({
+        documentCategory: 'id_card',
+        mock: false,
+        dsc_parsed: { issuer: 'some-issuer' },
+      });
+
+      await useProvingStore.getState().init(client, 'disclose');
+
+      expect(actorMock.send).toHaveBeenCalledWith({ type: 'PARSE_ID_DOCUMENT' });
+      expect(actorMock.send).not.toHaveBeenCalledWith({ type: 'FETCH_DATA' });
+    });
+
     it('parses for register when dsc_parsed is missing', async () => {
       const client = createMockSelfClient();
       mockDocument({ documentCategory: 'id_card', mock: false });
@@ -173,6 +187,33 @@ describe('init parsing decision', () => {
 
       expect(actorMock.send).toHaveBeenCalledWith({ type: 'PARSE_ID_DOCUMENT' });
       expect(actorMock.send).not.toHaveBeenCalledWith({ type: 'FETCH_DATA' });
+    });
+
+    it('rejects dsc circuit for aadhaar documents', async () => {
+      const client = createMockSelfClient();
+      mockDocument({ documentCategory: 'aadhaar', mock: false });
+
+      await useProvingStore.getState().init(client, 'dsc');
+
+      expect(actorMock.send).toHaveBeenCalledWith({ type: 'ERROR' });
+      expect(actorMock.send).not.toHaveBeenCalledWith({ type: 'PARSE_ID_DOCUMENT' });
+      expect(actorMock.send).not.toHaveBeenCalledWith({ type: 'FETCH_DATA' });
+      expect(client.trackEvent).toHaveBeenCalledWith(ProofEvents.PROOF_FAILED, {
+        message: 'DSC circuit not supported for aadhaar',
+      });
+    });
+
+    it('rejects dsc circuit for kyc documents', async () => {
+      const client = createMockSelfClient();
+      mockDocument({ documentCategory: 'kyc', mock: false });
+
+      await useProvingStore.getState().init(client, 'dsc');
+
+      expect(actorMock.send).toHaveBeenCalledWith({ type: 'ERROR' });
+      expect(actorMock.send).not.toHaveBeenCalledWith({ type: 'PARSE_ID_DOCUMENT' });
+      expect(client.trackEvent).toHaveBeenCalledWith(ProofEvents.PROOF_FAILED, {
+        message: 'DSC circuit not supported for kyc',
+      });
     });
   });
 
@@ -268,7 +309,7 @@ describe('startFetchingData', () => {
 
     expect(actorMock.send).toHaveBeenCalledWith({ type: 'FETCH_ERROR' });
     expect(mockSelfClient.trackEvent).toHaveBeenCalledWith(ProofEvents.FETCH_DATA_FAILED, {
-      message: 'Missing parsed DSC in passport data',
+      message: 'Missing parsed DSC in id_card data',
     });
   });
 


### PR DESCRIPTION
## Summary
- Fix bug where init() skipped DSC parsing for non-dsc circuits even when dsc_parsed was missing/incomplete, causing immediate FETCH_ERROR in startFetchingData
- Tighten DSC validity check to require authorityKeyIdentifier specifically, not just the presence of dsc_parsed
- Use actual document category in error messages instead of hardcoded "passport data"
- Add defensive guard rejecting dsc circuit for aadhaar/kyc documents that don't support it
- Expand test coverage from 1 test to 22, covering all document category + circuit type combinations

## Testing
- yarn workspace @selfxyz/mobile-sdk-alpha test proving/provingMachine.startFetchingData.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693e1d020440832db7aa667ee35c32a0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Data-driven parsing decision for ID documents (passport, id_card, aadhaar, kyc) with a DSC-support guard that aborts and tracks failures when DSC is unexpectedly required.
  * More specific error messages, logging, and analytics that include document type when DSC is missing.

* **Tests**
  * Expanded coverage for parsing decisions across document types and DSC states.
  * Introduced reusable test helpers and centralized mocks for clearer, maintainable tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->