### PR TITLE
skip reselect by default

### DIFF
--- a/app/src/screens/documents/scanning/DocumentNFCMethodSelectionScreen.tsx
+++ b/app/src/screens/documents/scanning/DocumentNFCMethodSelectionScreen.tsx
@@ -29,6 +29,7 @@ type NFCParams = {
   skipCA?: boolean;
   extendedMode?: boolean;
   usePacePolling?: boolean;
+  reselect?: boolean;
 };
 
 const NFC_METHODS = [
@@ -40,11 +41,11 @@ const NFC_METHODS = [
     params: {},
   },
   {
-    key: 'skipReselect',
-    label: 'Skip Re-select',
-    description: 'Skip the re-select step after the NFC scan.',
+    key: 'reselect',
+    label: 'Reselect',
+    description: 'Enable the re-select step after the NFC scan.',
     platform: ['android'],
-    params: { skipReselect: true },
+    params: { reselect: true },
   },
   {
     key: 'usePacePolling',

--- a/app/src/screens/documents/scanning/DocumentNFCScanScreen.tsx
+++ b/app/src/screens/documents/scanning/DocumentNFCScanScreen.tsx
@@ -85,7 +85,7 @@ const emitter =
     : null;
 
 type DocumentNFCScanRouteParams = {
-  skipReselect?: boolean;
+  reselect?: boolean;
   usePacePolling?: boolean;
   canNumber?: string;
   useCan?: boolean;
@@ -260,7 +260,17 @@ const DocumentNFCScanScreen: React.FC = () => {
     }
   };
 
+  const shouldReselect = (): boolean => {
+    const { reselect } = route.params ?? {};
+    const enabledCountries = ['IDFRA'];
+    const shouldReselectByCountry = enabledCountries.some(
+      country => documentType + countryCode === country,
+    );
+    return reselect !== undefined ? reselect : shouldReselectByCountry;
+  };
+
   const isPacePolling = usePacePolling();
+  const isReselect = shouldReselect();
 
   const onVerifyPress = useCallback(async () => {
     buttonTap();
@@ -324,14 +334,8 @@ const DocumentNFCScanScreen: React.FC = () => {
       }, 30000);
 
       try {
-        const {
-          canNumber,
-          useCan,
-          skipPACE,
-          skipCA,
-          extendedMode,
-          skipReselect,
-        } = route.params ?? {};
+        const { canNumber, useCan, skipPACE, skipCA, extendedMode } =
+          route.params ?? {};
 
         await configureNfcAnalytics();
         const scanResponse = await scan({
@@ -345,7 +349,7 @@ const DocumentNFCScanScreen: React.FC = () => {
           extendedMode,
           usePacePolling: isPacePolling,
           sessionId: sessionIdRef.current,
-          skipReselect,
+          skipReselect: !isReselect,
         });
 
         // Check if scan was cancelled by timeout
@@ -449,6 +453,7 @@ const DocumentNFCScanScreen: React.FC = () => {
     dateOfBirth,
     dateOfExpiry,
     isPacePolling,
+    isReselect,
     navigation,
     openErrorModal,
     trackEvent,


### PR DESCRIPTION
### Description

Defaults to not reselecting in the NFC step. Changed `skip-reselect` to `reselect` in DocumentNFCMethodSelection screen.

### How to QA

- Default NFC scan should work with most passports.
- If failed, enable `Reselect` option from `DocumentNFCMethodSelection` screen and scan again.

