### PR TITLE
Use default header for QR scanner screen

### DIFF
--- a/app/src/navigation/verification.ts
+++ b/app/src/navigation/verification.ts
@@ -6,6 +6,7 @@ import type { NativeStackNavigationOptions } from '@react-navigation/native-stac
 
 import { black, white } from '@selfxyz/mobile-sdk-alpha/constants/colors';
 
+import { DefaultNavBar } from '@/components/navbar/DefaultNavBar';
 import ProofRequestStatusScreen from '@/screens/verification/ProofRequestStatusScreen';
 import ProveScreen from '@/screens/verification/ProveScreen';
 import QRCodeTroubleScreen from '@/screens/verification/QRCodeTroubleScreen';
@@ -42,8 +43,15 @@ const verificationScreens = {
   QRCodeViewFinder: {
     screen: QRCodeViewFinderScreen,
     options: {
-      headerShown: false,
+      headerShown: true,
+      header: DefaultNavBar,
+      headerStyle: {
+        backgroundColor: black,
+      },
+      headerTintColor: white,
+      title: '',
       animation: 'slide_from_bottom',
+      gestureEnabled: false,
     } as NativeStackNavigationOptions,
   },
 };


### PR DESCRIPTION
## Summary
- use the shared DefaultNavBar as the header for the QR code scanner screen
- remove the custom in-screen navigation bar while keeping swipe gestures disabled
- maintain the existing scanner layout without overlaying additional controls

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6940929f76b8832d8a8505c0ed091b8c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added navigation header to the QR code scanner screen with dark styling (black background, white text).
  * Disabled back gesture navigation on the QR code scanner screen to improve usability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->