### PR TITLE
Fix CI pipelines and remove heavy common dependency

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -6,6 +6,9 @@ on:
       - staging
       - main
 
+env:
+  GH_HARDHAT_CACHE_VERSION: v1
+
 concurrency:
   group: contracts-ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -68,14 +71,26 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install Dependencies
         uses: ./.github/actions/yarn-install
+      - name: Cache Hardhat compilers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/hardhat-nodejs/compilers-v2
+          key: ${{ runner.os }}-hardhat-compilers-${{ env.GH_HARDHAT_CACHE_VERSION }}-${{ hashFiles('contracts/hardhat.config.ts', 'contracts/package.json', 'yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-hardhat-compilers-${{ env.GH_HARDHAT_CACHE_VERSION }}-
       - name: Prettier Check - Code Formatting
         run: yarn prettier:check
         working-directory: ./contracts
       - name: Build Common Dependencies
         run: yarn workspace @selfxyz/common build
       - name: Build Contracts
-        run: yarn build
-        working-directory: ./contracts
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_wait_seconds: 15
+          command: yarn build
+          working_directory: ./contracts
       - name: Run Tests (Contracts)
         working-directory: ./contracts
         # skip until they get fixed

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -96,20 +96,20 @@ jobs:
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 10
+          timeout_minutes: 20
           max_attempts: 3
           retry_wait_seconds: 5
-          command: yarn install --immutable --silent
+          command: yarn install --immutable
         env:
           SELFXYZ_APP_TOKEN: ${{ steps.github-token.outputs.token }}
       - name: Install deps (forked PRs - no secrets)
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 10
+          timeout_minutes: 20
           max_attempts: 3
           retry_wait_seconds: 5
-          command: yarn install --immutable --silent
+          command: yarn install --immutable
 
       - name: Validate Maestro test file
         run: |

--- a/.github/workflows/rn-sdk-test-app-ci.yml
+++ b/.github/workflows/rn-sdk-test-app-ci.yml
@@ -68,10 +68,15 @@ jobs:
           java-version: "17"
       - name: Generate debug keystore
         run: |
-          keytool -genkeypair -v -keystore packages/rn-sdk-test-app/android/app/debug.keystore \
-            -alias androiddebugkey -keyalg RSA -keysize 2048 -validity 10000 \
-            -storepass android -keypass android \
-            -dname "CN=Android Debug,O=Android,C=US"
+          KEYSTORE_PATH="packages/rn-sdk-test-app/android/app/debug.keystore"
+          if keytool -list -keystore "$KEYSTORE_PATH" -storepass android -alias androiddebugkey >/dev/null 2>&1; then
+            echo "Using existing debug keystore at $KEYSTORE_PATH"
+          else
+            keytool -genkeypair -v -keystore "$KEYSTORE_PATH" \
+              -alias androiddebugkey -keyalg RSA -keysize 2048 -validity 10000 \
+              -storepass android -keypass android \
+              -dname "CN=Android Debug,O=Android,C=US"
+          fi
       - name: Publish KMP SDK to mavenLocal
         run: |
           cd packages/kmp-sdk && ./gradlew :shared:publishToMavenLocal --quiet

--- a/app/.eslintrc.cjs
+++ b/app/.eslintrc.cjs
@@ -27,6 +27,7 @@ module.exports = {
     'android/',
     'deployments/',
     'node_modules/',
+    'vendor/',
     'web/dist/',
     '.tamagui/*',
     '*.js.map',

--- a/docs/reviews/PR-1901-review-findings.md
+++ b/docs/reviews/PR-1901-review-findings.md
@@ -1,0 +1,130 @@
+# PR #1901 Review Findings
+
+**PR:** Stitch tunnel flow screens with proving machine, recovery, and disclose
+**Branch:** `justin/debug-stitch-screens-build-issues`
+**Reviewed:** 2026-04-01
+
+This document reflects the substantive GitHub PR comments on PR #1901.
+It intentionally excludes low-signal review noise such as PR title, PR description, docstring coverage, and bot/meta comments.
+
+---
+
+## Critical
+
+### 1. Remote WebView loading in production without integrity checks
+
+**Files:** `AndroidWebViewHost.kt:96,116,180` · `SelfWebViewHost.swift:49-55`
+
+Non-debug builds now load from `https://self-app-alpha.vercel.app/` by default. The WebView still exposes the native bridge (`SelfNativeAndroid`), so a remote alpha deployment becomes privileged app code. A compromise or XSS on that host can drive the native bridge, camera/mic prompts inside host apps. iOS has no local/bundled fallback — offline devices fail at startup.
+
+**Fix:** Keep bundled `appassets` as the default entrypoint. Gate remote content behind an explicit environment flag and integrity check. Add offline fallback on iOS.
+
+---
+
+### 2. `null` selected document takes the success path in recovery
+
+**File:** `SecretPhraseInputScreen.tsx:183-197`
+
+`loadSelectedDocument()` returning `null` collapses into the same branch as a mock document. That branch calls `restoreSecretFromMnemonic()` and routes to `/tunnel/kyc`, so a missing/unreadable document context overwrites `self_mnemonic` and `self_private_key` without any identity match check.
+
+**Fix:** Explicitly handle `null` as an error state. Do not proceed with secret restoration when the document cannot be loaded.
+
+---
+
+### 3. Register phase can be skipped on stale `"completed"` state
+
+**File:** `TunnelProvingScreen.tsx:107-117`
+
+Lines 107-114 switch `phase` to `'register'` but keep `initDone` true. On next render, `currentState` can still be `"completed"`, so lines 115-117 immediately route to `/tunnel/proof/disclose` before `init(client, 'register', true)` has produced a fresh register state.
+
+**Fix:** Reset `initDone` (or the relevant gate) when switching phase to `'register'`, so the completed-state redirect doesn't fire before the new init resolves.
+
+---
+
+### 4. `setResult` lifecycle handler breaks backwards compatibility
+
+**File:** `LifecycleHandler.kt:44-47` · `LifecycleHandler.swift:33-38`
+
+Android now passes the full lifecycle envelope to `EXTRA_RESULT_DATA` instead of the verification payload. Missing `success` field returns `RESULT_OK`. A legacy or malformed bridge payload comes back as `RESULT_OK` with a JSON shape the host app can't parse. iOS similarly passes the full envelope to `onResult` instead of the verification payload.
+
+**Fix:** Extract `result` from the envelope before passing to `EXTRA_RESULT_DATA` / `onResult`. Treat missing `success` as `false` (fail closed). Support both payload shapes for backwards compatibility.
+
+---
+
+## Major
+
+### 5. Document finalization is half-transactional
+
+**File:** `recoveryValidation.ts:26-35`
+
+If `reStorePassportDataWithRightCSCA()` succeeds and `markCurrentDocumentAsRegistered()` throws, the caller only rolls back secret storage. The selected document has already been mutated, so retries run against a partially finalized document.
+
+**Fix:** Either make the two operations atomic, or roll back the document state on failure.
+
+---
+
+### 6. In-flight recovery navigates after unmount
+
+**File:** `SecretPhraseInputScreen.tsx:197,249-268`
+
+`isMountedRef` only protects `setState` calls. If the user backs out during validation/finalization, `navigate(...)` still fires from the stale request, yanking them onto another route.
+
+**Fix:** Gate `navigate()` calls behind the `isMountedRef` check as well.
+
+---
+
+### 7. No error handling on TourScreen final step
+
+**File:** `TourScreen.tsx:37`
+
+If `loadSelectedDocument(client)` rejects, `onNext` aborts and the user is stuck on the last tour screen with no recovery path.
+
+**Fix:** Wrap in try/catch, fall through to `/tunnel/kyc` on failure.
+
+---
+
+### 8. PII logged in TourScreen
+
+**File:** `TourScreen.tsx:29`
+
+`console.log('selected Doc', selectedDoc)` logs the full document payload, which can include passport/KYC PII.
+
+**Fix:** Remove the log statement.
+
+---
+
+### 9. Secret snapshot reads are not atomic
+
+**File:** `secretManager.ts:81`
+
+`readStoredSecretSnapshot()` runs two `get()` calls outside `secretLock`. A concurrent write can interleave, producing a mnemonic/private-key pair that never existed together.
+
+**Fix:** Run the read under `withSecretLock()`.
+
+---
+
+### 10. Snapshot restore is not failure-atomic
+
+**File:** `secretManager.ts:108-122`
+
+Two sequential writes with no rollback. If the mnemonic write succeeds and the private-key write fails, storage is left half-restored and mismatched.
+
+**Fix:** Capture the previous snapshot before writing. On failure, restore the previous values.
+
+---
+
+### 11. Hardcoded zero insets instead of `WEB_SAFE_AREA`
+
+**File:** `ProviderLaunchScreen.tsx:297`
+
+`KycPendingScreen` receives `{ top: 0, bottom: 0 }` instead of `WEB_SAFE_AREA`, causing potential safe-area overlap/clipping on some devices.
+
+**Fix:** Import and use `WEB_SAFE_AREA` from `src/utils/insets.ts`.
+
+---
+
+## Additional PR Comment Review
+
+- Reviewed the current PR comments on `selfxyz/self#1901`.
+- No additional non-pedantic findings need to be added beyond the items above.
+- The inline CodeRabbit comments about iOS legacy `setResult` compatibility and secret snapshot restore atomicity are already covered by findings 4 and 10.

--- a/packages/rn-sdk-test-app/ios/.xcode.env.local
+++ b/packages/rn-sdk-test-app/ios/.xcode.env.local
@@ -1,1 +1,0 @@
-export NODE_BINARY=/Users/ayman/.nvm/versions/node/v22.19.0/bin/node

--- a/packages/webview-app/package.json
+++ b/packages/webview-app/package.json
@@ -20,7 +20,6 @@
     "@didit-protocol/sdk-web": "^0.1.8",
     "@scure/bip32": "^2.0.1",
     "@scure/bip39": "^1.6.0",
-    "@selfxyz/common": "workspace:^",
     "@selfxyz/euclid": "1.3.0",
     "@selfxyz/euclid-core": "1.3.0",
     "@selfxyz/mobile-sdk-alpha": "workspace:^",

--- a/packages/webview-app/src/utils/selfAppContext.ts
+++ b/packages/webview-app/src/utils/selfAppContext.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
-import type { SelfApp, SelfAppDisclosureConfig } from '@selfxyz/common/utils';
-import type { SelfClient } from '@selfxyz/mobile-sdk-alpha/browser';
+import type { SelfApp, SelfAppDisclosureConfig, SelfClient } from '@selfxyz/mobile-sdk-alpha/browser';
 
 import type { ParsedVerificationRequestContext } from './verificationRequest';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11288,7 +11288,6 @@ __metadata:
     "@didit-protocol/sdk-web": "npm:^0.1.8"
     "@scure/bip32": "npm:^2.0.1"
     "@scure/bip39": "npm:^1.6.0"
-    "@selfxyz/common": "workspace:^"
     "@selfxyz/euclid": "npm:1.3.0"
     "@selfxyz/euclid-core": "npm:1.3.0"
     "@selfxyz/mobile-sdk-alpha": "workspace:^"


### PR DESCRIPTION
## Summary

- Remove `@selfxyz/common` from `webview-app` dependencies — it pulled in heavy transitive deps (git-forked `node-forge`, `snarkjs`, `ethers`) that caused `yarn install --immutable` to hang indefinitely in CI
- Fix E2E install step: increase timeout to 20 minutes and remove `--silent` flag so failures are visible
- Add Hardhat compiler caching and retry logic for contract builds
- Fix RN SDK test app: skip keystore generation when one already exists, remove developer-local `.xcode.env.local`

## Changes

### Config / Infra

- `.github/workflows/mobile-e2e.yml` — increase install timeout from 10 to 20 minutes, remove `--silent` flag for better debugging
- `.github/workflows/contracts.yml` — add Hardhat compiler cache, wrap contract build in retry (3 attempts, 15s wait)
- `.github/workflows/rn-sdk-test-app-ci.yml` — guard debug keystore generation to skip if already exists

### WebView App

- `packages/webview-app/package.json` — remove `@selfxyz/common` dependency
- `packages/webview-app/src/utils/selfAppContext.ts` — import `SelfApp`/`SelfAppDisclosureConfig` types from `@selfxyz/mobile-sdk-alpha/browser` (already re-exported there) instead of `@selfxyz/common`

### Cleanup

- Remove `packages/rn-sdk-test-app/ios/.xcode.env.local` (developer-local file pointing to a specific user's nvm path)
- `yarn.lock` — updated to reflect removed dependency

## Test Plan

- [ ] `yarn install` completes without hanging
- [ ] `cd packages/webview-app && yarn build` passes
- [ ] `cd packages/mobile-sdk-alpha && yarn test && yarn types` passes
- [ ] E2E CI pipeline completes the install step successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)