### PR TITLE
chore: self UUID namespace as a const

### DIFF
--- a/app/env.ts
+++ b/app/env.ts
@@ -27,7 +27,6 @@ export const IS_TEST_BUILD = process.env.IS_TEST_BUILD === 'true';
 
 export const MIXPANEL_NFC_PROJECT_TOKEN = undefined;
 export const SEGMENT_KEY = process.env.SEGMENT_KEY;
-export const SELF_UUID_NAMESPACE = process.env.SELF_UUID_NAMESPACE;
 export const SENTRY_DSN = process.env.SENTRY_DSN;
 export const SUMSUB_TEE_URL =
   process.env.SUMSUB_TEE_URL || 'http://localhost:8080';

--- a/app/src/screens/kyc/KycSuccessScreen.tsx
+++ b/app/src/screens/kyc/KycSuccessScreen.tsx
@@ -25,9 +25,9 @@ import { buttonTap } from '@/integrations/haptics';
 import type { RootStackParamList } from '@/navigation';
 import {
   getFCMToken,
-  getSelfUuidNamespace,
   registerDeviceToken,
   requestNotificationPermission,
+  SELF_UUID_NAMESPACE,
 } from '@/services/notifications/notificationService';
 import { useSettingStore } from '@/stores/settingStore';
 
@@ -58,7 +58,7 @@ const KycSuccessScreen: React.FC<KycSuccessRouteParams> = ({
         setFcmToken(token);
         trackEvent(ProofEvents.FCM_TOKEN_STORED);
 
-        const sessionId = uuidv5(userId, getSelfUuidNamespace());
+        const sessionId = uuidv5(userId, SELF_UUID_NAMESPACE);
         await registerDeviceToken(sessionId, token);
       }
     }

--- a/app/src/services/notifications/notificationService.ts
+++ b/app/src/services/notifications/notificationService.ts
@@ -3,7 +3,6 @@
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
 import { PermissionsAndroid, Platform } from 'react-native';
-import { SELF_UUID_NAMESPACE } from '@env';
 import type { FirebaseMessagingTypes } from '@react-native-firebase/messaging';
 import messaging from '@react-native-firebase/messaging';
 
@@ -14,6 +13,8 @@ import {
   getStateMessage,
 } from '@/services/notifications/notificationService.shared';
 import { useSettingStore } from '@/stores/settingStore';
+
+export const SELF_UUID_NAMESPACE = '00000000-0000-8000-8000-531f00000000';
 
 export async function getFCMToken(): Promise<string | null> {
   try {
@@ -36,10 +37,6 @@ const log = (...args: unknown[]) => {
 const error = (...args: unknown[]) => {
   if (!isTestEnv) console.error(...args);
 };
-
-export function getSelfUuidNamespace(): string {
-  return SELF_UUID_NAMESPACE ?? '';
-}
 
 export { getStateMessage };
 

--- a/app/tests/src/screens/kyc/KycSuccessScreen.test.tsx
+++ b/app/tests/src/screens/kyc/KycSuccessScreen.test.tsx
@@ -87,10 +87,10 @@ jest.mock('@/integrations/haptics', () => ({
 }));
 
 jest.mock('@/services/notifications/notificationService', () => ({
+  ...jest.requireActual('@/services/notifications/notificationService'),
   requestNotificationPermission: jest.fn(),
   getFCMToken: jest.fn(),
   registerDeviceToken: jest.fn(),
-  getSelfUuidNamespace: jest.fn(() => '1eebc0f5-eee9-45a4-9474-a0d103b9f20c'),
 }));
 
 jest.mock('@/config/sentry', () => ({
@@ -118,8 +118,6 @@ const mockUseNavigation = useNavigation as jest.MockedFunction<
 // Import mocked modules
 const { useSelfClient } = jest.requireMock('@selfxyz/mobile-sdk-alpha');
 const { useSettingStore } = jest.requireMock('@/stores/settingStore');
-
-const MOCK_SELF_UUID_NAMESPACE = '1eebc0f5-eee9-45a4-9474-a0d103b9f20c';
 
 describe('KycSuccessScreen', () => {
   const mockNavigate = jest.fn();
@@ -204,7 +202,7 @@ describe('KycSuccessScreen', () => {
     await waitFor(() => {
       // Verify device token was registered with deterministic session ID
       expect(notificationService.registerDeviceToken).toHaveBeenCalledWith(
-        uuidv5(mockUserId, MOCK_SELF_UUID_NAMESPACE),
+        uuidv5(mockUserId, notificationService.SELF_UUID_NAMESPACE),
         mockFcmToken,
       );
     });


### PR DESCRIPTION
### Description

This PR removes Self UUID namespace env var in favor of having it as a const.

### Tested

Ran tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated UUID namespace value management by centralizing the constant definition within the notifications service, replacing function-based access patterns with direct constant references throughout the application.

* **Tests**
  * Updated test mocks to rely on actual module exports instead of hand-written mock definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->