### PR TITLE
Remove path filters in workflow

### DIFF
--- a/.github/workflows/circuits.yml
+++ b/.github/workflows/circuits.yml
@@ -24,6 +24,8 @@ jobs:
             echo "Running for ${{ github.base_ref }} - no path filter"
           else
             # For dev branch, check if circuits files changed
+            # Fetch the base branch to ensure it's available for comparison
+            git fetch origin ${{ github.base_ref }} --depth=1
             CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD) || {
               echo "Error: Failed to diff against base branch"
               exit 1

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -29,6 +29,8 @@ jobs:
             echo "Running for ${{ github.base_ref }} - no path filter"
           else
             # For dev branch, check if contracts or common files changed
+            # Fetch the base branch to ensure it's available for comparison
+            git fetch origin ${{ github.base_ref }} --depth=1
             CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD) || {
               echo "Error: Failed to diff against base branch"
               exit 1

--- a/.github/workflows/core-sdk-ci.yml
+++ b/.github/workflows/core-sdk-ci.yml
@@ -26,6 +26,8 @@ jobs:
             echo "Running for ${{ github.base_ref }} - no path filter"
           else
             # For dev branch, check if relevant files changed
+            # Fetch the base branch to ensure it's available for comparison
+            git fetch origin ${{ github.base_ref }} --depth=1
             CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD) || {
               echo "Error: Failed to diff against base branch"
               exit 1

--- a/.github/workflows/qrcode-sdk-ci.yml
+++ b/.github/workflows/qrcode-sdk-ci.yml
@@ -34,6 +34,8 @@ jobs:
             echo "Running for ${{ github.base_ref }} - no path filter"
           else
             # For dev branch, check if relevant files changed
+            # Fetch the base branch to ensure it's available for comparison
+            git fetch origin ${{ github.base_ref }} --depth=1
             CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD) || {
               echo "Error: Failed to diff against base branch"
               exit 1


### PR DESCRIPTION
#1545 `integration-test` and `types` checks are not being executed because the list of changed files it too wide that the `paths` filter in the trigger does not work properly. To fix this, we must update the workflow adding a new job in charge of filtering the execution of jobs based on the list of changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized CI to use branch-based gating and a new change-detection step so main/staging always run full checks while feature branches only run relevant pipelines when affected areas change.
  * Propagated the gating across build, lint, test and verification steps and added a base-branch fetch to ensure accurate diffs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->