### PR TITLE
chore: increase build timeout to 12 hours in circuits-build.yml

### DIFF
--- a/.github/workflows/circuits-build.yml
+++ b/.github/workflows/circuits-build.yml
@@ -33,6 +33,7 @@ concurrency:
 jobs:
   build:
     runs-on: ["128ram"]
+    timeout-minutes: 720 # 12 hours
     permissions:
       contents: read
       actions: read


### PR DESCRIPTION
### Description

Increase build timeout to 12 hours in circuits-build.yml

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increases the GitHub Actions job timeout to handle longer circuit builds.
> 
> - Sets `timeout-minutes: 720` (12 hours) for the `build` job in `.github/workflows/circuits-build.yml`
> - No changes to build steps, dependencies, or circuit logic
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cc77ee38ddd44c1beb96a71a24d674863f1cbe4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended build timeout to 12 hours to accommodate longer build processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->