### PR TITLE
[SELF-1847] fix: register document from ManageDocuments screen

### DIFF
--- a/app/src/screens/documents/management/ManageDocumentsScreen.tsx
+++ b/app/src/screens/documents/management/ManageDocumentsScreen.tsx
@@ -106,8 +106,16 @@ const PassportDataSelector = () => {
   };
 
   const handleRegisterDocument = async (documentId: string) => {
-    await setSelectedDocument(documentId);
-    navigation.navigate('ConfirmBelonging', {});
+    try {
+      await setSelectedDocument(documentId);
+      navigation.navigate('ConfirmBelonging', {});
+    } catch (error) {
+      Alert.alert(
+        'Registration Error',
+        'Failed to prepare document for registration. Please try again.',
+        [{ text: 'OK', style: 'cancel' }],
+      );
+    }
   };
 
   const handleDeleteButtonPress = (


### PR DESCRIPTION
### Description

This PR accomplishes multiple things on `ManageDocuments` screen:
- prohibits from directly selecting a document that is not registered
- allows to trigger registration directly from the screen
- displays a warning when there are any not registered documents
- highlights the documents that are not registered
- refines warning before deleting based on registration status

### Tested

Manually registered 2 documents from the screen, removed some to see the refined message.

### How to QA

- register a document successfully
- go to Manage Documents screen
- see that there's no warning about not registered documents
- scan a document (or add a mock one) but exit the app on the Confirm Belonging screen
- go to Manage Documents screen
- see that there's a warning at the top of the list
- see that the latest document is highlighted in red and there's a plus icon next to it
- try removing the "valid" (registered) document
- see that the warning says about document being linked to your identity
- try removing the "invalid" (not registered)
- see that the warning doesn't say anything about document being linked to your identity
- mark the valid document as active
- try marking the invalid document as active
- see that there's warning displayed and app doesn't allow to select it
- click on the plus icon to trigger registration
- see that app redirects to the Confirm Belonging screen
- finish registration
- go to Manage Documents screen
- see that there's no warning and nothing marked in red, app should allow to choose any of the documents as active
- go to home screen and confirm both documents being there


<img width="250" alt="Screenshot_20260113_120117" src="https://github.com/user-attachments/assets/281326f6-f7c0-4275-ab5d-676dcdca05bc" />
<img width="250" alt="Screenshot_20260113_120133" src="https://github.com/user-attachments/assets/e5ad8b1d-2d8d-43ca-9a73-f3a38f21a742" />
<img width="250"  alt="Screenshot_20260113_120145" src="https://github.com/user-attachments/assets/e4d7516d-ae50-4eff-b525-cc32da4bf43d" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added document registration workflow with per-item "register" (plus) action and navigation to confirmation flow
  * Visual warning panel and distinct card styling for unregistered documents

* **Improvements**
  * Selection now enforces registration with validation alerts
  * Delete confirmation messaging and actions adapt based on document registration status

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds guardrails and inline actions for managing document registration in `ManageDocumentsScreen`.
> 
> - Blocks selecting unregistered documents with an alert; selection handlers now require `isRegistered`
> - Introduces inline registration via a new plus button that navigates to `ConfirmBelonging`
> - Highlights unregistered documents (light red) and shows a top warning banner when any are present
> - Refines delete confirmation message based on registration status
> - Minor UI updates: new `HousePlus` icon and helper for background color
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62789db1d5d8053ab0eefad321597ceefb737cd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->