### PR TITLE
SELF-1665: address sentry replay preview

### DIFF
--- a/app/src/config/sentry.ts
+++ b/app/src/config/sentry.ts
@@ -166,11 +166,9 @@ export const initSentry = () => {
     },
     integrations: [
       mobileReplayIntegration({
-        // Privacy-first: mask sensitive text data only
-        maskAllText: true, // Masks names, DOB, passport numbers, etc.
-        maskAllImages: false, // Show images (country flags, UI graphics - no document photos stored)
-        maskAllVectors: false, // Show SVG icons/graphics (UI elements, navigation)
-        // This allows full UI debugging while protecting PII text data
+        maskAllText: true,
+        maskAllImages: false,
+        maskAllVectors: false,
       }),
       consoleLoggingIntegration({
         levels: ['log', 'error', 'warn', 'info', 'debug'],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled mobile session replay for crash diagnostics with privacy defaults: all user-entered text is masked while app visuals (images and vector graphics) remain visible to aid debugging. Improved error context for faster issue resolution and app stability management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->