### PR TITLE
Add helper to normalize SQLite insertId handling in database.ts

### DIFF
--- a/app/src/stores/database.ts
+++ b/app/src/stores/database.ts
@@ -14,6 +14,9 @@ const STALE_PROOF_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 
 SQLite.enablePromise(true);
 
+const toInsertId = (result: SQLite.ResultSet) =>
+  result.insertId ? result.insertId.toString() : '0';
+
 async function openDatabase() {
   return SQLite.openDatabase({
     name: DB_NAME,
@@ -129,7 +132,7 @@ export const database: ProofDB = {
       );
       // Handle case where INSERT OR IGNORE skips insertion due to duplicate sessionId
       return {
-        id: insertResult.insertId ? insertResult.insertId.toString() : '0',
+        id: toInsertId(insertResult),
         timestamp,
         rowsAffected: insertResult.rowsAffected,
       };
@@ -157,7 +160,7 @@ export const database: ProofDB = {
         );
         // Handle case where INSERT OR IGNORE skips insertion due to duplicate sessionId
         return {
-          id: insertResult.insertId ? insertResult.insertId.toString() : '0',
+          id: toInsertId(insertResult),
           timestamp,
           rowsAffected: insertResult.rowsAffected,
         };
@@ -186,7 +189,7 @@ export const database: ProofDB = {
         );
         // Handle case where INSERT OR IGNORE skips insertion due to duplicate sessionId
         return {
-          id: insertResult.insertId ? insertResult.insertId.toString() : '0',
+          id: toInsertId(insertResult),
           timestamp,
           rowsAffected: insertResult.rowsAffected,
         };


### PR DESCRIPTION
### Motivation
- Reduce duplication and centralize the logic that converts SQLite insert results into string IDs.
- Ensure consistent fallback behavior for `INSERT OR IGNORE` paths where `insertId` may be falsy.

### Description
- Add `const toInsertId = (result: SQLite.ResultSet) => result.insertId ? result.insertId.toString() : '0';` near `SQLite.enablePromise(true)` in `app/src/stores/database.ts`.
- Replace inline `insertResult.insertId ? insertResult.insertId.toString() : '0'` usages in `insertProof` with calls to `toInsertId(insertResult)` across all insert paths.
- Preserve existing behavior for duplicate `sessionId` (the `INSERT OR IGNORE` case) and error-handling branches that add missing columns.

### Testing
- No automated tests were run as part of this change.
- Recommend running `yarn nice`, `yarn types`, and `yarn test` in the `app` workspace before merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69620e1398f4832dada46504148d6fc9)