### PR TITLE
fix: handle malformed KYC payload in card background selector

### DIFF
--- a/app/src/utils/cardBackgroundSelector.ts
+++ b/app/src/utils/cardBackgroundSelector.ts
@@ -29,10 +29,14 @@ export function getBackgroundIndex(document: IDDocument): number {
     hashInput = `${fields?.aadhaarLast4Digits}|${fields?.name}|${fields?.dob}`;
   } else if (isKycDocument(document)) {
     // For KYC: deserialize applicant info and use idNumber + fullName + dob
-    const applicantInfo = deserializeApplicantInfo(
-      document.serializedApplicantInfo,
-    );
-    hashInput = `${applicantInfo.idNumber}|${applicantInfo.fullName}|${applicantInfo.dob}`;
+    try {
+      const applicantInfo = deserializeApplicantInfo(
+        document.serializedApplicantInfo,
+      );
+      hashInput = `${applicantInfo.idNumber}|${applicantInfo.fullName}|${applicantInfo.dob}`;
+    } catch {
+      hashInput = document.serializedApplicantInfo ?? '';
+    }
   } else {
     // Fallback for unknown document types
     hashInput = '';

--- a/app/tests/src/utils/cardBackgroundSelector.test.ts
+++ b/app/tests/src/utils/cardBackgroundSelector.test.ts
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2025 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import type { IDDocument } from '@selfxyz/common';
+import { serializeKycData } from '@selfxyz/common';
+
+import { getBackgroundIndex } from '@/utils/cardBackgroundSelector';
+
+const BACKGROUND_COUNT = 6;
+
+function createKycDocument(serializedApplicantInfo: string): IDDocument {
+  return {
+    documentCategory: 'kyc',
+    documentType: 'drivers_licence',
+    mock: false,
+    serializedApplicantInfo,
+    signature: '',
+    pubkey: [],
+  };
+}
+
+describe('getBackgroundIndex', () => {
+  it('returns a deterministic index for a valid KYC payload', () => {
+    const serializedData = serializeKycData({
+      country: 'USA',
+      idType: 'passport',
+      idNumber: 'P1234567',
+      issuanceDate: '2020-01-01',
+      expiryDate: '2030-01-01',
+      fullName: 'Jane Doe',
+      dob: '1990-01-01',
+      photoHash: 'photohash',
+      phoneNumber: '+1234567890',
+      gender: 'F',
+      address: '123 Main St',
+    });
+    const serializedApplicantInfo = Buffer.from(
+      serializedData,
+      'utf-8',
+    ).toString('base64');
+
+    const document = createKycDocument(serializedApplicantInfo);
+
+    const firstIndex = getBackgroundIndex(document);
+    const secondIndex = getBackgroundIndex(document);
+
+    expect(firstIndex).toBe(secondIndex);
+    expect(firstIndex).toBeGreaterThanOrEqual(1);
+    expect(firstIndex).toBeLessThanOrEqual(BACKGROUND_COUNT);
+  });
+
+  it('does not throw for malformed KYC payload and still returns a valid index', () => {
+    const document = createKycDocument(undefined as unknown as string);
+
+    expect(() => getBackgroundIndex(document)).not.toThrow();
+
+    const index = getBackgroundIndex(document);
+    expect(index).toBeGreaterThanOrEqual(1);
+    expect(index).toBeLessThanOrEqual(BACKGROUND_COUNT);
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent `deserializeApplicantInfo` from throwing inside `getBackgroundIndex` for KYC documents so a malformed/invalid KYC payload cannot crash background selection. 
- Ensure the function always returns a stable background index (1-6) even when applicant deserialization fails.

### Description
- Wrapped the `deserializeApplicantInfo(document.serializedApplicantInfo)` call in a `try/catch` inside the `isKycDocument(document)` branch and on error fall back to `document.serializedApplicantInfo ?? ''` as a non-throwing hash input in `getBackgroundIndex` (`app/src/utils/cardBackgroundSelector.ts`).
- Added unit tests that exercise `getBackgroundIndex` for a valid KYC payload (deterministic index) and for a malformed KYC payload (does not throw and returns an index within `[1, BACKGROUND_COUNT]`) in `app/tests/src/utils/cardBackgroundSelector.test.ts`.

### Testing
- Ran lint on the selector and test files with `yarn workspace @selfxyz/mobile-app eslint src/utils/cardBackgroundSelector.ts tests/src/utils/cardBackgroundSelector.test.ts` and fixed formatting warnings.
- Ran the focused unit tests with `yarn workspace @selfxyz/mobile-app jest:run app/tests/src/utils/cardBackgroundSelector.test.ts` and all tests passed (2 tests, both green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698ce5550074832da3c518e9fea65daa)