### PR TITLE
Return to prior screen from DocumentSelector and guard Prove screen against stale session

### DIFF
--- a/app/src/screens/verification/DocumentSelectorForProvingScreen.tsx
+++ b/app/src/screens/verification/DocumentSelectorForProvingScreen.tsx
@@ -303,6 +303,43 @@ const DocumentSelectorForProvingScreen: React.FC = () => {
     };
   }, []);
 
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('beforeRemove', event => {
+      if (
+        event.data.action.type !== 'GO_BACK' &&
+        event.data.action.type !== 'POP'
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      const state = navigation.getState();
+      const routerIndex = state.routes.findIndex(
+        route => route.name === 'ProvingScreenRouter',
+      );
+
+      if (routerIndex > 0) {
+        const targetIndex = routerIndex - 1;
+        const routes = state.routes.slice(0, targetIndex + 1).map(route => ({
+          name: route.name as keyof RootStackParamList,
+          params: route.params,
+        }));
+        navigation.reset({
+          index: targetIndex,
+          routes,
+        });
+        return;
+      }
+
+      navigation.reset({
+        index: 0,
+        routes: [{ name: 'Home' }],
+      });
+    });
+
+    return unsubscribe;
+  }, [navigation]);
+
   const documents = useMemo(() => {
     return documentCatalog.documents
       .map(metadata => {

--- a/app/src/screens/verification/ProveScreen.tsx
+++ b/app/src/screens/verification/ProveScreen.tsx
@@ -76,8 +76,9 @@ function getDocumentTypeName(category: string | undefined): string {
 const ProveScreen: React.FC = () => {
   const selfClient = useSelfClient();
   const { trackEvent } = selfClient;
-  const { navigate } =
+  const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const { navigate } = navigation;
   const route = useRoute<RouteProp<RootStackParamList, 'Prove'>>();
   const isFocused = useIsFocused();
   const { useProvingStore, useSelfAppStore } = selfClient;
@@ -101,6 +102,7 @@ const ProveScreen: React.FC = () => {
   );
   const provingStore = useProvingStore();
   const currentState = useProvingStore(state => state.currentState);
+  const provingSessionId = useProvingStore(state => state.uuid);
   const isReadyToProve = currentState === 'ready_to_prove';
 
   const { addProofHistory } = useProofHistoryStore();
@@ -206,6 +208,22 @@ const ProveScreen: React.FC = () => {
     //as it sets provingStore.setUserConfirmed()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedApp?.sessionId, isFocused, selfClient]);
+
+  useEffect(() => {
+    if (!isFocused) {
+      return;
+    }
+
+    if (
+      !selectedApp?.sessionId ||
+      (provingSessionId && selectedApp.sessionId !== provingSessionId)
+    ) {
+      navigation.reset({
+        index: 0,
+        routes: [{ name: 'Home' }],
+      });
+    }
+  }, [isFocused, navigation, provingSessionId, selectedApp?.sessionId]);
 
   // Enhance selfApp with user's points address if not already set
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Ensure pressing back from `DocumentSelectorForProvingScreen` goes to the screen that was shown before `ProvingScreenRouter`, and fall back to `Home` for deeplink/no-prior-screen cases. 
- Prevent users from being stuck on the `Prove` screen due to stale/mismatched zustand proving session state.
- Keep navigation behavior predictable by resetting navigation state rather than juggling store internals.

### Description
- In `DocumentSelectorForProvingScreen.tsx` update the `beforeRemove` handler to inspect `navigation.getState()`, locate `ProvingScreenRouter`, and reset the navigation stack to the route just before the router when present, otherwise reset to `Home`.
- In `ProveScreen.tsx` expose the full `navigation` object (and keep `navigate`) and read the proving session id via `useProvingStore(state => state.uuid)`, then add a focus guard `useEffect` that resets to `Home` when the selected app session is missing or mismatched with the proving session.
- Minor refactor to preserve `navigate` while allowing `navigation.reset` calls from the same `navigation` instance.
- Files modified: `app/src/screens/verification/DocumentSelectorForProvingScreen.tsx` and `app/src/screens/verification/ProveScreen.tsx`.

### Testing
- No automated tests were executed as part of this change (not run).
- Recommended pre-merge checks per repo guidelines: run `yarn nice`, `yarn types`, `yarn test`, and `yarn build` in the `app` workspace.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6960681accf4832d87f28ee926577324)