### PR TITLE
Add composite dependencySubstitution for kmp shared module

### DIFF
--- a/packages/rn-sdk-test-app/android/settings.gradle
+++ b/packages/rn-sdk-test-app/android/settings.gradle
@@ -6,4 +6,8 @@ extensions.configure(com.facebook.react.ReactSettingsExtension){ ex ->
 rootProject.name = 'SelfRNSDKTestApp'
 include ':app'
 includeBuild('../../../node_modules/@react-native/gradle-plugin')
-includeBuild('../../kmp-sdk')
+includeBuild('../../kmp-sdk') {
+  dependencySubstitution {
+    substitute module('xyz.self.sdk:shared') using project(':shared')
+  }
+}


### PR DESCRIPTION
### Motivation
- The composite build include for the local `kmp-sdk` build must map the published Maven coordinate `xyz.self.sdk:shared` to the local `:shared` project because the included build root is named `kmp-sdk`, not the published group artifact. 
- With `mavenLocal()` removed, Gradle cannot resolve `xyz.self.sdk:shared:0.1.0` from the included build without an explicit `dependencySubstitution` block.

### Description
- Updated `packages/rn-sdk-test-app/android/settings.gradle` to wrap the `includeBuild('../../kmp-sdk')` call and add a `dependencySubstitution` block. 
- Added `substitute module('xyz.self.sdk:shared') using project(':shared')` so the composite build resolves the `shared` artifact from the local included build.

### Testing
- Ran `./gradlew -q help` in `packages/rn-sdk-test-app/android`, which failed in this environment with `Unsupported class file major version 69` due to local Java/Gradle compatibility and not due to the settings change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab31729dcc832d8e7d5f870aba6868)