### PR TITLE
Patch react-native-screens header subview type for codegen

### DIFF
--- a/patches/react-native-screens+4.15.3.patch
+++ b/patches/react-native-screens+4.15.3.patch
@@ -1,0 +1,16 @@
+diff --git a/node_modules/react-native-screens/src/fabric/ScreenStackHeaderSubviewNativeComponent.ts b/node_modules/react-native-screens/src/fabric/ScreenStackHeaderSubviewNativeComponent.ts
+index f7776a8..89e08cf 100644
+--- a/node_modules/react-native-screens/src/fabric/ScreenStackHeaderSubviewNativeComponent.ts
++++ b/node_modules/react-native-screens/src/fabric/ScreenStackHeaderSubviewNativeComponent.ts
+@@ -14,7 +14,10 @@ export type HeaderSubviewTypes =
+   | 'searchBar';
+ 
+ export interface NativeProps extends ViewProps {
+-  type?: WithDefault<HeaderSubviewTypes, 'left'>;
++  type?: WithDefault<
++    'back' | 'right' | 'left' | 'title' | 'center' | 'searchBar',
++    'left'
++  >;
+ }
+ 
+ export default codegenNativeComponent<NativeProps>(


### PR DESCRIPTION
### Motivation
- Fix a React Native codegen failure where the `type` prop in `react-native-screens` was resolved as `undefined` during bundling after an upgrade, by avoiding the `WithDefault<HeaderSubviewTypes, 'left'>` alias that the parser couldn't properly resolve.

### Description
- Add a patch file `patches/react-native-screens+4.15.3.patch` which updates `node_modules/react-native-screens/src/fabric/ScreenStackHeaderSubviewNativeComponent.ts` to inline the string-literal union in the `WithDefault` type (`type?: WithDefault<'back' | 'right' | 'left' | 'title' | 'center' | 'searchBar','left'>`) so the codegen parser can determine the prop type.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696817004cb4832d8bf7dcaf2430c536)