### PR TITLE
SELF-1959: reset isDecoding on OCR failure

### DIFF
--- a/app/android/app/src/main/java/com/proofofpassportapp/ui/CameraMLKitFragment.kt
+++ b/app/android/app/src/main/java/com/proofofpassportapp/ui/CameraMLKitFragment.kt
@@ -263,7 +263,6 @@ class CameraMLKitFragment(cameraMLKitCallback: CameraMLKitCallback) : CameraFrag
                     callback = mrzListener
                 )
             } catch (e: Exception) {
-                android.util.Log.e(TAG, "Error processing OCR results", e)
                 mrzListener.onFailure(e, timeRequired)
             }
         }


### PR DESCRIPTION
### Description

_A brief description of the changes, what and how is being changed._

### Tested

_Explain how the change has been tested (for example by manual testing, unit tests etc) or why it's not necessary (for example version bump)._

### How to QA

_How can the change be tested in a repeatable manner?_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OCR error handling so the app no longer crashes or freezes if document scanning fails. The camera remains responsive, the scan gracefully reports failure with timing info for diagnostics, and normal operation resumes without requiring a restart.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->