### PR TITLE
Update docstring coverage snapshots

### DIFF
--- a/docs/coverage/app.json
+++ b/docs/coverage/app.json
@@ -1,13 +1,13 @@
 {
-  "generatedAt": "2025-10-29T04:28:48.352Z",
+  "generatedAt": "2025-12-18T19:07:11.648Z",
   "label": "Mobile App",
   "totals": {
-    "exports": 389,
-    "documented": 38,
-    "undocumented": 351,
-    "coverage": 9.77
+    "exports": 497,
+    "documented": 75,
+    "undocumented": 422,
+    "coverage": 15.09
   },
-  "undocumentedTotal": 351,
+  "undocumentedTotal": 422,
   "undocumentedSampled": 50,
   "undocumented": [
     {
@@ -43,27 +43,27 @@
       "symbol": "default export"
     },
     {
-      "file": "app/src/components/homeScreen/idCard.tsx",
+      "file": "app/src/components/homescreen/IdCard.tsx",
       "symbol": "default export"
     },
     {
-      "file": "app/src/components/homeScreen/SvgXmlWrapper.native.tsx",
+      "file": "app/src/components/homescreen/SvgXmlWrapper.native.tsx",
       "symbol": "SvgXml"
     },
     {
-      "file": "app/src/components/homeScreen/SvgXmlWrapper.native.tsx",
+      "file": "app/src/components/homescreen/SvgXmlWrapper.native.tsx",
       "symbol": "default export"
     },
     {
-      "file": "app/src/components/homeScreen/SvgXmlWrapper.web.tsx",
+      "file": "app/src/components/homescreen/SvgXmlWrapper.web.tsx",
       "symbol": "SvgXml"
     },
     {
-      "file": "app/src/components/homeScreen/SvgXmlWrapper.web.tsx",
+      "file": "app/src/components/homescreen/SvgXmlWrapper.web.tsx",
       "symbol": "default export"
     },
     {
-      "file": "app/src/components/loading/LoadingUI.tsx",
+      "file": "app/src/components/LoadingUI.tsx",
       "symbol": "default export"
     },
     {
@@ -119,96 +119,96 @@
       "symbol": "RCTFragment"
     },
     {
-      "file": "app/src/components/NavBar/AadhaarNavBar.tsx",
+      "file": "app/src/components/navbar/AadhaarNavBar.tsx",
       "symbol": "AadhaarNavBar"
     },
     {
-      "file": "app/src/components/NavBar/BaseNavBar.tsx",
+      "file": "app/src/components/navbar/BaseNavBar.tsx",
       "symbol": "LeftAction"
     },
     {
-      "file": "app/src/components/NavBar/BaseNavBar.tsx",
+      "file": "app/src/components/navbar/BaseNavBar.tsx",
       "symbol": "RightAction"
     },
     {
-      "file": "app/src/components/NavBar/BaseNavBar.tsx",
+      "file": "app/src/components/navbar/BaseNavBar.tsx",
       "symbol": "NavBar"
     },
     {
-      "file": "app/src/components/NavBar/DefaultNavBar.tsx",
+      "file": "app/src/components/navbar/DefaultNavBar.tsx",
       "symbol": "DefaultNavBar"
     },
     {
-      "file": "app/src/components/NavBar/DocumentFlowNavBar.tsx",
+      "file": "app/src/components/navbar/DocumentFlowNavBar.tsx",
       "symbol": "DocumentFlowNavBar"
     },
     {
-      "file": "app/src/components/NavBar/HomeNavBar.tsx",
+      "file": "app/src/components/navbar/HeadlessNavForEuclid.tsx",
+      "symbol": "HeadlessNavForEuclid"
+    },
+    {
+      "file": "app/src/components/navbar/HomeNavBar.tsx",
       "symbol": "HomeNavBar"
     },
     {
-      "file": "app/src/components/NavBar/IdDetailsNavBar.tsx",
+      "file": "app/src/components/navbar/IdDetailsNavBar.tsx",
       "symbol": "IdDetailsNavBar"
     },
     {
-      "file": "app/src/components/NavBar/WebViewNavBar.tsx",
+      "file": "app/src/components/navbar/Points.tsx",
+      "symbol": "default export"
+    },
+    {
+      "file": "app/src/components/navbar/PointsNavBar.tsx",
+      "symbol": "PointsNavBar"
+    },
+    {
+      "file": "app/src/components/navbar/WebViewNavBar.tsx",
       "symbol": "WebViewNavBarProps"
     },
     {
-      "file": "app/src/components/NavBar/WebViewNavBar.tsx",
+      "file": "app/src/components/navbar/WebViewNavBar.tsx",
       "symbol": "WebViewNavBar"
     },
     {
-      "file": "app/src/components/Tips.tsx",
-      "symbol": "TipProps"
+      "file": "app/src/components/PointHistoryList.tsx",
+      "symbol": "PointHistoryListProps"
     },
     {
-      "file": "app/src/components/Tips.tsx",
-      "symbol": "Tips"
+      "file": "app/src/components/PointHistoryList.tsx",
+      "symbol": "PointHistoryList"
     },
     {
-      "file": "app/src/components/WebViewFooter.tsx",
-      "symbol": "WebViewFooterProps"
+      "file": "app/src/components/PointHistoryList.tsx",
+      "symbol": "default export"
     },
     {
-      "file": "app/src/components/WebViewFooter.tsx",
-      "symbol": "WebViewFooter"
+      "file": "app/src/components/referral/CopyReferralButton.tsx",
+      "symbol": "CopyReferralButtonProps"
     },
     {
-      "file": "app/src/consts/links.ts",
-      "symbol": "appStoreUrl"
+      "file": "app/src/components/referral/CopyReferralButton.tsx",
+      "symbol": "CopyReferralButton"
     },
     {
-      "file": "app/src/consts/links.ts",
-      "symbol": "gitHubUrl"
+      "file": "app/src/components/referral/ReferralHeader.tsx",
+      "symbol": "ReferralHeaderProps"
     },
     {
-      "file": "app/src/consts/links.ts",
-      "symbol": "playStoreUrl"
+      "file": "app/src/components/referral/ReferralHeader.tsx",
+      "symbol": "ReferralHeader"
     },
     {
-      "file": "app/src/consts/links.ts",
-      "symbol": "privacyUrl"
+      "file": "app/src/components/referral/ReferralInfo.tsx",
+      "symbol": "ReferralInfoProps"
     },
     {
-      "file": "app/src/consts/links.ts",
-      "symbol": "selfUrl"
+      "file": "app/src/components/referral/ReferralInfo.tsx",
+      "symbol": "ReferralInfo"
     },
     {
-      "file": "app/src/consts/links.ts",
-      "symbol": "supportedBiometricIdsUrl"
-    },
-    {
-      "file": "app/src/consts/links.ts",
-      "symbol": "telegramUrl"
-    },
-    {
-      "file": "app/src/consts/links.ts",
-      "symbol": "termsUrl"
-    },
-    {
-      "file": "app/src/consts/links.ts",
-      "symbol": "xUrl"
+      "file": "app/src/components/referral/ShareButton.tsx",
+      "symbol": "ShareButtonProps"
     }
   ]
 }

