### PR TITLE
SELF-1768: fix deeplink navigation

### DIFF
--- a/app/src/navigation/deeplinks.ts
+++ b/app/src/navigation/deeplinks.ts
@@ -112,14 +112,20 @@ export const getAndClearQueuedUrl = (): string | null => {
 const safeNavigate = (
   navigationState: ReturnType<typeof createDeeplinkNavigationState>,
 ): void => {
-  const targetScreen = navigationState.routes[1]
-    ?.name as keyof RootStackParamList;
+  const targetScreen = navigationState.routes[1]?.name as
+    | keyof RootStackParamList
+    | undefined;
 
   const currentRoute = navigationRef.getCurrentRoute();
   const isColdLaunch = currentRoute?.name === 'Splash';
 
-  if (!isColdLaunch) {
-    navigationRef.navigate(targetScreen as any);
+  if (!isColdLaunch && targetScreen) {
+    // Use object syntax to satisfy TypeScript's strict typing for navigate
+    // The params will be undefined for screens that don't require them
+    navigationRef.navigate({
+      name: targetScreen,
+      params: undefined,
+    } as Parameters<typeof navigationRef.navigate>[0]);
   } else {
     navigationRef.reset(navigationState);
   }

--- a/app/tests/src/navigation/deeplinks.test.ts
+++ b/app/tests/src/navigation/deeplinks.test.ts
@@ -604,7 +604,7 @@ describe('deeplinks', () => {
     mockLinking.getInitialURL.mockResolvedValue(undefined as any);
     mockLinking.addEventListener.mockReturnValue({ remove });
 
-    const cleanup = setupUniversalLinkListenerInNavigation();
+    const cleanup = setupUniversalLinkListenerInNavigation({} as SelfClient);
     expect(mockLinking.addEventListener).toHaveBeenCalled();
     cleanup();
     expect(remove).toHaveBeenCalled();


### PR DESCRIPTION
### Description

Fixes - deeplink not navigating to proveScreen when the app is open

### Tested

 - should not go to splashscreen on back cliked after deeplink navigation
 - should open provescreen on deeplink when app is open
 - should open prove screen on deeplink when app is open and in any screen other than Home
 - should open prove screen on deeplink when app is not open

- should open referral link correctly


### How to QA

1. Open the app
2. Open playground.staging.self.xyz and click `Open in App`
3. It should open the Prove screen
4. Close the app
5. Open playground.staging.self.xyz and click `Open in App`
6. It should open Prove screen
7. Click the back button - It should not get stuck in splashscreen


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Safer navigation handling for cold launches and error/special-case links, avoiding unintended navigation resets and applying conditional behavior for returning to Home.
* **Tests**
  * Updated tests to simulate cold-launch conditions and verify adjusted navigation/reset behavior and route expectations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves deeplink navigation to prevent unnecessary stack resets and handle warm vs cold launches correctly.
> 
> - Add `safeNavigate` that navigates when not on `Splash` and falls back to `reset` otherwise; replace prior `navigationRef.reset` calls across deeplink paths
> - Refine referrer handling: only navigate to `Home` when not already there; keeps modal behavior intact
> - Import `RootStackParamList` for stricter navigation typing and use `navigationRef.getCurrentRoute()`
> - Update tests to mock `getCurrentRoute`, adjust expectations for reset/navigate behavior, and pass `SelfClient` into `setupUniversalLinkListenerInNavigation`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0fa6840508d41dd9f6202317288f0ccbd3798137. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->