### PR TITLE
Make QR fragment creation idempotent and retry on failure

### DIFF
--- a/app/android/app/src/main/java/com/proofofpassportapp/ui/QRCodeScannerViewManager.kt
+++ b/app/android/app/src/main/java/com/proofofpassportapp/ui/QRCodeScannerViewManager.kt
@@ -77,6 +77,7 @@ class QRCodeScannerViewManager(
         val parentView = root.findViewById<ViewGroup>(reactNativeViewId)
         setupLayout(parentView)
 
+        destroyFragment(root, reactNativeViewId)
         val qrScannerFragment = QrCodeScannerFragment(this)
         val activity = reactContext.currentActivity as FragmentActivity
         activity.supportFragmentManager

--- a/app/src/components/native/RCTFragment.tsx
+++ b/app/src/components/native/RCTFragment.tsx
@@ -49,6 +49,9 @@ function dispatchCommand(
     console.warn(e);
     if (command === 'create') {
       dispatchCommand(fragmentComponentName, viewId, 'destroy');
+      setTimeout(() => {
+        dispatchCommand(fragmentComponentName, viewId, 'create');
+      }, 0);
     }
   }
 }


### PR DESCRIPTION
### Motivation
- Avoid camera freezes after a Metro hard reload by ensuring the native fragment is reliably recreated.  
- Handle transient `create` failures from the view manager and recover automatically.  
- Prevent duplicate fragments from being left in the FragmentManager which can cause creation errors or stale camera state.  

### Description
- In `app/src/components/native/RCTFragment.tsx` the `dispatchCommand` catch path now issues a `destroy` and then schedules a retry of `create` on the next tick via `setTimeout(..., 0)` when a `create` fails.  
- In `app/android/app/src/main/java/com/proofofpassportapp/ui/QRCodeScannerViewManager.kt` the `createFragment` method now calls `destroyFragment` first to make fragment creation idempotent before calling `replace(...)`.  
- These changes ensure the fragment is removed before re-adding it, and add a defensive retry for JS-side command dispatch errors.  

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696018d76be0832db84d27810c07d5ce)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved QR code scanner stability through enhanced fragment lifecycle management that ensures proper cleanup of existing fragments before initialization.
  * Added automatic retry logic for QR code scanner creation failures, allowing the system to gracefully recover from transient errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->