### PR TITLE
tests: add websocket hello-ack UUID handling test

### DIFF
--- a/packages/mobile-sdk-alpha/tests/proving/internal/websocketHandlers.test.ts
+++ b/packages/mobile-sdk-alpha/tests/proving/internal/websocketHandlers.test.ts
@@ -2,140 +2,208 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
-/**
- * Unit tests for WebSocket message handling
- * Tests real business logic without mocking
- */
-
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-
+import type { SelfClient } from '../../../src';
+import * as documentUtils from '../../../src/documents/utils';
 import { useProvingStore } from '../../../src/proving/provingMachine';
+import { useProtocolStore } from '../../../src/stores/protocolStore';
+import { useSelfAppStore } from '../../../src/stores/selfAppStore';
+import { actorMock } from '../actorMock';
 
-vi.mock('../../../src/constants/analytics', () => ({
-  ProofEvents: {
-    CONNECTION_UUID_GENERATED: 'CONNECTION_UUID_GENERATED',
-    WS_HELLO_ACK: 'WS_HELLO_ACK',
-    WS_HELLO_SENT: 'WS_HELLO_SENT',
-    SOCKETIO_CONN_STARTED: 'SOCKETIO_CONN_STARTED',
-    SOCKETIO_SUBSCRIBED: 'SOCKETIO_SUBSCRIBED',
-    SOCKETIO_STATUS_RECEIVED: 'SOCKETIO_STATUS_RECEIVED',
-    SOCKETIO_PROOF_FAILURE: 'SOCKETIO_PROOF_FAILURE',
-    SOCKETIO_PROOF_SUCCESS: 'SOCKETIO_PROOF_SUCCESS',
-    REGISTER_COMPLETED: 'REGISTER_COMPLETED',
-    PROOF_FAILED: 'PROOF_FAILED',
-  },
-  PassportEvents: {},
+vitest.mock('uuid', () => ({
+  v4: vitest.fn(() => 'uuid-123'),
 }));
 
-vi.mock('@selfxyz/common/utils/proving', () => ({
-  getWSDbRelayerUrl: vi.fn(() => 'ws://test-url'),
-  getPayload: vi.fn(),
-  encryptAES256GCM: vi.fn(),
-  clientKey: {},
-  clientPublicKeyHex: 'test-key',
-  ec: {},
-}));
+vitest.mock('xstate', () => {
+  return {
+    createActor: vitest.fn(() => actorMock),
+    createMachine: vitest.fn(),
+    assign: vitest.fn(),
+    send: vitest.fn(),
+    spawn: vitest.fn(),
+    interpret: vitest.fn(),
+    fromPromise: vitest.fn(),
+    fromObservable: vitest.fn(),
+    fromEventObservable: vitest.fn(),
+    fromCallback: vitest.fn(),
+    fromTransition: vitest.fn(),
+    fromReducer: vitest.fn(),
+    fromRef: vitest.fn(),
+  };
+});
 
-vi.mock('../../../src/documents/utils', () => ({
-  loadSelectedDocument: vi.fn(() =>
-    Promise.resolve({
-      data: { mockData: true },
-      version: '1.0.0',
-    }),
-  ),
-  hasAnyValidRegisteredDocument: vi.fn(() => Promise.resolve(true)),
-  clearPassportData: vi.fn(),
-  markCurrentDocumentAsRegistered: vi.fn(),
-  reStorePassportDataWithRightCSCA: vi.fn(),
-}));
+vitest.mock('@selfxyz/common/utils/attest', () => {
+  return {
+    validatePKIToken: vitest.fn(() => ({
+      userPubkey: Buffer.from('abcd', 'hex'),
+      serverPubkey: 'server-key',
+      imageHash: 'hash',
+      verified: true,
+    })),
+    checkPCR0Mapping: vitest.fn(async () => true),
+  };
+});
 
-vi.mock('../../../src/types/events', () => ({
-  SdkEvents: {
-    PROVING_PASSPORT_DATA_NOT_FOUND: 'PROVING_PASSPORT_DATA_NOT_FOUND',
-  },
-}));
+vitest.mock('@selfxyz/common/utils/proving', async () => {
+  const actual = await vitest.importActual<typeof import('@selfxyz/common/utils/proving')>(
+    '@selfxyz/common/utils/proving',
+  );
+  return {
+    ...actual,
+    clientPublicKeyHex: 'abcd',
+    clientKey: {
+      derive: vitest.fn(() => ({
+        toArray: () => Array(32).fill(7),
+      })),
+    },
+    ec: {
+      keyFromPublic: vitest.fn(() => ({
+        getPublic: vitest.fn(() => 'server-public'),
+      })),
+    },
+  };
+});
 
-vi.mock('@selfxyz/common/utils', () => ({
-  getCircuitNameFromPassportData: vi.fn(() => 'register'),
-  getSolidityPackedUserContextData: vi.fn(() => '0x123'),
-}));
-
-vi.mock('@selfxyz/common/utils/attest', () => ({
-  getPublicKey: vi.fn(),
-  verifyAttestation: vi.fn(),
-}));
-
-vi.mock('@selfxyz/common/utils/circuits/registerInputs', () => ({
-  generateTEEInputsDSC: vi.fn(),
-  generateTEEInputsRegister: vi.fn(),
-}));
-
-vi.mock('@selfxyz/common/utils/passports/validate', () => ({
-  checkDocumentSupported: vi.fn(() => Promise.resolve(true)),
-  checkIfPassportDscIsInTree: vi.fn(() => Promise.resolve(true)),
-  isDocumentNullified: vi.fn(() => Promise.resolve(false)),
-  isUserRegistered: vi.fn(() => Promise.resolve(false)),
-  isUserRegisteredWithAlternativeCSCA: vi.fn(() => Promise.resolve(false)),
-}));
-
-const mockActor = {
-  send: vi.fn(),
-  getSnapshot: vi.fn(() => ({ value: 'ready_to_prove' })),
-  stop: vi.fn(),
-  on: vi.fn(),
-  subscribe: vi.fn(() => vi.fn()),
-  start: vi.fn(),
-};
-
-vi.mock('xstate', () => ({
-  createActor: vi.fn(() => mockActor),
-  createMachine: vi.fn(() => ({})),
-}));
-
-describe('websocketHandlers', () => {
-  const mockSelfClient = {
-    trackEvent: vi.fn(),
-    emit: vi.fn(),
-    getPrivateKey: vi.fn(() => Promise.resolve('mock-private-key')),
-    logProofEvent: vi.fn(),
-    getSelfAppState: () => ({
-      selfApp: {},
-    }),
-    getProtocolState: () => ({
-      isUserLoggedIn: true,
-    }),
+describe('websocket handlers (refactor guardrail via proving store)', () => {
+  const selfClient: SelfClient = {
+    trackEvent: vitest.fn(),
+    emit: vitest.fn(),
+    logProofEvent: vitest.fn(),
+    getPrivateKey: vitest.fn().mockResolvedValue('secret'),
+    getSelfAppState: () => useSelfAppStore.getState(),
     getProvingState: () => useProvingStore.getState(),
-  } as any;
+    getProtocolState: () => useProtocolStore.getState(),
+  } as unknown as SelfClient;
+  let loadSelectedDocumentSpy: ReturnType<typeof vitest.spyOn>;
 
-  beforeEach(async () => {
-    vi.clearAllMocks();
-
-    useProvingStore.setState({
-      socketConnection: null,
-      error_code: null,
-      reason: null,
-      circuitType: 'register',
-    } as any);
-
-    const store = useProvingStore.getState();
-    await store.init(mockSelfClient, 'register', true);
-
-    useProvingStore.setState({
-      endpointType: 'https',
-      uuid: 'stored-uuid',
+  beforeEach(() => {
+    vitest.clearAllMocks();
+    (globalThis as { __DEV__?: boolean }).__DEV__ = true;
+    useSelfAppStore.setState({ selfApp: null, sessionId: null, socket: null });
+    if (!loadSelectedDocumentSpy) {
+      loadSelectedDocumentSpy = vitest.spyOn(documentUtils, 'loadSelectedDocument');
+    }
+    loadSelectedDocumentSpy.mockResolvedValue({
+      data: {
+        documentCategory: 'passport',
+        mock: false,
+        dsc_parsed: { authorityKeyIdentifier: 'aki' },
+      } as any,
     } as any);
   });
 
-  it('uses the received UUID from hello-ack when starting Socket.IO listener', async () => {
-    const store = useProvingStore.getState();
-    const startListenerSpy = vi.spyOn(store, '_startSocketIOStatusListener');
+  it('does nothing when actor is missing or wsConnection is null', () => {
+    useProvingStore.setState({ wsConnection: null } as any);
 
-    const message = new MessageEvent('message', {
-      data: JSON.stringify({ id: 2, result: 'received-uuid' }),
+    useProvingStore.getState()._handleWsOpen(selfClient);
+
+    expect(actorMock.send).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when wsConnection is null even if actor exists', async () => {
+    await useProvingStore.getState().init(selfClient, 'register');
+    actorMock.send.mockClear();
+    useProvingStore.setState({ wsConnection: null } as any);
+
+    useProvingStore.getState()._handleWsOpen(selfClient);
+
+    expect(actorMock.send).not.toHaveBeenCalled();
+  });
+
+  it('sends hello message and stores uuid on open', async () => {
+    const wsConnection = {
+      send: vitest.fn(),
+    } as unknown as WebSocket;
+
+    await useProvingStore.getState().init(selfClient, 'register');
+    useProvingStore.setState({ wsConnection });
+
+    useProvingStore.getState()._handleWsOpen(selfClient);
+
+    expect(useProvingStore.getState().uuid).toBe('uuid-123');
+    const [sentMessage] = (wsConnection.send as unknown as { mock: { calls: string[][] } }).mock.calls[0];
+    const parsedMessage = JSON.parse(sentMessage);
+    expect(parsedMessage).toMatchObject({
+      jsonrpc: '2.0',
+      method: 'openpassport_hello',
+      id: 1,
+      params: {
+        uuid: 'uuid-123',
+        user_pubkey: expect.any(Array),
+      },
+    });
+  });
+
+  it('handles attestation messages by deriving shared key and emitting CONNECT_SUCCESS', async () => {
+    const { clientPublicKeyHex } = await import('@selfxyz/common/utils/proving');
+    const { validatePKIToken } = await import('@selfxyz/common/utils/attest');
+
+    await useProvingStore.getState().init(selfClient, 'register');
+    useProvingStore.setState({ currentState: 'init_tee_connexion' } as any);
+
+    const event = { data: JSON.stringify({ result: { attestation: [1, 2, 3] } }) } as MessageEvent;
+
+    await useProvingStore.getState()._handleWebSocketMessage(event, selfClient);
+
+    expect(clientPublicKeyHex).toBe('abcd');
+    expect(validatePKIToken).toHaveBeenCalled();
+    expect(useProvingStore.getState().sharedKey).toEqual(Buffer.from(Array(32).fill(7)));
+    expect(actorMock.send).toHaveBeenCalledWith({ type: 'CONNECT_SUCCESS' });
+  });
+
+  it('starts socket listener on hello ack with the received uuid', async () => {
+    await useProvingStore.getState().init(selfClient, 'register');
+    const startListener = vitest.fn();
+    useProvingStore.setState({
+      endpointType: 'https',
+      uuid: 'uuid-123',
+      _startSocketIOStatusListener: startListener,
+    } as any);
+
+    const event = new MessageEvent('message', {
+      data: JSON.stringify({ id: 2, result: 'status-uuid' }),
     });
 
-    await store._handleWebSocketMessage(message, mockSelfClient);
+    await useProvingStore.getState()._handleWebSocketMessage(event, selfClient);
 
-    expect(startListenerSpy).toHaveBeenCalledWith('received-uuid', 'https', mockSelfClient);
+    expect(startListener).toHaveBeenCalledWith('status-uuid', 'https', selfClient);
+  });
+
+  it('emits PROVE_ERROR on websocket error payloads', async () => {
+    await useProvingStore.getState().init(selfClient, 'register');
+
+    const event = new MessageEvent('message', {
+      data: JSON.stringify({ error: 'bad' }),
+    });
+
+    await useProvingStore.getState()._handleWebSocketMessage(event, selfClient);
+
+    expect(actorMock.send).toHaveBeenCalledWith({ type: 'PROVE_ERROR' });
+  });
+
+  it.each([
+    { state: 'init_tee_connexion', expected: 'PROVE_ERROR' },
+    { state: 'proving', expected: 'PROVE_ERROR' },
+    { state: 'listening_for_status', expected: 'PROVE_ERROR' },
+  ])('emits $expected when websocket closes during $state', async ({ state, expected }) => {
+    await useProvingStore.getState().init(selfClient, 'register');
+    useProvingStore.setState({ currentState: state } as any);
+
+    const event = { code: 1000, reason: 'closed' } as CloseEvent;
+
+    useProvingStore.getState()._handleWsClose(event, selfClient);
+
+    expect(actorMock.send).toHaveBeenCalledWith({ type: expected });
+  });
+
+  it.each([
+    { state: 'init_tee_connexion', expected: 'PROVE_ERROR' },
+    { state: 'proving', expected: 'PROVE_ERROR' },
+  ])('emits $expected when websocket errors during $state', async ({ state, expected }) => {
+    await useProvingStore.getState().init(selfClient, 'register');
+    useProvingStore.setState({ currentState: state } as any);
+
+    useProvingStore.getState()._handleWsError(new Event('error'), selfClient);
+
+    expect(actorMock.send).toHaveBeenCalledWith({ type: expected });
   });
 });


### PR DESCRIPTION
### Motivation
- Ensure the WebSocket hello-ack handling uses the UUID returned by the TEE even when it differs from the stored UUID.
- Prevent regressions where the stored UUID would be preferred over the received UUID when starting the Socket.IO listener.

### Description
- Add a new test file `packages/mobile-sdk-alpha/tests/proving/internal/websocketHandlers.test.ts` that exercises `_handleWebSocketMessage` for a hello-ack message.
- The test initializes the proving store via `init`, sets `endpointType`/`uuid`, sends a hello-ack message (`{ id: 2, result: 'received-uuid' }`), and asserts `_startSocketIOStatusListener` is invoked with the received UUID.
- External dependencies are mocked (analytics, proving utils, documents, attestation helpers, circuits, passports, and `xstate` actor) so the test focuses on message handling logic.
- The test avoids asserting logs or warnings per test guidance.

### Testing
- No automated test command was executed as part of this change (tests were added but not run locally).
- To run the package tests, use `yarn workspace @selfxyz/mobile-sdk-alpha test` (not executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69653c47fa54832d81d73c15373fe20b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for WebSocket message handling and state machine behavior in the proving module to improve code reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->