### PR TITLE
Fix settings options real document check

### DIFF
--- a/app/src/screens/account/settings/SettingsScreen.tsx
+++ b/app/src/screens/account/settings/SettingsScreen.tsx
@@ -187,22 +187,16 @@ const SettingsScreen: React.FC = () => {
 
   const screenRoutes = useMemo(() => {
     const baseRoutes = isDevMode ? [...routes, ...DEBUG_MENU] : routes;
-
-    // Show all routes while loading or if user has a real document
-    if (hasRealDocument === null || hasRealDocument === true) {
-      return baseRoutes;
-    }
-
     const shouldHideCloudBackup = Platform.OS === 'android';
+    const hasConfirmedRealDocument = hasRealDocument === true;
 
-    // Only filter out document-related routes if we've confirmed user has no real documents
     return baseRoutes.filter(([, , route]) => {
       if (DOCUMENT_DEPENDENT_ROUTES.includes(route)) {
-        return false;
+        return hasConfirmedRealDocument;
       }
 
       if (shouldHideCloudBackup && route === CLOUD_BACKUP_ROUTE) {
-        return false;
+        return hasConfirmedRealDocument;
       }
 
       return true;


### PR DESCRIPTION
### Motivation
- Prevent the settings menu from flashing document-dependent options when mock documents are present by switching from optimistic to pessimistic visibility logic.

### Description
- Update `app/src/screens/account/settings/SettingsScreen.tsx` so routes that depend on a real document are shown only when `hasRealDocument === true` instead of showing while loading.  
- This affects `DOCUMENT_DEPENDENT_ROUTES` (`DocumentDataInfo`, `ShowRecoveryPhrase`) and hides the Android `CloudBackupSettings` route unless a real document is confirmed.  
- Retains developer/debug menu handling and other non-document routes.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6966c3516a18832d8416dcac5301893f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access to document-dependent account settings and cloud backup features. These options are now correctly displayed when you have a verified document, enhancing the settings experience and enabling previously unavailable account management features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->