### PR TITLE
SELF-1627: CountryPickerScreen: remove info icon

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -105,7 +105,7 @@
     "@segment/analytics-react-native": "^2.21.2",
     "@segment/sovran-react-native": "^1.1.3",
     "@selfxyz/common": "workspace:^",
-    "@selfxyz/euclid": "^0.6.0",
+    "@selfxyz/euclid": "^0.6.1",
     "@selfxyz/mobile-sdk-alpha": "workspace:^",
     "@sentry/react": "^9.32.0",
     "@sentry/react-native": "7.0.1",

--- a/packages/mobile-sdk-alpha/package.json
+++ b/packages/mobile-sdk-alpha/package.json
@@ -151,7 +151,7 @@
   "dependencies": {
     "@babel/runtime": "^7.28.3",
     "@selfxyz/common": "workspace:^",
-    "@selfxyz/euclid": "^0.6.0",
+    "@selfxyz/euclid": "^0.6.1",
     "@xstate/react": "^5.0.5",
     "node-forge": "^1.3.1",
     "react-native-nfc-manager": "^3.17.1",

--- a/packages/mobile-sdk-alpha/src/flows/onboarding/country-picker-screen.tsx
+++ b/packages/mobile-sdk-alpha/src/flows/onboarding/country-picker-screen.tsx
@@ -74,6 +74,7 @@ const CountryPickerScreen: React.FC<SafeArea> & { statusBar: typeof CountryPicke
       onClose={selfClient.goBack}
       onInfoPress={() => selfClient.trackEvent(DocumentEvents.COUNTRY_HELP_TAPPED)}
       onSearchChange={onSearchChange}
+      showInfoIcon={false}
     />
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8499,16 +8499,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@selfxyz/euclid@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "@selfxyz/euclid@npm:0.6.0"
+"@selfxyz/euclid@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "@selfxyz/euclid@npm:0.6.1"
   peerDependencies:
     react: ">=18.2.0"
     react-native: ">=0.72.0"
     react-native-blur-effect: ^1.1.3
     react-native-svg: ">=15.14.0"
     react-native-webview: ^13.16.0
-  checksum: 10c0/2dd34f96f75e7641806bb8398a54c4ad666c4b953bf83810cda6ba85ded88780cc30ff2b1bd8dcbb1131d67f8a8cf05f955be5491a7ad706b0360a6a37b9c003
+  checksum: 10c0/8e62c3c01a439f82de5327af45bd55acb741fbc99c9c87ec6726a37b8bccd6ce0a6bef507aaa906be242c8df22e424dc8e32b93a8e9365bbd07e10ecfe65427b
   languageName: node
   linkType: hard
 
@@ -8550,7 +8550,7 @@ __metadata:
     "@segment/analytics-react-native": "npm:^2.21.2"
     "@segment/sovran-react-native": "npm:^1.1.3"
     "@selfxyz/common": "workspace:^"
-    "@selfxyz/euclid": "npm:^0.6.0"
+    "@selfxyz/euclid": "npm:^0.6.1"
     "@selfxyz/mobile-sdk-alpha": "workspace:^"
     "@sentry/react": "npm:^9.32.0"
     "@sentry/react-native": "npm:7.0.1"
@@ -8674,7 +8674,7 @@ __metadata:
   dependencies:
     "@babel/runtime": "npm:^7.28.3"
     "@selfxyz/common": "workspace:^"
-    "@selfxyz/euclid": "npm:^0.6.0"
+    "@selfxyz/euclid": "npm:^0.6.1"
     "@testing-library/react": "npm:^14.1.2"
     "@types/react": "npm:^18.3.4"
     "@types/react-dom": "npm:^18.3.0"


### PR DESCRIPTION
This PR removes unnecessary info icon from country picker screen.

**Tested**

Ran app in the emulator and made sure the icon is not there anymore:

<img width="1080" height="2400" alt="Screenshot_20251216_222606" src="https://github.com/user-attachments/assets/590b625f-f480-4bf4-acd6-6c9b094fccd8" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Hides the info icon on the onboarding country picker and bumps `@selfxyz/euclid` to `0.6.1`.
> 
> - **UI (onboarding)**:
>   - `CountryPickerScreen`: passes `showInfoIcon={false}` to `CountryPickerUI` to remove the info icon.
> - **Dependencies**:
>   - Bump `@selfxyz/euclid` from `^0.6.0` to `^0.6.1` in `app/package.json` and `packages/mobile-sdk-alpha/package.json` (updated `yarn.lock`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7b83571c49e8d944dda0f221a529f10784aab0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed info icon from the country selection screen in the onboarding flow.

* **Chores**
  * Updated internal dependency versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->