--- a/docs/coverage/report.json
+++ b/docs/coverage/report.json
@@ -1,13 +1,13 @@
 {
-  "generatedAt": "2025-10-29T04:29:01.442Z",
+  "generatedAt": "2025-12-18T19:07:39.092Z",
   "label": "App + SDK",
   "totals": {
-    "exports": 618,
-    "documented": 73,
-    "undocumented": 545,
-    "coverage": 11.81
+    "exports": 731,
+    "documented": 152,
+    "undocumented": 579,
+    "coverage": 20.79
   },
-  "undocumentedTotal": 545,
+  "undocumentedTotal": 579,
   "undocumentedSampled": 50,
   "undocumented": [
     {
@@ -43,27 +43,27 @@
       "symbol": "default export"
     },
     {
-      "file": "app/src/components/homeScreen/idCard.tsx",
+      "file": "app/src/components/homescreen/IdCard.tsx",
       "symbol": "default export"
     },
     {
-      "file": "app/src/components/homeScreen/SvgXmlWrapper.native.tsx",
+      "file": "app/src/components/homescreen/SvgXmlWrapper.native.tsx",
       "symbol": "SvgXml"
     },
     {
-      "file": "app/src/components/homeScreen/SvgXmlWrapper.native.tsx",
+      "file": "app/src/components/homescreen/SvgXmlWrapper.native.tsx",
       "symbol": "default export"
     },
     {
-      "file": "app/src/components/homeScreen/SvgXmlWrapper.web.tsx",
+      "file": "app/src/components/homescreen/SvgXmlWrapper.web.tsx",
       "symbol": "SvgXml"
     },
     {
-      "file": "app/src/components/homeScreen/SvgXmlWrapper.web.tsx",
+      "file": "app/src/components/homescreen/SvgXmlWrapper.web.tsx",
       "symbol": "default export"
     },
     {
-      "file": "app/src/components/loading/LoadingUI.tsx",
+      "file": "app/src/components/LoadingUI.tsx",
       "symbol": "default export"
     },
     {
@@ -119,96 +119,96 @@
       "symbol": "RCTFragment"
     },
     {
-      "file": "app/src/components/NavBar/AadhaarNavBar.tsx",
+      "file": "app/src/components/navbar/AadhaarNavBar.tsx",
       "symbol": "AadhaarNavBar"
     },
     {
-      "file": "app/src/components/NavBar/BaseNavBar.tsx",
+      "file": "app/src/components/navbar/BaseNavBar.tsx",
       "symbol": "LeftAction"
     },
     {
-      "file": "app/src/components/NavBar/BaseNavBar.tsx",
+      "file": "app/src/components/navbar/BaseNavBar.tsx",
       "symbol": "RightAction"
     },
     {
-      "file": "app/src/components/NavBar/BaseNavBar.tsx",
+      "file": "app/src/components/navbar/BaseNavBar.tsx",
       "symbol": "NavBar"
     },
     {
-      "file": "app/src/components/NavBar/DefaultNavBar.tsx",
+      "file": "app/src/components/navbar/DefaultNavBar.tsx",
       "symbol": "DefaultNavBar"
     },
     {
-      "file": "app/src/components/NavBar/DocumentFlowNavBar.tsx",
+      "file": "app/src/components/navbar/DocumentFlowNavBar.tsx",
       "symbol": "DocumentFlowNavBar"
     },
     {
-      "file": "app/src/components/NavBar/HomeNavBar.tsx",
+      "file": "app/src/components/navbar/HeadlessNavForEuclid.tsx",
+      "symbol": "HeadlessNavForEuclid"
+    },
+    {
+      "file": "app/src/components/navbar/HomeNavBar.tsx",
       "symbol": "HomeNavBar"
     },
     {
-      "file": "app/src/components/NavBar/IdDetailsNavBar.tsx",
+      "file": "app/src/components/navbar/IdDetailsNavBar.tsx",
       "symbol": "IdDetailsNavBar"
     },
     {
-      "file": "app/src/components/NavBar/WebViewNavBar.tsx",
+      "file": "app/src/components/navbar/Points.tsx",
+      "symbol": "default export"
+    },
+    {
+      "file": "app/src/components/navbar/PointsNavBar.tsx",
+      "symbol": "PointsNavBar"
+    },
+    {
+      "file": "app/src/components/navbar/WebViewNavBar.tsx",
       "symbol": "WebViewNavBarProps"
     },
     {
-      "file": "app/src/components/NavBar/WebViewNavBar.tsx",
+      "file": "app/src/components/navbar/WebViewNavBar.tsx",
       "symbol": "WebViewNavBar"
     },
     {
-      "file": "app/src/components/Tips.tsx",
-      "symbol": "TipProps"
+      "file": "app/src/components/PointHistoryList.tsx",
+      "symbol": "PointHistoryListProps"
     },
     {
-      "file": "app/src/components/Tips.tsx",
-      "symbol": "Tips"
+      "file": "app/src/components/PointHistoryList.tsx",
+      "symbol": "PointHistoryList"
     },
     {
-      "file": "app/src/components/WebViewFooter.tsx",
-      "symbol": "WebViewFooterProps"
+      "file": "app/src/components/PointHistoryList.tsx",
+      "symbol": "default export"
     },
     {
-      "file": "app/src/components/WebViewFooter.tsx",
-      "symbol": "WebViewFooter"
+      "file": "app/src/components/referral/CopyReferralButton.tsx",
+      "symbol": "CopyReferralButtonProps"
     },
     {
-      "file": "app/src/consts/links.ts",
-      "symbol": "appStoreUrl"
+      "file": "app/src/components/referral/CopyReferralButton.tsx",
+      "symbol": "CopyReferralButton"
     },
     {
-      "file": "app/src/consts/links.ts",
-      "symbol": "gitHubUrl"
+      "file": "app/src/components/referral/ReferralHeader.tsx",
+      "symbol": "ReferralHeaderProps"
     },
     {
-      "file": "app/src/consts/links.ts",
-      "symbol": "playStoreUrl"
+      "file": "app/src/components/referral/ReferralHeader.tsx",
+      "symbol": "ReferralHeader"
     },
     {
-      "file": "app/src/consts/links.ts",
-      "symbol": "privacyUrl"
+      "file": "app/src/components/referral/ReferralInfo.tsx",
+      "symbol": "ReferralInfoProps"
     },
     {
-      "file": "app/src/consts/links.ts",
-      "symbol": "selfUrl"
+      "file": "app/src/components/referral/ReferralInfo.tsx",
+      "symbol": "ReferralInfo"
     },
     {
-      "file": "app/src/consts/links.ts",
-      "symbol": "supportedBiometricIdsUrl"
-    },
-    {
-      "file": "app/src/consts/links.ts",
-      "symbol": "telegramUrl"
-    },
-    {
-      "file": "app/src/consts/links.ts",
-      "symbol": "termsUrl"
-    },
-    {
-      "file": "app/src/consts/links.ts",
-      "symbol": "xUrl"
+      "file": "app/src/components/referral/ShareButton.tsx",
+      "symbol": "ShareButtonProps"
     }
   ]
 }

