### PR TITLE
Update mobile-e2e.yml: Reenable e2e-ios

### DIFF
--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -307,7 +307,6 @@ jobs:
     timeout-minutes: 120
     # runs-on: macos-latest-large
     runs-on: namespace-profile-apple-silicon-6cpu
-    if: false
     concurrency:
       group: ${{ github.workflow }}-ios-${{ github.ref }}
       cancel-in-progress: true


### PR DESCRIPTION
It had been disabled while testing Android e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Re-enabled iOS end-to-end testing in the CI/CD pipeline to ensure tests run under normal workflow conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->