### PR TITLE
Hide Secondary button in AadhaarUploadError screen

### DIFF
--- a/app/src/screens/documents/aadhaar/AadhaarUploadErrorScreen.tsx
+++ b/app/src/screens/documents/aadhaar/AadhaarUploadErrorScreen.tsx
@@ -99,7 +99,7 @@ const AadhaarUploadErrorScreen: React.FC = () => {
               Try Again
             </PrimaryButton>
           </YStack>
-          <YStack flex={1}>
+          {/* <YStack flex={1}>
             <SecondaryButton
               onPress={() => {
                 trackEvent(AadhaarEvents.HELP_BUTTON_PRESSED, { errorType });
@@ -108,7 +108,7 @@ const AadhaarUploadErrorScreen: React.FC = () => {
             >
               Need Help?
             </SecondaryButton>
-          </YStack>
+          </YStack> */}
         </XStack>
       </YStack>
     </YStack>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the "Need Help?" option from the Aadhaar Upload Error Screen while preserving the "Try Again" functionality for users to retry the upload process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->