### PR TITLE
fix(sdk): store correct metadata for KYC documents in storeDocumentWithDeduplication

### DIFF
--- a/packages/mobile-sdk-alpha/src/documents/utils.ts
+++ b/packages/mobile-sdk-alpha/src/documents/utils.ts
@@ -14,6 +14,7 @@ import {
   calculateContentHash,
   inferDocumentCategory,
   isAadhaarDocument,
+  isKycDocument,
   isMRZDocument,
   parseCertificateSimple,
 } from '@selfxyz/common';
@@ -241,10 +242,15 @@ export async function storeDocumentWithDeduplication(
     id: contentHash,
     documentType: docType,
     documentCategory,
-    data: isMRZDocument(passportData) ? passportData.mrz : (passportData as AadhaarData).qrData || '',
+    data: isMRZDocument(passportData)
+      ? passportData.mrz
+      : isKycDocument(passportData)
+        ? passportData.serializedApplicantInfo
+        : (passportData as AadhaarData).qrData || '',
     mock: passportData.mock || false,
     isRegistered: false,
     hasExpirationDate: documentCategory === 'id_card' || documentCategory === 'passport',
+    ...(isKycDocument(passportData) ? { idType: passportData.documentType } : {}),
   };
 
   catalog.documents.push(metadata);


### PR DESCRIPTION
## Summary

- Fix `storeDocumentWithDeduplication` to correctly handle KYC documents — stores `serializedApplicantInfo` as `metadata.data` and adds `idType`, instead of falling through to the Aadhaar/MRZ branches which produces an empty string
- Without this fix, `ManageDocumentsScreen` crashes when calling `deserializeApplicantInfo(metadata.data)` on KYC documents since `metadata.data` is `''`

## Test plan

- [x] `yarn test` passes (319/319 tests) in `packages/mobile-sdk-alpha`
- [x] `yarn types` passes
- [x] Lint/format clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced KYC document handling with improved data storage and retention.
  * Added document type identification field to KYC document metadata.
  * MRZ document processing behavior remains consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->