### PR TITLE
Fix cloud backup visibility on iOS

### DIFF
--- a/app/src/screens/account/settings/SettingsScreen.tsx
+++ b/app/src/screens/account/settings/SettingsScreen.tsx
@@ -107,10 +107,10 @@ const DEBUG_MENU: [React.FC<SvgProps>, string, RouteOption][] = [
 ];
 
 const DOCUMENT_DEPENDENT_ROUTES: RouteOption[] = [
-  'CloudBackupSettings',
   'DocumentDataInfo',
   'ShowRecoveryPhrase',
 ];
+const CLOUD_BACKUP_ROUTE: RouteOption = 'CloudBackupSettings';
 
 const social = [
   [X, xUrl],
@@ -193,10 +193,20 @@ const SettingsScreen: React.FC = () => {
       return baseRoutes;
     }
 
+    const shouldHideCloudBackup = Platform.OS === 'android';
+
     // Only filter out document-related routes if we've confirmed user has no real documents
-    return baseRoutes.filter(
-      ([, , route]) => !DOCUMENT_DEPENDENT_ROUTES.includes(route),
-    );
+    return baseRoutes.filter(([, , route]) => {
+      if (DOCUMENT_DEPENDENT_ROUTES.includes(route)) {
+        return false;
+      }
+
+      if (shouldHideCloudBackup && route === CLOUD_BACKUP_ROUTE) {
+        return false;
+      }
+
+      return true;
+    });
   }, [hasRealDocument, isDevMode]);
 
   const devModeTap = Gesture.Tap()


### PR DESCRIPTION
### Motivation
- The settings menu previously hid the cloud backup entry when the device had no valid real documents, which prevents iOS users from recovering via iCloud even when they have backups. 
- iOS can restore from iCloud without a local scanned document, whereas Android requires a scanned document before recovery. 
- Adjust behavior so cloud backup remains accessible on iOS but document-dependent routes remain hidden when appropriate. 

### Description
- Removed `CloudBackupSettings` from `DOCUMENT_DEPENDENT_ROUTES` and added a new `CLOUD_BACKUP_ROUTE` constant in `app/src/screens/account/settings/SettingsScreen.tsx`.
- Updated the `screenRoutes` filtering logic to only hide the cloud backup route on Android when no real documents are present by checking `Platform.OS === 'android'`.
- The net effect is `CloudBackupSettings` remains visible on iOS even when `hasRealDocument` is `false`, while other document-dependent routes continue to be hidden.

### Testing
- Ran `yarn workspaces foreach` / `nice` variants: the command including `-A` failed due to invalid option schema but the variant without `-A` executed successfully.
- Ran `yarn lint`, which completed successfully.
- Ran `yarn build` and `yarn types`, which completed successfully for the workspaces run here.
- Ran `yarn workspace @selfxyz/contracts build`, which failed due to a Hardhat compiler download error caused by a proxy/403 response (external network issue).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69655c85f0d0832d98a74f43aa4ad812)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cloud Backup feature is now hidden on Android devices when no documents are available

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->