### PR TITLE
fix: close Didit modal on completion, show KycPendingScreen

### DIFF
--- a/packages/webview-app/src/screens/onboarding/ProviderLaunchScreen.tsx
+++ b/packages/webview-app/src/screens/onboarding/ProviderLaunchScreen.tsx
@@ -6,7 +6,7 @@ import type React from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
-import { Button, colors, Description, spacing, Title } from '@selfxyz/euclid';
+import { Button, colors, Description, KycPendingScreen, spacing, Title } from '@selfxyz/euclid';
 import { generateMockDocument, storePassportData } from '@selfxyz/mobile-sdk-alpha/browser';
 
 import { useSelfClient } from '../../providers/SelfClientProvider';
@@ -291,7 +291,16 @@ export const ProviderLaunchScreen: React.FC = () => {
         backgroundColor: colors.white,
       }}
     >
-      {(phase === 'loading' || phase === 'waiting') && (
+      {phase === 'waiting' && (
+        <KycPendingScreen
+          insets={{ top: 0, bottom: 0 }}
+          onCheckBackLater={handleBack}
+          onReceiveLiveUpdates={() => {
+            // TODO: wire up push notifications
+          }}
+        />
+      )}
+      {phase === 'loading' && (
         <div
           style={{
             display: 'flex',
@@ -313,14 +322,7 @@ export const ProviderLaunchScreen: React.FC = () => {
             }}
           />
           <div style={{ marginTop: spacing.md }}>
-            <Title textAlign="center">
-              {phase === 'waiting' ? 'Processing verification...' : 'Loading verification...'}
-            </Title>
-            {phase === 'waiting' && (
-              <Description style={{ marginTop: 8 }}>
-                Your documents are being verified. This may take a moment.
-              </Description>
-            )}
+            <Title textAlign="center">Loading verification...</Title>
           </div>
         </div>
       )}

--- a/packages/webview-app/src/utils/diditProvider.ts
+++ b/packages/webview-app/src/utils/diditProvider.ts
@@ -79,6 +79,8 @@ export async function launchDiditWebSdk(config: DiditLaunchConfig): Promise<() =
   const emitOnce = (result: KycProviderResult, isError: boolean) => {
     if (hasCompleted) return;
     hasCompleted = true;
+    // Close the Didit SDK modal immediately so our UI can take over
+    DiditSdk.shared.close();
     if (isError) {
       config.onError(result);
     } else {


### PR DESCRIPTION
## Summary

- Close the Didit SDK modal immediately when `onComplete` fires, regardless of status
- Show Euclid's `KycPendingScreen` while Socket.IO waits for the TEE attestation
- When Didit returns `'In Review'`, the SDK shows its own pending screen that blocks the UI — this fix dismisses it so our flow takes over

## Changes

- `diditProvider.ts`: Call `DiditSdk.shared.close()` in `emitOnce()` before callbacks
- `ProviderLaunchScreen.tsx`: Replace spinner with `KycPendingScreen` for the `waiting` phase

## Test plan

- [ ] Didit modal closes after verification submission
- [ ] KycPendingScreen shows while waiting for TEE attestation
- [ ] Attestation arrives via Socket.IO after Didit approves
- [ ] "Check back later" navigates back