### PR TITLE
Add websocket hello-ack UUID coverage

### DIFF
--- a/packages/mobile-sdk-alpha/tests/proving/internal/websocketHandlers.test.ts
+++ b/packages/mobile-sdk-alpha/tests/proving/internal/websocketHandlers.test.ts
@@ -168,6 +168,24 @@ describe('websocket handlers (refactor guardrail via proving store)', () => {
     expect(startListener).toHaveBeenCalledWith('status-uuid', 'https', selfClient);
   });
 
+  it('uses hello ack uuid when it differs from stored uuid', async () => {
+    await useProvingStore.getState().init(selfClient, 'register');
+    const startListener = vitest.fn();
+    useProvingStore.setState({
+      endpointType: 'https',
+      uuid: 'uuid-123',
+      _startSocketIOStatusListener: startListener,
+    } as any);
+
+    const event = new MessageEvent('message', {
+      data: JSON.stringify({ id: 2, result: 'uuid-456' }),
+    });
+
+    await useProvingStore.getState()._handleWebSocketMessage(event, selfClient);
+
+    expect(startListener).toHaveBeenCalledWith('uuid-456', 'https', selfClient);
+  });
+
   it('emits PROVE_ERROR on websocket error payloads', async () => {
     await useProvingStore.getState().init(selfClient, 'register');
 


### PR DESCRIPTION
### Motivation
- Ensure the websocket hello-ack UUID returned by the server is used when starting the socket status listener even if it differs from the stored UUID.
- Prevent regressions in the `useProvingStore` websocket handling logic after refactors.
- Provide explicit test coverage for hello-ack behavior without asserting logs or warnings.

### Description
- Add a new test in `packages/mobile-sdk-alpha/tests/proving/internal/websocketHandlers.test.ts` that covers the hello-ack case where the returned UUID differs from the stored one.
- The test initializes the store via `useProvingStore.getState().init(selfClient, 'register')`, sets a spy for `_startSocketIOStatusListener`, sends a `MessageEvent` with `result: 'uuid-456'`, and asserts the spy was called with the received UUID.
- No production code changes; this is a test-only addition to increase coverage for websocket handling.

### Testing
- No automated tests were run locally for this change.
- CI / repository test suites (e.g. `yarn workspace @selfxyz/mobile-sdk-alpha test`) are expected to execute this test during standard pipeline runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696540e5bbb8832d9752dab8198b890d)