### PR TITLE
Include app version in release calendar PR titles

### DIFF
--- a/.github/workflows/release-calendar.yml
+++ b/.github/workflows/release-calendar.yml
@@ -159,17 +159,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python - <<'PY'
+          python - <<PY >> "$GITHUB_OUTPUT"
           import json
-          import os
           import pathlib
 
           package_json = pathlib.Path("app/package.json")
           version = json.loads(package_json.read_text())["version"]
           print(f"app_version={version}")
-          output_path = os.environ["GITHUB_OUTPUT"]
-          with open(output_path, "a", encoding="utf-8") as output:
-            output.write(f"app_version={version}\n")
           PY
 
       - name: Create dev to staging release PR
@@ -345,17 +341,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python - <<'PY'
+          python - <<PY >> "$GITHUB_OUTPUT"
           import json
-          import os
           import pathlib
 
           package_json = pathlib.Path("app/package.json")
           version = json.loads(package_json.read_text())["version"]
           print(f"app_version={version}")
-          output_path = os.environ["GITHUB_OUTPUT"]
-          with open(output_path, "a", encoding="utf-8") as output:
-            output.write(f"app_version={version}\n")
           PY
 
       - name: Create staging to main release PR


### PR DESCRIPTION
### Motivation
- Improve release PR clarity by including the mobile app version from `app/package.json` in auto-created release PR titles for both dev→staging and staging→main jobs.
- Make it easier for reviewers and stakeholders to identify which app version is being promoted by the automated release calendar workflow.

### Description
- Added a `Read app version` step that reads `app/package.json` and writes `app_version` to the workflow outputs using a small Python snippet in `.github/workflows/release-calendar.yml`.
- Exposed the read value to subsequent steps via `APP_VERSION` and updated the PR title in the dev→staging job to `Release to Staging v${APP_VERSION} - ${PR_DATE}`.
- Updated the staging→main job to similarly include `v${APP_VERSION}` in the production PR title.
- Modified file: `.github/workflows/release-calendar.yml`.

### Testing
- No automated tests were run because this is a workflow-only change and requires CI execution to validate; change was committed locally and reviewed by diff.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69716edcef90832daa6992fbbdac8cc9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release workflow now reads and exposes the application version and propagates it into release PR environments for dev→staging, staging→main, and production flows.
  * PR titles updated to include the app version (e.g., "Release to Staging vX - DATE") for clearer visibility, applied only when a release PR does not already exist.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->