### PR TITLE
fix(app): rewrite tsup __require to require for Metro bundling

### DIFF
--- a/app/babel.config.cjs
+++ b/app/babel.config.cjs
@@ -2,9 +2,31 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
+// tsup wraps require() as __require() in ESM builds for externalized modules.
+// Metro's dependency collector only recognizes standard require() calls, so __require()
+// calls are invisible to bundling. This plugin converts them back to require() so Metro
+// can resolve and include the assets (e.g. .lottie files from the SDK dist).
+function rewriteDunderRequire() {
+  return {
+    visitor: {
+      CallExpression(path) {
+        if (
+          path.node.callee.type === 'Identifier' &&
+          path.node.callee.name === '__require' &&
+          path.node.arguments.length === 1 &&
+          path.node.arguments[0].type === 'StringLiteral'
+        ) {
+          path.node.callee.name = 'require';
+        }
+      },
+    },
+  };
+}
+
 module.exports = {
   presets: ['module:@react-native/babel-preset'],
   plugins: [
+    rewriteDunderRequire,
     [
       'module-resolver',
       {


### PR DESCRIPTION
## Summary
- Adds a Babel plugin that converts `__require(stringLiteral)` → `require(stringLiteral)` before Metro's dependency collection pass
- Fixes "Unknown named module" runtime errors for `.lottie` assets loaded from the SDK's ESM dist

## Problem
After `9406bacd` converted SDK animations from `.json` to `.lottie`, the SDK's tsup ESM build externalizes `.lottie` requires and wraps them as `__require()`. Metro's static dependency collector doesn't recognize `__require()`, so these assets are never added to the bundle graph. At runtime, Metro's `require` fails with "Unknown named module" because the module was never registered.

## Fix
A small Babel visitor plugin runs early in the transform pipeline (before Metro's `collectDependencies`), rewriting `__require("...")` → `require("...")`. This makes the dependency visible to Metro, which then resolves it through the existing custom `.lottie` resolver in `metro.config.cjs`.

## Test plan
- [ ] `npx react-native start --reset-cache` — Metro starts without errors
- [ ] Navigate to a screen using `ConfirmIdentificationScreen` — lottie animation loads
- [ ] Navigate to NFC scan screen — passport_verify.lottie loads
- [ ] Navigate to camera scan screen — passport_scan.lottie loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to handle code transformations during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->