### PR TITLE
Tighten native consolidation contract gates after MRZ unification

### DIFF
--- a/app/jest.setup.js
+++ b/app/jest.setup.js
@@ -30,7 +30,6 @@ const NativeModules = {
     scanPassport: jest.fn(),
     trackEvent: jest.fn(),
     flush: jest.fn(),
-    reset: jest.fn(),
   },
   ReactNativeBiometrics: {
     isSensorAvailable: jest.fn().mockResolvedValue({
@@ -960,8 +959,8 @@ jest.mock('react-native-nfc-manager', () => ({
 // Mock react-native-passport-reader
 jest.mock('react-native-passport-reader', () => {
   const mockScanPassport = jest.fn();
-  // Mock the parameter count for scanPassport (iOS native method takes 9 parameters)
-  Object.defineProperty(mockScanPassport, 'length', { value: 9 });
+  // Mock the parameter count for scanPassport (iOS native method takes 10 parameters)
+  Object.defineProperty(mockScanPassport, 'length', { value: 10 });
 
   const mockPassportReader = {
     configure: jest.fn(),
@@ -987,15 +986,14 @@ jest.mock('react-native-passport-reader', () => {
 // Mock @/integrations/nfc/passportReader to properly expose the interface expected by tests
 jest.mock('./src/integrations/nfc/passportReader', () => {
   const mockScanPassport = jest.fn();
-  // Mock the parameter count for scanPassport (iOS native method takes 9 parameters)
-  Object.defineProperty(mockScanPassport, 'length', { value: 9 });
+  // Mock the parameter count for scanPassport (iOS native method takes 10 parameters)
+  Object.defineProperty(mockScanPassport, 'length', { value: 10 });
 
   const mockPassportReader = {
     configure: jest.fn(),
     scanPassport: mockScanPassport,
     trackEvent: jest.fn(),
     flush: jest.fn(),
-    reset: jest.fn(),
   };
 
   return {

--- a/app/tests/src/integrations/nfc/nfcScanner.test.ts
+++ b/app/tests/src/integrations/nfc/nfcScanner.test.ts
@@ -423,9 +423,10 @@ describe('scan', () => {
 
       const { scan: isolatedScan } = require('@/integrations/nfc/nfcScanner');
 
-      await expect(isolatedScan(mockInputs)).rejects.toThrow(
-        'NFC scanning is currently unavailable.',
-      );
+      await expect(isolatedScan(mockInputs)).rejects.toMatchObject({
+        message:
+          'NFC scanning is currently unavailable. Please ensure the app is properly installed.',
+      });
     });
 
     it('should reject with unavailable error when android module is unavailable', async () => {
@@ -442,9 +443,9 @@ describe('scan', () => {
 
       const { scan: isolatedScan } = require('@/integrations/nfc/nfcScanner');
 
-      await expect(isolatedScan(mockInputs)).rejects.toThrow(
-        'NFC scanning is currently unavailable.',
-      );
+      await expect(isolatedScan(mockInputs)).rejects.toMatchObject({
+        message: 'NFC scanning is currently unavailable.',
+      });
     });
   });
 

--- a/app/tests/src/integrations/nfc/passportReader.test.ts
+++ b/app/tests/src/integrations/nfc/passportReader.test.ts
@@ -7,7 +7,7 @@
  * These tests verify critical interface requirements without conditional expects
  */
 
-import { PassportReader } from '@/integrations/nfc/passportReader';
+import { PassportReader, reset } from '@/integrations/nfc/passportReader';
 
 describe('PassportReader Simple Contract Tests', () => {
   describe('Critical Interface Requirements', () => {
@@ -22,15 +22,14 @@ describe('PassportReader Simple Contract Tests', () => {
       expect((PassportReader as any).scan).toBeUndefined();
     });
 
-    it('should have reset method', () => {
-      // This should always exist
-      expect(PassportReader.reset).toBeDefined();
-      expect(typeof PassportReader.reset).toBe('function');
+    it('should export reset as a standalone function', () => {
+      expect(reset).toBeDefined();
+      expect(typeof reset).toBe('function');
     });
 
     it('should have scanPassport with correct parameter count', () => {
-      // scanPassport should take exactly 9 parameters
-      expect(PassportReader.scanPassport.length).toBe(9);
+      // scanPassport should take exactly 10 parameters including sessionId
+      expect(PassportReader.scanPassport.length).toBe(10);
     });
 
     it('should allow configure to be optional', () => {
@@ -92,14 +91,14 @@ describe('PassportReader Simple Contract Tests', () => {
           false,
           false,
           false,
+          'session-id',
         );
       }).not.toThrow(TypeError);
     });
 
-    it('should not crash when calling reset', () => {
-      // Should be callable
+    it('should not crash when calling reset export', () => {
       expect(() => {
-        PassportReader.reset();
+        reset();
       }).not.toThrow(TypeError);
     });
   });
@@ -113,7 +112,7 @@ describe('PassportReader Simple Contract Tests', () => {
 
     it('should have proper method types', () => {
       // All defined methods should be functions
-      expect(typeof PassportReader.reset).toBe('function');
+      expect(typeof reset).toBe('function');
       expect(typeof PassportReader.scanPassport).toBe('function');
 
       // Optional methods should be function or undefined

--- a/specs/projects/sdk/workstreams/native-consolidation/CONTRACTS.md
+++ b/specs/projects/sdk/workstreams/native-consolidation/CONTRACTS.md
@@ -1,7 +1,8 @@
-# Native Consolidation Phase 0 Contract Snapshot (Test-Pinned)
+# Native Consolidation Contract Gates
 
-This document tracks only contracts currently enforced by automated tests.
-Anything not listed here is not yet a hard compatibility gate.
+This file is intentionally narrow.
+It lists only contract facts that are both true in the current code and pinned by automated tests.
+Anything not listed here is not yet a merge gate for native consolidation work.
 
 ## Sources of Truth
 
@@ -11,7 +12,7 @@ Anything not listed here is not yet a hard compatibility gate.
 
 ## Contract: App NFC Scanner Bridge
 
-### Availability Error Messages (hard requirement)
+### Availability Error Messages
 
 | Platform | Condition                                  | Required error message                                                                |
 | -------- | ------------------------------------------ | ------------------------------------------------------------------------------------- |
@@ -32,9 +33,10 @@ Anything not listed here is not yet a hard compatibility gate.
 
 | Surface              | Required contract                                                                                                             |
 | -------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| Required methods     | `scanPassport` must exist and be callable on `PassportReader`; `reset` is a standalone export (not a `PassportReader` method) |
+| Required exports     | `PassportReader` and standalone `reset` export must both exist                                                                 |
+| Required method      | `scanPassport` must exist and be callable on `PassportReader`                                                                  |
 | Forbidden method     | `scan` must be absent on iOS-facing `PassportReader` interface                                                                |
-| `scanPassport` arity | `scanPassport.length === 9`                                                                                                   |
+| `scanPassport` arity | `scanPassport.length === 10` (includes `sessionId`)                                                                           |
 | Optional methods     | `configure`, `trackEvent`, `flush` may be `function` or `undefined`                                                           |
 | Safe optional access | Existence checks for optional methods must not throw                                                                          |
 
@@ -51,7 +53,8 @@ Anything not listed here is not yet a hard compatibility gate.
 
 The following are intentionally excluded from this file until automated tests enforce them:
 
-- App vs SDK MRZ Swift implementation parity details
+- App vs SDK MRZ Swift implementation parity details beyond RN test-app bridge behavior
+- App vs SDK PassportReader native parity tables
 - ObjC shim-level selector parity tables
 - PassportReader native payload key-by-key parity
 - Analytics provider-specific integration behavior


### PR DESCRIPTION
This PR is a follow-up to #1823 and keeps scope limited to contract cleanup.

  It corrects drift between the current PassportReader/NFC test baseline and the real app-facing interface, and trims CONTRACTS.md so it only documents verified, test-enforced facts. It also adds exact platform-specific assertions for NFC module-unavailable error text so both iOS and Android
  behavior are pinned.

  This PR does not change native MRZ code, does not start PassportReader consolidation, and does not alter public native module names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced NFC scan error messages with additional installation guidance for improved troubleshooting.

* **Tests**
  * Updated NFC scanner tests to validate error message content.
  * Refactored PassportReader tests to use standalone reset function export.
  * Adjusted API parameter expectations for scanner operations.

* **Chores**
  * Updated contract documentation and test mock configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->