### PR TITLE
fix: close Didit SDK modal on 'In Review' status

### DIFF
--- a/packages/webview-app/src/screens/onboarding/ProviderLaunchScreen.tsx
+++ b/packages/webview-app/src/screens/onboarding/ProviderLaunchScreen.tsx
@@ -6,7 +6,7 @@ import type React from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
-import { Button, colors, Description, spacing, Title } from '@selfxyz/euclid';
+import { Button, colors, Description, KycPendingScreen, spacing, Title } from '@selfxyz/euclid';
 import { generateMockDocument, storePassportData } from '@selfxyz/mobile-sdk-alpha/browser';
 
 import { useSelfClient } from '../../providers/SelfClientProvider';
@@ -291,7 +291,16 @@ export const ProviderLaunchScreen: React.FC = () => {
         backgroundColor: colors.white,
       }}
     >
-      {(phase === 'loading' || phase === 'waiting') && (
+      {phase === 'waiting' && (
+        <KycPendingScreen
+          insets={{ top: 0, bottom: 0 }}
+          onCheckBackLater={handleBack}
+          onReceiveLiveUpdates={() => {
+            // TODO: wire up push notifications
+          }}
+        />
+      )}
+      {phase === 'loading' && (
         <div
           style={{
             display: 'flex',
@@ -313,14 +322,7 @@ export const ProviderLaunchScreen: React.FC = () => {
             }}
           />
           <div style={{ marginTop: spacing.md }}>
-            <Title textAlign="center">
-              {phase === 'waiting' ? 'Processing verification...' : 'Loading verification...'}
-            </Title>
-            {phase === 'waiting' && (
-              <Description style={{ marginTop: 8 }}>
-                Your documents are being verified. This may take a moment.
-              </Description>
-            )}
+            <Title textAlign="center">Loading verification...</Title>
           </div>
         </div>
       )}

--- a/packages/webview-app/src/utils/diditProvider.ts
+++ b/packages/webview-app/src/utils/diditProvider.ts
@@ -79,6 +79,8 @@ export async function launchDiditWebSdk(config: DiditLaunchConfig): Promise<() =
   const emitOnce = (result: KycProviderResult, isError: boolean) => {
     if (hasCompleted) return;
     hasCompleted = true;
+    // Close the Didit SDK modal immediately so our UI can take over
+    DiditSdk.shared.close();
     if (isError) {
       config.onError(result);
     } else {


### PR DESCRIPTION
## Summary

- Close the Didit SDK modal immediately when `onComplete` fires, regardless of status
- When Didit returns `'In Review'`, the SDK shows its own "Your submission is under review" screen that blocks the UI indefinitely
- By calling `DiditSdk.shared.close()` before emitting the result, our "Processing verification..." screen takes over and Socket.IO waits for the TEE webhook

## Problem

Didit SDK fires `onComplete({type: 'completed', session: {status: 'In Review'}})` but keeps its modal visible, showing a pending screen. The user sees Didit's UI instead of ours, with no way to proceed until the review completes.

## Fix

Call `DiditSdk.shared.close()` in `emitOnce()` before invoking the complete/error callback. This dismisses the modal so our waiting UI can show while Socket.IO subscribes and waits for the signed attestation.

## Test plan

- [x] Didit modal closes after verification submission
- [ ] "Processing verification..." screen shows while waiting for TEE
- [ ] Attestation arrives via Socket.IO after Didit approves

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated "verification pending" screen and explicit back navigation; separated the loading spinner into its own state and updated loading text to "Loading verification...".
  * Placeholder support added for receiving live updates during pending verification.

* **Bug Fixes**
  * Modal now reliably closes immediately when verification completes or errors, ensuring proper termination of the process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->