### PR TITLE
Re-enable Android E2E workflow

### DIFF
--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -229,8 +229,8 @@ jobs:
           arch: x86_64
           target: google_apis
           force-avd-creation: true
-          emulator-boot-timeout: 900
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none -memory 8192 -cores 4 -accel on -partition-size 2048
+          emulator-boot-timeout: 1800
+          emulator-options: -no-snapshot-save -no-snapshot-load -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none -memory 4096 -cores 2 -accel on -partition-size 2048 -wipe-data
           disable-animations: true
           script: |
             echo "Installing app on emulator..."


### PR DESCRIPTION
### Motivation

- Re-enable the Android E2E flow in CI to run Maestro-based end-to-end tests on the namespace.so runners and validate the real emulator test flow.
- Reduce emulator startup hangs and improve stability by adding KVM permission configuration and a more robust Maestro install/cache flow.

### Description

- Restored Android E2E steps in `/.github/workflows/mobile-e2e.yml` by removing the `if: false` guards that previously skipped Maestro and emulator execution.
- Added Maestro caching and a retry-backed install using `actions/cache` and `nick-fields/retry` so `maestro` is installed when the cache misses.
- Added an `Enable KVM group perms` step that writes a udev rule and reloads triggers to help the Android emulator start reliably on Linux runners.
- Kept APK build verification and re-enabled the `reactivecircus/android-emulator-runner@v2` step to install the APK and run `maestro test`, and restored uploading of `app/maestro-results.xml` via `actions/upload-artifact`.

### Testing

- No automated tests were executed locally because this change targets the GitHub Actions workflow and will be validated when the workflow runs on the PR.
- The CI run is expected to produce a JUnit-format `maestro` output uploaded as `app/maestro-results.xml`, and any failures will be visible in the workflow logs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69680dbd4854832d959516aaf48a5ee3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Re-enabled Android emulator end-to-end testing so full E2E runs execute and results are uploaded.

* **Chores**
  * Improved mobile CI reliability: conditional installer with retries, cache-aware installs, Android SDK/AVD preparation, virtualization permission setup, Gradle cache trimming, extended emulator timeouts and resource settings, and retained artifact uploads.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->