### PR TITLE
add option for closed testing

### DIFF
--- a/.github/workflows/mobile-deploy-auto.yml
+++ b/.github/workflows/mobile-deploy-auto.yml
@@ -46,6 +46,13 @@ jobs:
             exit 0
           fi
 
+          # Check for deploy:closed-testing label
+          if [[ "$labels" =~ deploy:closed-testing ]]; then
+            echo "deployment_track=closed" >> $GITHUB_OUTPUT
+            echo "🧪 Deployment track: closed testing (alpha)"
+            exit 0
+          fi
+
           # Determine deployment track based on target branch
           if [[ "${{ github.base_ref }}" == "main" ]]; then
             echo "deployment_track=production" >> $GITHUB_OUTPUT

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -6,8 +6,20 @@ name: Mobile Deploy
 #
 # === PR LABELS ===
 # - deploy:skip: Skip deployment entirely (no version bump, no builds)
+# - deploy:closed-testing: Deploy to closed testing/alpha track (Android)
 # - version:major/minor/patch: Control version bump type
 # - deploy:ios/deploy:android: Build only one platform
+#
+# === DEPLOYMENT TRACKS ===
+# - internal: Limited internal testing (up to 100 testers)
+#   * Android: Google Play Internal Testing track
+#   * iOS: TestFlight internal distribution
+# - closed: Closed testing/alpha track (larger pre-release testing group)
+#   * Android: Google Play Alpha track (closed testing with email list or Google Group)
+#   * iOS: TestFlight external distribution (uses same TestFlight as internal)
+# - production: Production release to app stores
+#   * Android: Google Play Production track
+#   * iOS: App Store (requires manual submission)
 #
 # === WORKFLOW LOGIC ===
 # Build Branch: Always builds from the branch that triggered the workflow
@@ -75,12 +87,13 @@ on:
         type: boolean
         default: false
       deployment_track:
-        description: "Deployment track (internal/production)"
+        description: "Deployment track (internal/closed/production)"
         required: false
         type: choice
         default: "internal"
         options:
           - internal
+          - closed
           - production
       version_bump:
         description: "Version bump type"

--- a/app/fastlane/Fastfile
+++ b/app/fastlane/Fastfile
@@ -299,7 +299,14 @@ platform :android do
     end
 
     # Map deployment track to Play Store track
-    play_store_track = deployment_track == "production" ? "production" : "internal"
+    play_store_track = case deployment_track
+    when "production"
+      "production"
+    when "closed"
+      "alpha"
+    else
+      "internal"
+    end
 
     # Build and deploy
     upload_android_build(track: play_store_track, test_mode: test_mode, deployment_track: deployment_track, version_bump: version_bump)


### PR DESCRIPTION
### Description

_A brief description of the changes, what and how is being changed._

### Tested

_Explain how the change has been tested (for example by manual testing, unit tests etc) or why it's not necessary (for example version bump)._

### How to QA

_How can the change be tested in a repeatable manner?_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds support for a new pre-release track and aligns deployment routing.
> 
> - **New track:** `closed` (closed testing/alpha) selectable via `deploy:closed-testing` label or `deployment_track` input
> - **Android mapping:** `deployment_track=closed` → Play Store `alpha` track in `Fastfile`
> - **Workflow updates:** `mobile-deploy.yml` inputs and docs expanded to include `closed`; auto workflow detects the new label and sets `deployment_track` accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad331ffc3884c270b1f01c8687bde4a0fa02c49c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- Extended deployment track options to support a new "closed" track for mobile releases.
- Updated mobile build automation to route the closed deployment track to alpha distribution.
- Enhanced release automation with conditional logic to detect and process specific deployment labels.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->