### PR TITLE
chore: increase build timeout to 12 hours in circuits-build.yml

### DIFF
--- a/.github/workflows/circuits-build.yml
+++ b/.github/workflows/circuits-build.yml
@@ -33,6 +33,7 @@ concurrency:
 jobs:
   build:
     runs-on: ["128ram"]
+    timeout-minutes: 720 # 12 hours
     permissions:
       contents: read
       actions: read


### PR DESCRIPTION
### Description

Increase build timeout to 12 hours in circuits-build.yml

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> In `.github/workflows/circuits-build.yml`:
> 
> - Adds `timeout-minutes: 720` to the `build` job to permit longer runs; no other changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a0bc083941a4aecac1bafe2ded7c9beaad78220. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build process workflow configuration to improve job execution timing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->