### PR TITLE
SELF-1668: Handle webview mini app prove flow

### DIFF
--- a/app/src/screens/verification/ProofRequestStatusScreen.tsx
+++ b/app/src/screens/verification/ProofRequestStatusScreen.tsx
@@ -5,7 +5,7 @@
 import type { LottieViewProps } from 'lottie-react-native';
 import LottieView from 'lottie-react-native';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Linking, StyleSheet, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { SystemBars } from 'react-native-edge-to-edge';
 import { ScrollView, Spinner } from 'tamagui';
 import { useIsFocused, useNavigation } from '@react-navigation/native';
@@ -36,6 +36,7 @@ import type { RootStackParamList } from '@/navigation';
 import { getWhiteListedDisclosureAddresses } from '@/services/points/utils';
 import { useProofHistoryStore } from '@/stores/proofHistoryStore';
 import { ProofStatus } from '@/stores/proofTypes';
+import { handleDeeplinkCallbackNavigation } from '@/utils/deeplinkCallbacks';
 
 const SuccessScreen: React.FC = () => {
   const selfClient = useSelfClient();
@@ -94,6 +95,21 @@ const SuccessScreen: React.FC = () => {
     }
     setCountdown(null);
   }
+
+  const navigateWithDeeplinkCallback = useCallback(
+    async (deeplink: string) => {
+      try {
+        await handleDeeplinkCallbackNavigation({
+          deeplinkCallback: deeplink,
+          navigation,
+        });
+      } catch (error) {
+        console.error('Failed to open deep link:', error);
+        onOkPress();
+      }
+    },
+    [navigation, onOkPress],
+  );
 
   useEffect(() => {
     if (isFocused) {
@@ -191,13 +207,15 @@ const SuccessScreen: React.FC = () => {
     } else {
       setCountdown(null);
       if (selfApp?.deeplinkCallback) {
-        Linking.openURL(selfApp.deeplinkCallback).catch(err => {
-          console.error('Failed to open deep link:', err);
-          onOkPress();
-        });
+        navigateWithDeeplinkCallback(selfApp.deeplinkCallback);
       }
     }
-  }, [countdown, selfApp?.deeplinkCallback, onOkPress]);
+  }, [
+    countdown,
+    selfApp?.deeplinkCallback,
+    navigateWithDeeplinkCallback,
+    onOkPress,
+  ]);
 
   useEffect(() => {
     if (!isFocused) {

--- a/app/src/services/points/utils.ts
+++ b/app/src/services/points/utils.ts
@@ -6,7 +6,7 @@ import { v4 } from 'uuid';
 
 import { SelfAppBuilder } from '@selfxyz/common/utils/appType';
 
-import { selfLogoReverseUrl } from '@/consts/links';
+import { appsUrl, selfLogoReverseUrl } from '@/consts/links';
 import { getOrGeneratePointsAddress } from '@/providers/authProvider';
 import { POINTS_API_BASE_URL } from '@/services/points/constants';
 import type { IncomingPoints } from '@/services/points/types';
@@ -166,18 +166,30 @@ export const hasUserDoneThePointsDisclosure = async (): Promise<boolean> => {
   }
 };
 
+const buildPointsDisclosureMetadata = (walletAddress: string) => ({
+  action: 'points-disclosure',
+  issuedAt: new Date().toISOString(),
+  nonce: v4(),
+  wallet: walletAddress.toLowerCase(),
+});
+
 export const pointsSelfApp = async () => {
   const endpoint = '0x829d183faaa675f8f80e8bb25fb1476cd4f7c1f0';
+  const pointsAddress = (await getPointsAddress()).toLowerCase();
+  const disclosureMetadata = buildPointsDisclosureMetadata(pointsAddress);
   const builder = new SelfAppBuilder({
     appName: '✨ Self Points',
     endpoint: endpoint.toLowerCase(),
     endpointType: 'celo',
     scope: 'minimal-disclosure-quest',
-    userId: v4(),
-    userIdType: 'uuid',
+    userId: pointsAddress,
+    userIdType: 'hex',
     disclosures: {},
     logoBase64: selfLogoReverseUrl,
     header: '',
+    deeplinkCallback: appsUrl,
+    userDefinedData: JSON.stringify(disclosureMetadata),
+    selfDefinedData: pointsAddress,
   });
 
   return builder.build();

--- a/app/src/utils/deeplinkCallbacks.ts
+++ b/app/src/utils/deeplinkCallbacks.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2025 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { Linking } from 'react-native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+
+import type { RootStackParamList } from '@/navigation';
+
+const isSelfHostname = (hostname: string) => {
+  return hostname === 'self.xyz' || hostname.endsWith('.self.xyz');
+};
+
+const isSelfHostedUrl = (deeplink: string): boolean => {
+  try {
+    const url = new URL(deeplink);
+    if (url.protocol !== 'https:') {
+      return false;
+    }
+    return isSelfHostname(url.hostname);
+  } catch {
+    return false;
+  }
+};
+
+export const handleDeeplinkCallbackNavigation = async ({
+  deeplinkCallback,
+  navigation,
+}: {
+  deeplinkCallback: string;
+  navigation: NativeStackNavigationProp<RootStackParamList>;
+}) => {
+  if (isSelfHostedUrl(deeplinkCallback)) {
+    navigation.navigate('WebView', {
+      url: deeplinkCallback,
+      title: 'Explore Apps',
+    });
+    return;
+  }
+
+  await Linking.openURL(deeplinkCallback);
+};
+
+export const isSelfHostedDeeplink = isSelfHostedUrl;

--- a/app/tests/src/services/points/utils.test.ts
+++ b/app/tests/src/services/points/utils.test.ts
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2025 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { pointsSelfApp } from '@/services/points/utils';
+
+jest.mock('uuid', () => ({
+  v4: jest.fn(),
+}));
+
+jest.mock('@/providers/authProvider', () => ({
+  getOrGeneratePointsAddress: jest.fn(),
+}));
+
+const mockUuid = jest.requireMock('uuid').v4 as jest.Mock;
+const mockGetOrGeneratePointsAddress = jest.requireMock(
+  '@/providers/authProvider',
+).getOrGeneratePointsAddress as jest.Mock;
+
+describe('pointsSelfApp', () => {
+  beforeEach(() => {
+    mockUuid.mockReset();
+    mockGetOrGeneratePointsAddress.mockReset();
+  });
+
+  it('builds a SelfApp with wallet-bound metadata and deeplink callback', async () => {
+    mockUuid
+      .mockImplementationOnce(() => 'nonce-uuid')
+      .mockImplementationOnce(() => 'session-uuid');
+    mockGetOrGeneratePointsAddress.mockResolvedValue(
+      '0xABCDEF1234567890ABCDEF1234567890ABCDEF12',
+    );
+
+    const selfApp = await pointsSelfApp();
+    const metadata = JSON.parse(selfApp.userDefinedData);
+
+    expect(selfApp.userIdType).toBe('hex');
+    expect(selfApp.userId).toBe('abcdef1234567890abcdef1234567890abcdef12');
+    expect(selfApp.deeplinkCallback).toBe('https://apps.self.xyz');
+    expect(metadata.nonce).toBe('nonce-uuid');
+    expect(metadata.wallet).toBe('0xabcdef1234567890abcdef1234567890abcdef12');
+    expect(metadata.action).toBe('points-disclosure');
+    expect(new Date(metadata.issuedAt).toString()).not.toBe('Invalid Date');
+    expect(selfApp.selfDefinedData).toBe(
+      '0xabcdef1234567890abcdef1234567890abcdef12',
+    );
+  });
+});

--- a/app/tests/src/utils/deeplinkCallbacks.test.ts
+++ b/app/tests/src/utils/deeplinkCallbacks.test.ts
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2025 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { Linking } from 'react-native';
+
+import {
+  handleDeeplinkCallbackNavigation,
+  isSelfHostedDeeplink,
+} from '@/utils/deeplinkCallbacks';
+
+jest.mock('react-native', () => ({
+  Linking: {
+    openURL: jest.fn(),
+  },
+}));
+
+describe('deeplinkCallbacks', () => {
+  const mockNavigation = {
+    navigate: jest.fn(),
+  } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('routes self-hosted https callbacks through in-app WebView', async () => {
+    await handleDeeplinkCallbackNavigation({
+      deeplinkCallback: 'https://apps.self.xyz/proof/done',
+      navigation: mockNavigation,
+    });
+
+    expect(mockNavigation.navigate).toHaveBeenCalledWith('WebView', {
+      url: 'https://apps.self.xyz/proof/done',
+      title: 'Explore Apps',
+    });
+    expect(Linking.openURL).not.toHaveBeenCalled();
+  });
+
+  it('opens non-self callbacks externally', async () => {
+    await handleDeeplinkCallbackNavigation({
+      deeplinkCallback: 'https://example.com/next',
+      navigation: mockNavigation,
+    });
+
+    expect(mockNavigation.navigate).not.toHaveBeenCalled();
+    expect(Linking.openURL).toHaveBeenCalledWith('https://example.com/next');
+  });
+
+  it('treats malformed callbacks as external fallbacks', async () => {
+    await handleDeeplinkCallbackNavigation({
+      deeplinkCallback: 'not-a-url',
+      navigation: mockNavigation,
+    });
+
+    expect(mockNavigation.navigate).not.toHaveBeenCalled();
+    expect(Linking.openURL).toHaveBeenCalledWith('not-a-url');
+  });
+
+  it('detects self-hosted https deeplinks', () => {
+    expect(isSelfHostedDeeplink('https://apps.self.xyz/foo')).toBe(true);
+    expect(isSelfHostedDeeplink('https://malicious.com/foo')).toBe(false);
+    expect(isSelfHostedDeeplink('ftp://apps.self.xyz/foo')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- intercept trusted self.xyz deeplink URLs inside the in-app WebView and forward them to the proof flow instead of navigating the page
- route proof completion callbacks back into the in-app WebView when the callback URL is self-hosted, logging failures and preserving the existing status countdown UX
- attach wallet-bound metadata, deeplink callbacks, and self-defined data to the points SelfApp configuration for per-user tracking

## Testing
- yarn lint
- yarn types
- yarn jest:run tests/src/utils/deeplinkCallbacks.test.ts tests/src/services/points/utils.test.ts tests/src/screens/WebViewScreen.test.tsx


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6941fc404b94832d86d1685ad373c0bc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Intercepts and routes certain in-app redirects to the native handler with trusted-domain checks.
  * Adds a deeplink callback handler that routes self-hosted callbacks into an in-app WebView or falls back to external opening.
  * Points flow now uses a deterministic, address-based user ID and includes disclosure metadata and deeplink callback.

* **Bug Fixes / Improvements**
  * Replaced direct deep-link openings with a stable, error-handled navigation callback.

* **Tests**
  * Added tests for redirect interception, deeplink routing, and points payload composition.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->