### PR TITLE
Limit keychain error modal to Android

### DIFF
--- a/app/src/providers/selfClientProvider.tsx
+++ b/app/src/providers/selfClientProvider.tsx
@@ -349,6 +349,7 @@ export function enableKeychainErrorModal() {
 export function showKeychainErrorModal(
   errorType: 'user_cancelled' | 'crypto_failed',
 ) {
+  if (Platform.OS !== 'android') return;
   if (!navigationRef.isReady()) return;
 
   const errorContent = {


### PR DESCRIPTION
### Motivation
- Prevent the keychain error modal from appearing on iOS devices where it is not desired or may be confusing.
- Ensure the modal behavior is platform-conditional so only Android users receive the keychain error UX.

### Description
- Added an early-return platform guard to `showKeychainErrorModal` so it only runs when `Platform.OS === 'android'`.
- Change applied in `app/src/providers/selfClientProvider.tsx` inside the exported `showKeychainErrorModal` function.
- Existing `enableKeychainErrorModal` / `disableKeychainErrorModal` APIs and modal registration logic were left unchanged.

### Testing
- No automated tests were run as part of this change.
- Recommend running `yarn workspace @selfxyz/mobile-app test` and `yarn types` before merging to validate behavior and types on both platforms.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69655c390b44832da32c7174737c156b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Keychain error modal now displays exclusively on Android devices, preventing unnecessary interactions on other platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->