### PR TITLE
Regenerate Sumsub patch-package patch

### DIFF
--- a/patches/@sumsub+react-native-mobilesdk-module+1.40.2.patch
+++ b/patches/@sumsub+react-native-mobilesdk-module+1.40.2.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@sumsub/react-native-mobilesdk-module/android/build.gradle b/node_modules/@sumsub/react-native-mobilesdk-module/android/build.gradle
-index a1b2c3d..e4f5g6h 100644
+index 8796953..b00f0d4 100644
 --- a/node_modules/@sumsub/react-native-mobilesdk-module/android/build.gradle
 +++ b/node_modules/@sumsub/react-native-mobilesdk-module/android/build.gradle
 @@ -77,7 +77,7 @@ dependencies {


### PR DESCRIPTION
### Motivation

- Ensure the Sumsub patch is tool-generated and parseable so `patch-package` can apply it reliably during install. 

### Description

- Regenerated `patches/@sumsub+react-native-mobilesdk-module+1.40.2.patch` using `patch-package` so the diff header is a valid tool-generated header. 
- The patch is scoped to a single functional change: uncommenting the Fisherman dependency line in `node_modules/@sumsub/react-native-mobilesdk-module/android/build.gradle` (enable `idensic-mobile-sdk-fisherman`). 
- No other source files or behavior changes were introduced beyond the regenerated patch file. 

### Testing

- Ran `yarn install` at the repo root and it completed with warnings only. 
- Created the patch with `yarn exec patch-package @sumsub/react-native-mobilesdk-module --patch-dir patches` which produced `patches/@sumsub+react-native-mobilesdk-module+1.40.2.patch`. 
- Verified `yarn run postinstall` (which executes the repository `postinstall` script that runs `patch-package`) applied patches to `root`, `app`, and `contracts` workspaces with no parse/apply errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698ce556e374832d80e0a32df887584e)