### PR TITLE
Fix react-native-gesture-handler Android dependency resolution

### DIFF
--- a/patches/react-native-gesture-handler+2.30.0.patch
+++ b/patches/react-native-gesture-handler+2.30.0.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/react-native-gesture-handler/android/build.gradle b/node_modules/react-native-gesture-handler/android/build.gradle
+--- a/node_modules/react-native-gesture-handler/android/build.gradle
++++ b/node_modules/react-native-gesture-handler/android/build.gradle
+@@ -178,8 +178,10 @@
+ }
+ 
+ def kotlin_version = safeExtGet('kotlinVersion', project.properties['RNGH_kotlinVersion'])
++def reactNativeDependency = safeExtGet("reactNativeDependency", "com.facebook.react:react-android")
++
+ dependencies {
+-    implementation 'com.facebook.react:react-native:+' // from node_modules
++    implementation reactNativeDependency
+ 
+ 
+     if (shouldUseCommonInterfaceFromReanimated()) {


### PR DESCRIPTION
### Motivation
- The Android Kotlin compile was failing due to mismatched React dependency references in the gesture-handler library; the intent is to make the native dependency resolution explicit and configurable so the library uses the proper `react-android` artifact for the app's React version.

### Description
- Add a patch `patches/react-native-gesture-handler+2.30.0.patch` that updates `node_modules/react-native-gesture-handler/android/build.gradle` to use a `reactNativeDependency` Gradle property with a fallback of `com.facebook.react:react-android` instead of hardcoding `implementation 'com.facebook.react:react-native:+'`.
- Keep the dependency configurable via `safeExtGet("reactNativeDependency", "com.facebook.react:react-android")` so projects can override the artifact if needed.

### Testing
- No automated tests were run for this patch-only change; validation recommended: run `yarn install` and perform an Android build (`yarn android` / Gradle assemble) to confirm the Kotlin compile error is resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696816c23344832d8f78988733995b8e)