### PR TITLE
Align KMP callback/result contract with canonical VerificationResult

### DIFF
--- a/packages/kmp-sdk/shared/src/commonMain/kotlin/xyz/self/sdk/api/SelfSdkCallback.kt
+++ b/packages/kmp-sdk/shared/src/commonMain/kotlin/xyz/self/sdk/api/SelfSdkCallback.kt
@@ -100,12 +100,12 @@ internal object VerificationResultSerializer : KSerializer<VerificationResult> {
 
         return VerificationResult(
             success = payload["success"]?.jsonPrimitive?.booleanOrNull ?: false,
-            userId = payload["userId"]?.jsonPrimitive?.contentOrNull,
-            verificationId = payload["verificationId"]?.jsonPrimitive?.contentOrNull,
-            proof = payload["proof"]?.let(::jsonElementToProofString),
-            claims = payload["claims"]?.jsonObject?.mapValues { (_, value) -> value.toKotlinValue() },
+            userId = payload["userId"]?.takeUnless { it is JsonNull }?.jsonPrimitive?.contentOrNull,
+            verificationId = payload["verificationId"]?.takeUnless { it is JsonNull }?.jsonPrimitive?.contentOrNull,
+            proof = payload["proof"]?.takeUnless { it is JsonNull }?.let(::jsonElementToProofString),
+            claims = payload["claims"]?.takeUnless { it is JsonNull }?.jsonObject?.mapValues { (_, value) -> value.toKotlinValue() },
             error =
-                payload["error"]?.let { error ->
+                payload["error"]?.takeUnless { it is JsonNull }?.let { error ->
                     decoder.json.decodeFromJsonElement(SelfSdkError.serializer(), error)
                 },
         )

--- a/packages/kmp-sdk/shared/src/commonMain/kotlin/xyz/self/sdk/api/VerificationResultJson.kt
+++ b/packages/kmp-sdk/shared/src/commonMain/kotlin/xyz/self/sdk/api/VerificationResultJson.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonPrimitive
@@ -26,14 +27,15 @@ internal fun deserializeVerificationResult(json: String): VerificationResult =
 internal fun verificationResultFromLifecycleParams(params: Map<String, JsonElement>): VerificationResult =
     VerificationResult(
         success = true,
-        userId = params["userId"]?.jsonPrimitive?.contentOrNull,
-        verificationId = params["verificationId"]?.jsonPrimitive?.contentOrNull,
-        proof = params["proof"]?.let(::lifecycleProofString),
+        userId = runCatching { params["userId"]?.jsonPrimitive?.contentOrNull }.getOrNull(),
+        verificationId = runCatching { params["verificationId"]?.jsonPrimitive?.contentOrNull }.getOrNull(),
+        proof = params["proof"]?.takeUnless { it is JsonNull }?.let(::lifecycleProofString),
         claims = (params["claims"] as? JsonObject)?.mapValues { (_, value) -> value.toKotlinValue() },
     )
 
 private fun lifecycleProofString(element: JsonElement): String? =
     when (element) {
+        JsonNull -> null
         is JsonObject -> element.toString()
         else -> runCatching { element.jsonPrimitive.contentOrNull }.getOrNull() ?: element.toString()
     }


### PR DESCRIPTION
## Summary
  - Removes non-canonical `type` field from KMP `VerificationResult`, adds `error: SelfSdkError?` for canonical error support
  - Widens `claims` from `Map<String, String>` to `Map<String, Any?>` to match TypeScript `Record<string, unknown>`
  - Android/iOS lifecycle handlers translate legacy flat `{ type }` payloads internally without leaking `type` to the public API
  - Adds JSON round-trip and lifecycle-params serialization tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of edge cases in SDK verification result processing for more reliable API response parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->