### PR TITLE
Hide unregistered docs from DocumentSelectorForProvingScreen

### DIFF
--- a/app/src/screens/verification/DocumentSelectorForProvingScreen.tsx
+++ b/app/src/screens/verification/DocumentSelectorForProvingScreen.tsx
@@ -219,6 +219,7 @@ const DocumentSelectorForProvingScreen: React.FC = () => {
 
   const documents = useMemo(() => {
     return documentCatalog.documents
+      .filter(metadata => metadata.isRegistered)
       .map(metadata => {
         const docData = allDocuments[metadata.id];
         const baseState = determineDocumentState(metadata, docData?.data);

--- a/app/src/screens/verification/ProvingScreenRouter.tsx
+++ b/app/src/screens/verification/ProvingScreenRouter.tsx
@@ -89,7 +89,9 @@ const ProvingScreenRouter: React.FC = () => {
       // Determine if we should skip the selector
       const shouldSkip =
         skipDocumentSelector ||
-        (skipDocumentSelectorIfSingle && validCount === 1);
+        (skipDocumentSelectorIfSingle &&
+          validCount === 1 &&
+          firstValidDoc.isRegistered);
 
       if (shouldSkip) {
         // Auto-select and navigate to Prove


### PR DESCRIPTION
### Description

- Hides unregistered docs from the selector in DocumentSelectorForProvingScreen
- Update `shouldSkip` condition to include registration check.

### Tested

Manually tested the following cases,
- Have a total of one document which has failed registration - should show no registered documents
- Have a total of two failed documents - Should show no registered documents
- Have a total of 2 docs with 1 not registered - DocumentSelectorForProvingScreen should show only registered document

### How to QA

1. Delete all documents
2. Register a mock document, exit when it asks for fingerprint/faceId
3. Open a proof request through deeplink
4. App should show "no documents found" instead of "Are you new here" screen
5. Register another mock document completely
6. Open a proof request through deeplink
7. The document selector should show only the selected document.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Document selection interface now displays only registered documents instead of all available documents
  * Auto-progression to the proving step now requires selected documents to have registered status

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->