--- a/docs/coverage/sdk.json
+++ b/docs/coverage/sdk.json
@@ -1,13 +1,13 @@
 {
-  "generatedAt": "2025-10-29T04:28:54.782Z",
+  "generatedAt": "2025-12-18T19:07:23.722Z",
   "label": "Mobile SDK Alpha",
   "totals": {
-    "exports": 229,
-    "documented": 35,
-    "undocumented": 194,
-    "coverage": 15.28
+    "exports": 234,
+    "documented": 77,
+    "undocumented": 157,
+    "coverage": 32.91
   },
-  "undocumentedTotal": 194,
+  "undocumentedTotal": 157,
   "undocumentedSampled": 50,
   "undocumented": [
     {


### PR DESCRIPTION
## Summary
- regenerate the mobile app docstring coverage snapshot
- regenerate the mobile SDK alpha docstring coverage snapshot
- refresh the combined app + SDK docstring coverage report

## Testing
- yarn docstrings:app
- yarn docstrings:sdk
- yarn docstrings:report
- yarn lint

## Additional Notes
- Unable to fetch or rebase onto `dev` because no `origin` remote is configured in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69444ef52540832db354fb3474c87756)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refreshes docstring coverage snapshots (app, SDK, combined) with updated timestamps, counts, coverage, and normalized component paths.
> 
> - **Docs Coverage Snapshots**:
>   - **Updated counts/coverage**:
>     - `docs/coverage/app.json`: exports 497; documented 75; coverage 15.09 (was 9.77).
>     - `docs/coverage/sdk.json`: exports 234; documented 77; coverage 32.91 (was 15.28).
>     - `docs/coverage/report.json`: exports 731; documented 152; coverage 20.79 (was 11.81).
>   - **Path normalization/renames reflected**:
>     - `homeScreen` → `homescreen`; `NavBar` → `navbar`; `components/loading/LoadingUI.tsx` → `components/LoadingUI.tsx`.
>   - **Scope changes in undocumented listings**:
>     - Adds entries like `navbar/HeadlessNavForEuclid`, `navbar/Points.tsx`, `navbar/PointsNavBar.tsx`, `PointHistoryList.tsx`, and referral components (`CopyReferralButton`, `ReferralHeader`, `ReferralInfo`, `ShareButton`).
>   - Updated `generatedAt` timestamps for all snapshots.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecc1eeff326876d8580eda3874f57c757d06b365. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->