### PR TITLE
fix: implemented fix for skipped nfcScanner tests on ios and android

### DIFF
--- a/app/tests/src/integrations/nfc/nfcScanner.test.ts
+++ b/app/tests/src/integrations/nfc/nfcScanner.test.ts
@@ -43,12 +43,15 @@ const getFreshParseScanResponse = () => {
   jest.resetModules();
   jest.doMock('react-native', () => ({
     Platform: {
-      get OS() { return global.mockPlatformOS; },
+      get OS() {
+        return global.mockPlatformOS;
+      },
       Version: 14,
-      select: (obj: Record<string, unknown>) => obj[global.mockPlatformOS] || obj.default,
+      select: (obj: Record<string, unknown>) =>
+        obj[global.mockPlatformOS] || obj.default,
     },
   }));
-  return require('@/integrations/nfc/nfcScanner').parseScanResponse; // eslint-disable-line
+  return require('@/integrations/nfc/nfcScanner').parseScanResponse;
 };
 
 describe('parseScanResponse', () => {


### PR DESCRIPTION
### Description

Fixes the skipped NFC scanner tests by resetting the jest cache on tests that require different operating system environment.

### Tested

Tests failed before, they pass after.

### How to QA

Run the tests `yarn jest:run tests/src/integrations/nfc/nfcScanner.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens NFC scanner test coverage and makes tests platform-agnostic.
> 
> - Introduces getter-based `Platform` mock and `getFreshParseScanResponse` to reset module cache for per-test iOS/Android evaluation in `nfcScanner.test.ts`
> - Unskips and updates `parseScanResponse` tests for iOS and Android; verifies parsed fields, data group hashes, and document metadata
> - Adds negative tests for malformed payloads, missing required fields, and invalid hex in `dataGroupHashes`
> - Adds `scan` tests (iOS) to assert `PassportReader.scanPassport` is called with correct parameters, defaults, and analytics configuration
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef0d826247e56a0b88d5ceeb0f2a34fe5b552e61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved cross-platform test behavior by dynamically switching mocked platform OS per test, allowing iOS and Android paths to be exercised in the same suite.
  * Enabled previously skipped tests and added per-test fresh imports to ensure correct platform-specific behavior for malformed or missing input cases.
  * Removed an extraneous console output from expectations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->