### PR TITLE
fix: address PR #1901 review findings for native shells and recovery

### DIFF
--- a/packages/mobile-sdk-alpha/src/proving/recoveryValidation.ts
+++ b/packages/mobile-sdk-alpha/src/proving/recoveryValidation.ts
@@ -5,6 +5,7 @@
 import type { DocumentCategory, IDDocument } from '@selfxyz/common';
 import { isUserRegisteredWithAlternativeCSCA } from '@selfxyz/common/utils/passports/validate';
 
+import { cloneForStorage } from '../adapters/browser/documents';
 import {
   markCurrentDocumentAsRegistered,
   reStorePassportDataWithRightCSCA,
@@ -33,7 +34,7 @@ export async function finalizeRecoveredDocumentRegistration(
   document: IDDocument,
   csca?: string,
 ): Promise<void> {
-  const originalDocument = structuredClone(document);
+  const originalDocument = cloneForStorage(document);
   const selectedDocumentId = (await selfClient.loadDocumentCatalog()).selectedDocumentId;
 
   try {
@@ -44,11 +45,19 @@ export async function finalizeRecoveredDocumentRegistration(
     await markCurrentDocumentAsRegistered(selfClient);
   } catch (error) {
     if (csca) {
-      await storePassportData(selfClient, originalDocument);
+      try {
+        await storePassportData(selfClient, originalDocument);
+      } catch (rollbackError) {
+        console.error('Rollback failed while restoring the original document during recovery:', rollbackError);
+      }
     }
 
     if (selectedDocumentId) {
-      await updateDocumentRegistrationState(selfClient, selectedDocumentId, false);
+      try {
+        await updateDocumentRegistrationState(selfClient, selectedDocumentId, false);
+      } catch (rollbackError) {
+        console.error('Rollback failed while clearing the registration flag during recovery:', rollbackError);
+      }
     }
 
     throw error;

--- a/packages/mobile-sdk-alpha/src/proving/recoveryValidation.ts
+++ b/packages/mobile-sdk-alpha/src/proving/recoveryValidation.ts
@@ -5,7 +5,12 @@
 import type { DocumentCategory, IDDocument } from '@selfxyz/common';
 import { isUserRegisteredWithAlternativeCSCA } from '@selfxyz/common/utils/passports/validate';
 
-import { markCurrentDocumentAsRegistered, reStorePassportDataWithRightCSCA } from '../documents/utils';
+import {
+  markCurrentDocumentAsRegistered,
+  reStorePassportDataWithRightCSCA,
+  storePassportData,
+  updateDocumentRegistrationState,
+} from '../documents/utils';
 import { getCommitmentTree } from '../stores';
 import type { SelfClient } from '../types/public';
 
@@ -28,11 +33,26 @@ export async function finalizeRecoveredDocumentRegistration(
   document: IDDocument,
   csca?: string,
 ): Promise<void> {
-  if (csca) {
-    await reStorePassportDataWithRightCSCA(selfClient, document, csca);
-  }
+  const originalDocument = structuredClone(document);
+  const selectedDocumentId = (await selfClient.loadDocumentCatalog()).selectedDocumentId;
 
-  await markCurrentDocumentAsRegistered(selfClient);
+  try {
+    if (csca) {
+      await reStorePassportDataWithRightCSCA(selfClient, document, csca);
+    }
+
+    await markCurrentDocumentAsRegistered(selfClient);
+  } catch (error) {
+    if (csca) {
+      await storePassportData(selfClient, originalDocument);
+    }
+
+    if (selectedDocumentId) {
+      await updateDocumentRegistrationState(selfClient, selectedDocumentId, false);
+    }
+
+    throw error;
+  }
 }
 
 export async function validateRecoverySecretForDocument(

--- a/packages/mobile-sdk-alpha/tests/proving/recoveryValidation.test.ts
+++ b/packages/mobile-sdk-alpha/tests/proving/recoveryValidation.test.ts
@@ -178,4 +178,16 @@ describe('finalizeRecoveredDocumentRegistration', () => {
     expect(storePassportDataMock).not.toHaveBeenCalled();
     expect(updateDocumentRegistrationStateMock).toHaveBeenCalledWith(expect.anything(), 'doc-1', false);
   });
+
+  it('still clears the registration flag when restoring the original document fails', async () => {
+    storePassportDataMock.mockRejectedValue(new Error('document rollback failed'));
+    markCurrentDocumentAsRegisteredMock.mockRejectedValue(new Error('catalog save failed'));
+
+    await expect(
+      finalizeRecoveredDocumentRegistration(createSelfClient(), documentFixture, 'new-csca'),
+    ).rejects.toThrow('catalog save failed');
+
+    expect(storePassportDataMock).toHaveBeenCalledTimes(1);
+    expect(updateDocumentRegistrationStateMock).toHaveBeenCalledWith(expect.anything(), 'doc-1', false);
+  });
 });

--- a/packages/mobile-sdk-alpha/tests/proving/recoveryValidation.test.ts
+++ b/packages/mobile-sdk-alpha/tests/proving/recoveryValidation.test.ts
@@ -6,13 +6,27 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { IDDocument } from '@selfxyz/common';
 
-import { validateRecoverySecretForDocument } from '../../src/proving/recoveryValidation';
+import {
+  finalizeRecoveredDocumentRegistration,
+  validateRecoverySecretForDocument,
+} from '../../src/proving/recoveryValidation';
 import type { SelfClient } from '../../src/types/public';
 
 const isUserRegisteredWithAlternativeCSCAMock = vi.fn();
+const markCurrentDocumentAsRegisteredMock = vi.fn();
+const restorePassportDataWithRightCSCAmock = vi.fn();
+const storePassportDataMock = vi.fn();
+const updateDocumentRegistrationStateMock = vi.fn();
 
 vi.mock('@selfxyz/common/utils/passports/validate', () => ({
   isUserRegisteredWithAlternativeCSCA: (...args: unknown[]) => isUserRegisteredWithAlternativeCSCAMock(...args),
+}));
+
+vi.mock('../../src/documents/utils', () => ({
+  markCurrentDocumentAsRegistered: (...args: unknown[]) => markCurrentDocumentAsRegisteredMock(...args),
+  reStorePassportDataWithRightCSCA: (...args: unknown[]) => restorePassportDataWithRightCSCAmock(...args),
+  storePassportData: (...args: unknown[]) => storePassportDataMock(...args),
+  updateDocumentRegistrationState: (...args: unknown[]) => updateDocumentRegistrationStateMock(...args),
 }));
 
 const documentFixture = {
@@ -22,6 +36,10 @@ const documentFixture = {
 
 function createSelfClient() {
   return {
+    loadDocumentCatalog: async () => ({
+      selectedDocumentId: 'doc-1',
+      documents: [],
+    }),
     getProtocolState: () => ({
       passport: {
         commitment_tree: 'passport-tree',
@@ -109,5 +127,55 @@ describe('validateRecoverySecretForDocument', () => {
     await validateRecoverySecretForDocument(createSelfClient(), documentFixture, 'matching-secret');
 
     expect(isUserRegisteredWithAlternativeCSCAMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('finalizeRecoveredDocumentRegistration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rolls back document state when registration marking fails after a CSCA restore', async () => {
+    restorePassportDataWithRightCSCAmock.mockImplementation(async (_client, document) => {
+      document.passportMetadata = {
+        ...(document.passportMetadata ?? {}),
+        csca: 'new-csca',
+      };
+    });
+    markCurrentDocumentAsRegisteredMock.mockRejectedValue(new Error('catalog save failed'));
+
+    const document = {
+      ...documentFixture,
+      passportMetadata: {
+        csca: 'old-csca',
+      },
+    } as IDDocument;
+
+    await expect(finalizeRecoveredDocumentRegistration(createSelfClient(), document, 'new-csca')).rejects.toThrow(
+      'catalog save failed',
+    );
+
+    expect(restorePassportDataWithRightCSCAmock).toHaveBeenCalledWith(expect.anything(), document, 'new-csca');
+    expect(storePassportDataMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        passportMetadata: expect.objectContaining({
+          csca: 'old-csca',
+        }),
+      }),
+    );
+    expect(updateDocumentRegistrationStateMock).toHaveBeenCalledWith(expect.anything(), 'doc-1', false);
+  });
+
+  it('does not attempt document restore when mark fails without a CSCA override', async () => {
+    markCurrentDocumentAsRegisteredMock.mockRejectedValue(new Error('catalog save failed'));
+
+    await expect(finalizeRecoveredDocumentRegistration(createSelfClient(), documentFixture)).rejects.toThrow(
+      'catalog save failed',
+    );
+
+    expect(restorePassportDataWithRightCSCAmock).not.toHaveBeenCalled();
+    expect(storePassportDataMock).not.toHaveBeenCalled();
+    expect(updateDocumentRegistrationStateMock).toHaveBeenCalledWith(expect.anything(), 'doc-1', false);
   });
 });

--- a/packages/native-shell-android/build.gradle.kts
+++ b/packages/native-shell-android/build.gradle.kts
@@ -58,4 +58,6 @@ dependencies {
     implementation("androidx.webkit:webkit:1.9.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.jetbrains.kotlin:kotlin-test:1.9.22")
 }

--- a/packages/native-shell-android/src/main/kotlin/xyz/self/sdk/api/SelfSdk.kt
+++ b/packages/native-shell-android/src/main/kotlin/xyz/self/sdk/api/SelfSdk.kt
@@ -30,6 +30,10 @@ object SelfSdk {
             config.chainID?.let { putExtra(SelfVerificationActivity.EXTRA_CHAIN_ID, it) }
             config.userDefinedData?.let { putExtra(SelfVerificationActivity.EXTRA_USER_DEFINED_DATA, it) }
             config.selfDefinedData?.let { putExtra(SelfVerificationActivity.EXTRA_SELF_DEFINED_DATA, it) }
+            config.remoteWebAppBaseUrl?.let { putExtra(SelfVerificationActivity.EXTRA_REMOTE_WEB_APP_BASE_URL, it) }
+            config.remoteWebAppIntegritySha256?.let {
+                putExtra(SelfVerificationActivity.EXTRA_REMOTE_WEB_APP_INTEGRITY_SHA256, it)
+            }
         }
         activity.startActivityForResult(intent, requestCode)
     }

--- a/packages/native-shell-android/src/main/kotlin/xyz/self/sdk/api/SelfSdkConfig.kt
+++ b/packages/native-shell-android/src/main/kotlin/xyz/self/sdk/api/SelfSdkConfig.kt
@@ -19,6 +19,8 @@ data class SelfSdkConfig(
     val chainID: Int? = null,
     val userDefinedData: String? = null,
     val selfDefinedData: String? = null,
+    val remoteWebAppBaseUrl: String? = null,
+    val remoteWebAppIntegritySha256: String? = null,
 )
 
 class SelfSdkException(message: String) : Exception(message)

--- a/packages/native-shell-android/src/main/kotlin/xyz/self/sdk/handlers/LifecycleHandler.kt
+++ b/packages/native-shell-android/src/main/kotlin/xyz/self/sdk/handlers/LifecycleHandler.kt
@@ -15,7 +15,7 @@ import xyz.self.sdk.webview.SelfVerificationActivity
 
 class LifecycleHandler(private val activity: Activity) : BridgeHandler {
     override val domain = BridgeDomain.LIFECYCLE
-    private var hasResult = false
+    internal val resultGate = LifecycleResultGate()
 
     override suspend fun handle(
         method: String,
@@ -29,7 +29,7 @@ class LifecycleHandler(private val activity: Activity) : BridgeHandler {
 
     private fun dismiss(): JsonElement? {
         activity.runOnUiThread {
-            if (!hasResult) {
+            if (resultGate.tryClaim()) {
                 activity.setResult(Activity.RESULT_CANCELED)
             }
             activity.finish()
@@ -39,15 +39,38 @@ class LifecycleHandler(private val activity: Activity) : BridgeHandler {
 
     private fun setResult(params: Map<String, JsonElement>): JsonElement? {
         activity.runOnUiThread {
-            hasResult = true
+            if (!resultGate.tryClaim()) return@runOnUiThread
             val intent = Intent()
-            val resultJson = JsonObject(params)
-            intent.putExtra(SelfVerificationActivity.EXTRA_RESULT_DATA, resultJson.toString())
-            val isSuccess = params["success"]?.jsonPrimitive?.booleanOrNull != false
+            val resultPayload = LifecycleResultEnvelope.extractPayload(params)
+            intent.putExtra(SelfVerificationActivity.EXTRA_RESULT_DATA, resultPayload.toString())
+            val isSuccess = LifecycleResultEnvelope.extractSuccess(resultPayload)
             val resultCode = if (isSuccess) Activity.RESULT_OK else Activity.RESULT_FIRST_USER
             activity.setResult(resultCode, intent)
             activity.finish()
         }
         return null
     }
+}
+
+internal class LifecycleResultGate {
+    private var claimed = false
+
+    fun tryClaim(): Boolean {
+        if (claimed) return false
+        claimed = true
+        return true
+    }
+
+    val isClaimed: Boolean get() = claimed
+}
+
+internal object LifecycleResultEnvelope {
+    fun extractPayload(params: Map<String, JsonElement>): JsonObject =
+        when (val nestedResult = params["result"]) {
+            is JsonObject -> nestedResult
+            else -> JsonObject(params)
+        }
+
+    fun extractSuccess(payload: JsonObject): Boolean =
+        payload["success"]?.jsonPrimitive?.booleanOrNull == true
 }

--- a/packages/native-shell-android/src/main/kotlin/xyz/self/sdk/webview/AndroidWebViewHost.kt
+++ b/packages/native-shell-android/src/main/kotlin/xyz/self/sdk/webview/AndroidWebViewHost.kt
@@ -34,11 +34,14 @@ class AndroidWebViewHost(
     private val remoteWebAppIntegritySha256: String? = null,
 ) {
     private lateinit var webView: WebView
+    @Volatile
+    private var isDestroyed = false
     var fileUploadCallback: ValueCallback<Array<Uri>>? = null
     var pendingPermissionRequest: PermissionRequest? = null
 
     @SuppressLint("SetJavaScriptEnabled")
     fun createWebView(queryParams: String): WebView {
+        isDestroyed = false
         val selfWalletHandler = WebViewAssetLoader.PathHandler { rawPath ->
             try {
                 val normalizedPath = rawPath.removePrefix("/")
@@ -104,10 +107,10 @@ class AndroidWebViewHost(
                             view: WebView?,
                             request: WebResourceRequest?,
                         ): Boolean {
-                            val url = request?.url?.toString() ?: return true
-                            if (url.startsWith(BUNDLED_ORIGIN)) return false
-                            if (isDebugMode && url.startsWith(DEBUG_ORIGIN)) return false
-                            if (isAllowedRemoteOrigin(url)) return false
+                            val url = request?.url ?: return true
+                            if (isBundledOrigin(url)) return false
+                            if (isDebugMode && isDebugOrigin(url)) return false
+                            if (isAllowedRemoteOrigin(url.toString())) return false
                             return true
                         }
 
@@ -125,12 +128,13 @@ class AndroidWebViewHost(
                         override fun onPermissionRequest(request: PermissionRequest?) {
                             request ?: return
 
-                            val origin = request.origin?.toString() ?: ""
+                            val originStr = request.origin?.toString() ?: ""
+                            val originUri = Uri.parse(originStr)
                             val isTrusted =
-                                origin.startsWith(BUNDLED_ORIGIN) ||
-                                    (isDebugMode && origin.startsWith(DEBUG_ORIGIN)) ||
-                                    origin.startsWith("https://verify.didit.me") ||
-                                    isAllowedRemoteOrigin(origin)
+                                isBundledOrigin(originUri) ||
+                                    (isDebugMode && isDebugOrigin(originUri)) ||
+                                    isMatchingOrigin(originUri, "https", "verify.didit.me", 443) ||
+                                    isAllowedRemoteOrigin(originStr)
                             if (!isTrusted) {
                                 request.deny()
                                 return
@@ -212,6 +216,7 @@ class AndroidWebViewHost(
 
     fun destroy() {
         if (!::webView.isInitialized) return
+        isDestroyed = true
         webView.destroy()
     }
 
@@ -234,20 +239,26 @@ class AndroidWebViewHost(
         val expectedSha256 = remoteWebAppIntegritySha256?.takeIf { it.isNotBlank() } ?: return
 
         Thread {
-            val isVerified = verifyRemoteEntry(remoteUrl, expectedSha256)
-            if (!isVerified || !::webView.isInitialized) {
+            val verifiedHtml = fetchAndVerifyRemoteEntry(remoteUrl, expectedSha256)
+            if (verifiedHtml == null || !::webView.isInitialized || isDestroyed) {
                 return@Thread
             }
 
             webView.post {
-                if (::webView.isInitialized) {
-                    webView.loadUrl(remoteUrl)
+                if (::webView.isInitialized && !isDestroyed) {
+                    webView.loadDataWithBaseURL(
+                        remoteUrl,
+                        verifiedHtml,
+                        "text/html",
+                        "UTF-8",
+                        null,
+                    )
                 }
             }
         }.start()
     }
 
-    private fun verifyRemoteEntry(remoteUrl: String, expectedSha256: String): Boolean {
+    private fun fetchAndVerifyRemoteEntry(remoteUrl: String, expectedSha256: String): String? {
         return try {
             val connection = URL(remoteUrl).openConnection() as HttpURLConnection
             connection.requestMethod = "GET"
@@ -258,17 +269,22 @@ class AndroidWebViewHost(
 
             if (connection.responseCode !in 200..299) {
                 Log.w("WebViewHost", "Remote web app integrity check failed with HTTP ${connection.responseCode}")
-                false
+                null
             } else if (!RemoteContentIntegrity.isAcceptableContentType(connection.contentType)) {
                 Log.w("WebViewHost", "Remote web app integrity check failed due to unexpected content type ${connection.contentType}")
-                false
+                null
             } else {
                 val body = connection.inputStream.use { it.readBytes() }
-                sha256Hex(body) == normalizeSha256(expectedSha256)
+                if (sha256Hex(body) == normalizeSha256(expectedSha256)) {
+                    String(body, Charsets.UTF_8)
+                } else {
+                    Log.w("WebViewHost", "Remote web app integrity check failed: hash mismatch")
+                    null
+                }
             }
         } catch (error: Exception) {
             Log.w("WebViewHost", "Remote web app integrity check failed", error)
-            false
+            null
         }
     }
 
@@ -301,9 +317,18 @@ class AndroidWebViewHost(
         }
     }
 
+    private fun isBundledOrigin(uri: Uri): Boolean =
+        isMatchingOrigin(uri, "https", BUNDLED_HOST, 443)
+
+    private fun isDebugOrigin(uri: Uri): Boolean =
+        isMatchingOrigin(uri, "http", "127.0.0.1", 5173)
+
+    private fun isMatchingOrigin(uri: Uri, scheme: String, host: String, port: Int): Boolean =
+        uri.scheme == scheme && uri.host == host && resolvePort(uri) == port
+
     companion object {
         private const val BUNDLED_HOST = "appassets.androidplatform.net"
-        private const val BUNDLED_ORIGIN = "https://appassets.androidplatform.net"
+        private const val BUNDLED_ORIGIN = "https://$BUNDLED_HOST"
         private const val DEBUG_ORIGIN = "http://127.0.0.1:5173"
 
         const val FILE_CHOOSER_REQUEST_CODE = 1001

--- a/packages/native-shell-android/src/main/kotlin/xyz/self/sdk/webview/AndroidWebViewHost.kt
+++ b/packages/native-shell-android/src/main/kotlin/xyz/self/sdk/webview/AndroidWebViewHost.kt
@@ -6,10 +6,10 @@ import android.Manifest
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
-import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.net.http.SslError
+import android.util.Log
 import android.webkit.JavascriptInterface
 import android.webkit.PermissionRequest
 import android.webkit.SslErrorHandler
@@ -22,12 +22,16 @@ import android.webkit.WebViewClient
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.webkit.WebViewAssetLoader
+import java.net.HttpURLConnection
+import java.net.URL
 import xyz.self.sdk.bridge.MessageRouter
 
 class AndroidWebViewHost(
     private val context: Context,
     private val router: MessageRouter,
     private val isDebugMode: Boolean = false,
+    private val remoteWebAppBaseUrl: String? = null,
+    private val remoteWebAppIntegritySha256: String? = null,
 ) {
     private lateinit var webView: WebView
     var fileUploadCallback: ValueCallback<Array<Uri>>? = null
@@ -35,157 +39,172 @@ class AndroidWebViewHost(
 
     @SuppressLint("SetJavaScriptEnabled")
     fun createWebView(queryParams: String): WebView {
-        val selfWalletHandler = WebViewAssetLoader.PathHandler { path ->
+        val selfWalletHandler = WebViewAssetLoader.PathHandler { rawPath ->
             try {
-                val assetPath = "self-wallet/$path"
+                val normalizedPath = rawPath.removePrefix("/")
+                val assetPath =
+                    if (normalizedPath.isEmpty() || !normalizedPath.contains('.')) {
+                        "self-wallet/index.html"
+                    } else {
+                        "self-wallet/$normalizedPath"
+                    }
                 val inputStream = context.assets.open(assetPath)
-                val mimeType = when {
-                    path.endsWith(".js") -> "application/javascript"
-                    path.endsWith(".css") -> "text/css"
-                    path.endsWith(".html") -> "text/html"
-                    path.endsWith(".json") -> "application/json"
-                    path.endsWith(".woff2") -> "font/woff2"
-                    path.endsWith(".woff") -> "font/woff"
-                    path.endsWith(".otf") -> "font/otf"
-                    path.endsWith(".ttf") -> "font/ttf"
-                    path.endsWith(".png") -> "image/png"
-                    path.endsWith(".svg") -> "image/svg+xml"
-                    else -> "application/octet-stream"
-                }
+                val mimeType =
+                    when {
+                        assetPath.endsWith(".js") -> "application/javascript"
+                        assetPath.endsWith(".css") -> "text/css"
+                        assetPath.endsWith(".html") -> "text/html"
+                        assetPath.endsWith(".json") -> "application/json"
+                        assetPath.endsWith(".woff2") -> "font/woff2"
+                        assetPath.endsWith(".woff") -> "font/woff"
+                        assetPath.endsWith(".otf") -> "font/otf"
+                        assetPath.endsWith(".ttf") -> "font/ttf"
+                        assetPath.endsWith(".png") -> "image/png"
+                        assetPath.endsWith(".svg") -> "image/svg+xml"
+                        else -> "application/octet-stream"
+                    }
                 WebResourceResponse(mimeType, "UTF-8", inputStream)
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 null
             }
         }
 
-        val assetLoader = WebViewAssetLoader.Builder()
-            .addPathHandler("/", selfWalletHandler)
-            .build()
+        val assetLoader =
+            WebViewAssetLoader.Builder()
+                .addPathHandler("/", selfWalletHandler)
+                .build()
 
-        webView = WebView(context).apply {
-            settings.apply {
-                javaScriptEnabled = true
-                domStorageEnabled = true
-                allowFileAccess = false
-                allowContentAccess = false
-                mediaPlaybackRequiresUserGesture = false
+        webView =
+            WebView(context).apply {
+                settings.apply {
+                    javaScriptEnabled = true
+                    domStorageEnabled = true
+                    allowFileAccess = false
+                    allowContentAccess = false
+                    mediaPlaybackRequiresUserGesture = false
+
+                    if (isDebugMode) {
+                        WebView.setWebContentsDebuggingEnabled(true)
+                    }
+                }
+
+                webViewClient =
+                    object : WebViewClient() {
+                        override fun shouldInterceptRequest(
+                            view: WebView?,
+                            request: WebResourceRequest?,
+                        ): WebResourceResponse? {
+                            request ?: return null
+                            val url = request.url
+                            if (url.host != BUNDLED_HOST) return null
+                            return assetLoader.shouldInterceptRequest(url)
+                        }
+
+                        override fun shouldOverrideUrlLoading(
+                            view: WebView?,
+                            request: WebResourceRequest?,
+                        ): Boolean {
+                            val url = request?.url?.toString() ?: return true
+                            if (url.startsWith(BUNDLED_ORIGIN)) return false
+                            if (isDebugMode && url.startsWith(DEBUG_ORIGIN)) return false
+                            if (isAllowedRemoteOrigin(url)) return false
+                            return true
+                        }
+
+                        override fun onReceivedSslError(
+                            view: WebView?,
+                            handler: SslErrorHandler?,
+                            error: SslError?,
+                        ) {
+                            handler?.cancel()
+                        }
+                    }
+
+                webChromeClient =
+                    object : WebChromeClient() {
+                        override fun onPermissionRequest(request: PermissionRequest?) {
+                            request ?: return
+
+                            val origin = request.origin?.toString() ?: ""
+                            val isTrusted =
+                                origin.startsWith(BUNDLED_ORIGIN) ||
+                                    (isDebugMode && origin.startsWith(DEBUG_ORIGIN)) ||
+                                    origin.startsWith("https://verify.didit.me") ||
+                                    isAllowedRemoteOrigin(origin)
+                            if (!isTrusted) {
+                                request.deny()
+                                return
+                            }
+
+                            val activity = context as? Activity ?: run {
+                                request.deny()
+                                return
+                            }
+
+                            val neededPermissions = mutableListOf<String>()
+                            if (request.resources.contains(PermissionRequest.RESOURCE_VIDEO_CAPTURE)) {
+                                neededPermissions.add(Manifest.permission.CAMERA)
+                            }
+                            if (request.resources.contains(PermissionRequest.RESOURCE_AUDIO_CAPTURE)) {
+                                neededPermissions.add(Manifest.permission.RECORD_AUDIO)
+                            }
+
+                            val missingPermissions =
+                                neededPermissions.filter {
+                                    ContextCompat.checkSelfPermission(activity, it) != PackageManager.PERMISSION_GRANTED
+                                }
+
+                            if (missingPermissions.isNotEmpty()) {
+                                pendingPermissionRequest = request
+                                ActivityCompat.requestPermissions(
+                                    activity,
+                                    missingPermissions.toTypedArray(),
+                                    CAMERA_PERMISSION_REQUEST_CODE,
+                                )
+                                return
+                            }
+
+                            request.grant(request.resources)
+                        }
+
+                        override fun onShowFileChooser(
+                            webView: WebView?,
+                            filePathCallback: ValueCallback<Array<Uri>>?,
+                            fileChooserParams: FileChooserParams?,
+                        ): Boolean {
+                            fileUploadCallback?.onReceiveValue(null)
+                            fileUploadCallback = filePathCallback
+
+                            val intent = fileChooserParams?.createIntent() ?: return false
+                            val activity = context as? Activity ?: run {
+                                fileUploadCallback = null
+                                return false
+                            }
+                            try {
+                                activity.startActivityForResult(intent, FILE_CHOOSER_REQUEST_CODE)
+                            } catch (_: Exception) {
+                                fileUploadCallback = null
+                                return false
+                            }
+                            return true
+                        }
+                    }
+
+                addJavascriptInterface(BridgeJsInterface(), "SelfNativeAndroid")
 
                 if (isDebugMode) {
-                    WebView.setWebContentsDebuggingEnabled(true)
+                    loadUrl(buildDebugUrl(queryParams))
+                } else {
+                    loadUrl(buildBundledUrl(queryParams))
+                    maybeLoadVerifiedRemoteContent(queryParams)
                 }
             }
-
-            webViewClient = object : WebViewClient() {
-                override fun shouldInterceptRequest(
-                    view: WebView?,
-                    request: WebResourceRequest?,
-                ): WebResourceResponse? {
-                    request ?: return null
-                    val url = request.url
-                    if (url.host != "appassets.androidplatform.net") return null
-                    return assetLoader.shouldInterceptRequest(url)
-                }
-
-                override fun shouldOverrideUrlLoading(
-                    view: WebView?,
-                    request: WebResourceRequest?,
-                ): Boolean {
-                    val url = request?.url?.toString() ?: return true
-                    if (url.startsWith("https://appassets.androidplatform.net/")) return false
-                    if (url.startsWith("https://self-app-alpha.vercel.app/")) return false
-                    if (isDebugMode && url.startsWith("http://127.0.0.1:5173")) return false
-                    return true
-                }
-
-                override fun onReceivedSslError(
-                    view: WebView?,
-                    handler: SslErrorHandler?,
-                    error: SslError?,
-                ) {
-                    handler?.cancel()
-                }
-            }
-
-            webChromeClient = object : WebChromeClient() {
-                override fun onPermissionRequest(request: PermissionRequest?) {
-                    request ?: return
-
-                    // Only allow permissions from trusted origins
-                    val origin = request.origin?.toString() ?: ""
-                    val isTrusted = origin.startsWith("https://appassets.androidplatform.net") ||
-                        origin.startsWith("https://self-app-alpha.vercel.app") ||
-                        origin.startsWith("https://verify.didit.me") ||
-                        (isDebugMode && origin.startsWith("http://127.0.0.1"))
-                    if (!isTrusted) {
-                        request.deny()
-                        return
-                    }
-
-                    val activity = context as? Activity ?: run {
-                        request.deny()
-                        return
-                    }
-
-                    // Collect required Android permissions
-                    val neededPermissions = mutableListOf<String>()
-                    if (request.resources.contains(PermissionRequest.RESOURCE_VIDEO_CAPTURE)) {
-                        neededPermissions.add(Manifest.permission.CAMERA)
-                    }
-                    if (request.resources.contains(PermissionRequest.RESOURCE_AUDIO_CAPTURE)) {
-                        neededPermissions.add(Manifest.permission.RECORD_AUDIO)
-                    }
-
-                    // Check if any runtime permissions are missing
-                    val missingPermissions = neededPermissions.filter {
-                        ContextCompat.checkSelfPermission(activity, it) != PackageManager.PERMISSION_GRANTED
-                    }
-
-                    if (missingPermissions.isNotEmpty()) {
-                        pendingPermissionRequest = request
-                        ActivityCompat.requestPermissions(activity, missingPermissions.toTypedArray(), CAMERA_PERMISSION_REQUEST_CODE)
-                        return
-                    }
-
-                    request.grant(request.resources)
-                }
-
-                override fun onShowFileChooser(
-                    webView: WebView?,
-                    filePathCallback: ValueCallback<Array<Uri>>?,
-                    fileChooserParams: FileChooserParams?,
-                ): Boolean {
-                    fileUploadCallback?.onReceiveValue(null)
-                    fileUploadCallback = filePathCallback
-
-                    val intent = fileChooserParams?.createIntent() ?: return false
-                    val activity = context as? Activity ?: run {
-                        fileUploadCallback = null
-                        return false
-                    }
-                    try {
-                        activity.startActivityForResult(intent, FILE_CHOOSER_REQUEST_CODE)
-                    } catch (e: Exception) {
-                        fileUploadCallback = null
-                        return false
-                    }
-                    return true
-                }
-            }
-
-            addJavascriptInterface(BridgeJsInterface(), "SelfNativeAndroid")
-
-            if (isDebugMode) {
-                loadUrl("http://127.0.0.1:5173/tunnel/tour/1?$queryParams")
-            } else {
-                loadUrl("https://self-app-alpha.vercel.app/tunnel/tour/1?$queryParams")
-            }
-        }
         return webView
     }
 
     fun evaluateJs(js: String) {
         if (!::webView.isInitialized) {
-            android.util.Log.e("WebViewHost", "evaluateJs called but webView not initialized")
+            Log.e("WebViewHost", "evaluateJs called but webView not initialized")
             return
         }
         webView.evaluateJavascript(js, null)
@@ -196,6 +215,85 @@ class AndroidWebViewHost(
         webView.destroy()
     }
 
+    private fun buildBundledUrl(queryParams: String): String = buildEntryUrl(BUNDLED_ORIGIN, queryParams)
+
+    private fun buildDebugUrl(queryParams: String): String = buildEntryUrl(DEBUG_ORIGIN, queryParams)
+
+    private fun buildRemoteUrl(queryParams: String): String? {
+        val baseUrl = remoteWebAppBaseUrl?.takeIf { it.isNotBlank() } ?: return null
+        return buildEntryUrl(baseUrl.trimEnd('/'), queryParams)
+    }
+
+    private fun buildEntryUrl(baseUrl: String, queryParams: String): String {
+        val separator = if (queryParams.isEmpty()) "" else "?$queryParams"
+        return "$baseUrl/tunnel/tour/1$separator"
+    }
+
+    private fun maybeLoadVerifiedRemoteContent(queryParams: String) {
+        val remoteUrl = buildRemoteUrl(queryParams) ?: return
+        val expectedSha256 = remoteWebAppIntegritySha256?.takeIf { it.isNotBlank() } ?: return
+
+        Thread {
+            val isVerified = verifyRemoteEntry(remoteUrl, expectedSha256)
+            if (!isVerified || !::webView.isInitialized) {
+                return@Thread
+            }
+
+            webView.post {
+                if (::webView.isInitialized) {
+                    webView.loadUrl(remoteUrl)
+                }
+            }
+        }.start()
+    }
+
+    private fun verifyRemoteEntry(remoteUrl: String, expectedSha256: String): Boolean {
+        return try {
+            val connection = URL(remoteUrl).openConnection() as HttpURLConnection
+            connection.requestMethod = "GET"
+            connection.instanceFollowRedirects = false
+            connection.connectTimeout = 5_000
+            connection.readTimeout = 5_000
+            connection.connect()
+
+            if (connection.responseCode !in 200..299) {
+                Log.w("WebViewHost", "Remote web app integrity check failed with HTTP ${connection.responseCode}")
+                false
+            } else if (!RemoteContentIntegrity.isAcceptableContentType(connection.contentType)) {
+                Log.w("WebViewHost", "Remote web app integrity check failed due to unexpected content type ${connection.contentType}")
+                false
+            } else {
+                val body = connection.inputStream.use { it.readBytes() }
+                sha256Hex(body) == normalizeSha256(expectedSha256)
+            }
+        } catch (error: Exception) {
+            Log.w("WebViewHost", "Remote web app integrity check failed", error)
+            false
+        }
+    }
+
+    private fun isAllowedRemoteOrigin(url: String): Boolean {
+        val baseUrl = remoteWebAppBaseUrl?.takeIf { it.isNotBlank() } ?: return false
+        val baseUri = Uri.parse(baseUrl)
+        val candidateUri = Uri.parse(url)
+
+        return baseUri.scheme == candidateUri.scheme &&
+            baseUri.host == candidateUri.host &&
+            resolvePort(baseUri) == resolvePort(candidateUri)
+    }
+
+    private fun resolvePort(uri: Uri): Int =
+        when {
+            uri.port != -1 -> uri.port
+            uri.scheme == "https" -> 443
+            uri.scheme == "http" -> 80
+            else -> -1
+        }
+
+    private fun sha256Hex(bytes: ByteArray): String = RemoteContentIntegrity.sha256Hex(bytes)
+
+    private fun normalizeSha256(value: String): String = RemoteContentIntegrity.normalizeSha256(value)
+
     inner class BridgeJsInterface {
         @JavascriptInterface
         fun postMessage(json: String) {
@@ -204,6 +302,10 @@ class AndroidWebViewHost(
     }
 
     companion object {
+        private const val BUNDLED_HOST = "appassets.androidplatform.net"
+        private const val BUNDLED_ORIGIN = "https://appassets.androidplatform.net"
+        private const val DEBUG_ORIGIN = "http://127.0.0.1:5173"
+
         const val FILE_CHOOSER_REQUEST_CODE = 1001
         const val CAMERA_PERMISSION_REQUEST_CODE = 1002
     }

--- a/packages/native-shell-android/src/main/kotlin/xyz/self/sdk/webview/RemoteContentIntegrity.kt
+++ b/packages/native-shell-android/src/main/kotlin/xyz/self/sdk/webview/RemoteContentIntegrity.kt
@@ -4,7 +4,7 @@ package xyz.self.sdk.webview
 
 import java.security.MessageDigest
 
-// null/empty contentType is allowed — some CDNs omit Content-Type; the SHA-256 hash is the primary integrity gate.
+// null contentType is allowed — some CDNs omit Content-Type; the SHA-256 hash is the primary integrity gate.
 internal object RemoteContentIntegrity {
     fun normalizeSha256(value: String): String =
         value.lowercase().removePrefix("sha256-").removePrefix("0x")
@@ -16,6 +16,6 @@ internal object RemoteContentIntegrity {
 
     fun isAcceptableContentType(rawContentType: String?): Boolean {
         val normalized = rawContentType?.substringBefore(";")?.trim()?.lowercase()
-        return normalized in setOf("", "text/html", null)
+        return normalized == null || normalized == "text/html"
     }
 }

--- a/packages/native-shell-android/src/main/kotlin/xyz/self/sdk/webview/RemoteContentIntegrity.kt
+++ b/packages/native-shell-android/src/main/kotlin/xyz/self/sdk/webview/RemoteContentIntegrity.kt
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package xyz.self.sdk.webview
+
+import java.security.MessageDigest
+
+// null/empty contentType is allowed — some CDNs omit Content-Type; the SHA-256 hash is the primary integrity gate.
+internal object RemoteContentIntegrity {
+    fun normalizeSha256(value: String): String =
+        value.lowercase().removePrefix("sha256-").removePrefix("0x")
+
+    fun sha256Hex(bytes: ByteArray): String =
+        MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { byte ->
+            "%02x".format(byte)
+        }
+
+    fun isAcceptableContentType(rawContentType: String?): Boolean {
+        val normalized = rawContentType?.substringBefore(";")?.trim()?.lowercase()
+        return normalized in setOf("", "text/html", null)
+    }
+}

--- a/packages/native-shell-android/src/main/kotlin/xyz/self/sdk/webview/SelfVerificationActivity.kt
+++ b/packages/native-shell-android/src/main/kotlin/xyz/self/sdk/webview/SelfVerificationActivity.kt
@@ -36,6 +36,8 @@ class SelfVerificationActivity : AppCompatActivity() {
         val chainID = if (intent.hasExtra(EXTRA_CHAIN_ID)) intent.getIntExtra(EXTRA_CHAIN_ID, 0) else null
         val userDefinedData = intent.getStringExtra(EXTRA_USER_DEFINED_DATA)
         val selfDefinedData = intent.getStringExtra(EXTRA_SELF_DEFINED_DATA)
+        val remoteWebAppBaseUrl = intent.getStringExtra(EXTRA_REMOTE_WEB_APP_BASE_URL)
+        val remoteWebAppIntegritySha256 = intent.getStringExtra(EXTRA_REMOTE_WEB_APP_INTEGRITY_SHA256)
 
         router = MessageRouter(
             sendToWebView = { js ->
@@ -59,7 +61,13 @@ class SelfVerificationActivity : AppCompatActivity() {
         router.register(CryptoHandler())
         router.register(LifecycleHandler(this))
 
-        webViewHost = AndroidWebViewHost(this, router, isDebugMode)
+        webViewHost = AndroidWebViewHost(
+            context = this,
+            router = router,
+            isDebugMode = isDebugMode,
+            remoteWebAppBaseUrl = remoteWebAppBaseUrl,
+            remoteWebAppIntegritySha256 = remoteWebAppIntegritySha256,
+        )
 
         val queryParams = buildString {
             append("environment=").append(Uri.encode(environment))
@@ -140,6 +148,8 @@ class SelfVerificationActivity : AppCompatActivity() {
         const val EXTRA_CHAIN_ID = "xyz.self.sdk.CHAIN_ID"
         const val EXTRA_USER_DEFINED_DATA = "xyz.self.sdk.USER_DEFINED_DATA"
         const val EXTRA_SELF_DEFINED_DATA = "xyz.self.sdk.SELF_DEFINED_DATA"
+        const val EXTRA_REMOTE_WEB_APP_BASE_URL = "xyz.self.sdk.REMOTE_WEB_APP_BASE_URL"
+        const val EXTRA_REMOTE_WEB_APP_INTEGRITY_SHA256 = "xyz.self.sdk.REMOTE_WEB_APP_INTEGRITY_SHA256"
         const val EXTRA_RESULT_DATA = "xyz.self.sdk.RESULT_DATA"
     }
 }

--- a/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/handlers/LifecycleResultEnvelopeTest.kt
+++ b/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/handlers/LifecycleResultEnvelopeTest.kt
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package xyz.self.sdk.handlers
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+class LifecycleResultEnvelopeTest {
+
+    @Test
+    fun `extractPayload unwraps nested result object`() {
+        val inner = buildJsonObject { put("success", true); put("data", "value") }
+        val params = mapOf("result" to inner, "extra" to JsonPrimitive("ignored"))
+
+        val payload = LifecycleResultEnvelope.extractPayload(params)
+
+        assertEquals(inner, payload)
+    }
+
+    @Test
+    fun `extractPayload falls back to wrapping params when result is missing`() {
+        val params = mapOf("success" to JsonPrimitive(false), "error" to JsonPrimitive("oops"))
+
+        val payload = LifecycleResultEnvelope.extractPayload(params)
+
+        assertEquals(JsonObject(params), payload)
+    }
+
+    @Test
+    fun `extractPayload falls back to wrapping params when result is not a JsonObject`() {
+        val params = mapOf("result" to JsonPrimitive("not-an-object"), "success" to JsonPrimitive(true))
+
+        val payload = LifecycleResultEnvelope.extractPayload(params)
+
+        assertEquals(JsonObject(params), payload)
+    }
+
+    @Test
+    fun `extractSuccess returns true when success is true`() {
+        val payload = buildJsonObject { put("success", true) }
+
+        assertTrue(LifecycleResultEnvelope.extractSuccess(payload))
+    }
+
+    @Test
+    fun `extractSuccess returns false when success is false`() {
+        val payload = buildJsonObject { put("success", false) }
+
+        assertFalse(LifecycleResultEnvelope.extractSuccess(payload))
+    }
+
+    @Test
+    fun `extractSuccess returns false when success field is missing`() {
+        val payload = buildJsonObject { put("data", "value") }
+
+        assertFalse(LifecycleResultEnvelope.extractSuccess(payload))
+    }
+
+    @Test
+    fun `extractSuccess returns false when success is not a boolean`() {
+        val payload = buildJsonObject { put("success", "yes") }
+
+        assertFalse(LifecycleResultEnvelope.extractSuccess(payload))
+    }
+
+    @Test
+    fun `extractSuccess returns false for empty payload`() {
+        val payload = buildJsonObject {}
+
+        assertFalse(LifecycleResultEnvelope.extractSuccess(payload))
+    }
+}

--- a/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/handlers/LifecycleResultGateTest.kt
+++ b/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/handlers/LifecycleResultGateTest.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package xyz.self.sdk.handlers
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LifecycleResultGateTest {
+
+    @Test
+    fun `first tryClaim succeeds`() {
+        val gate = LifecycleResultGate()
+
+        assertTrue(gate.tryClaim())
+        assertTrue(gate.isClaimed)
+    }
+
+    @Test
+    fun `second tryClaim fails after first claim`() {
+        val gate = LifecycleResultGate()
+
+        assertTrue(gate.tryClaim())
+        assertFalse(gate.tryClaim())
+    }
+
+    @Test
+    fun `isClaimed is false before any claim`() {
+        val gate = LifecycleResultGate()
+
+        assertFalse(gate.isClaimed)
+    }
+
+    @Test
+    fun `dismiss-then-setResult scenario - second caller is rejected`() {
+        val gate = LifecycleResultGate()
+
+        // dismiss claims the gate
+        val dismissClaimed = gate.tryClaim()
+        // setResult tries to claim after dismiss
+        val setResultClaimed = gate.tryClaim()
+
+        assertTrue(dismissClaimed, "dismiss should win the gate")
+        assertFalse(setResultClaimed, "setResult should be rejected after dismiss")
+    }
+
+    @Test
+    fun `setResult-then-dismiss scenario - dismiss does not reclaim`() {
+        val gate = LifecycleResultGate()
+
+        // setResult claims the gate
+        val setResultClaimed = gate.tryClaim()
+        // dismiss tries to claim after setResult
+        val dismissClaimed = gate.tryClaim()
+
+        assertTrue(setResultClaimed, "setResult should win the gate")
+        assertFalse(dismissClaimed, "dismiss should not reclaim after setResult")
+    }
+
+    @Test
+    fun `many claims after first all fail`() {
+        val gate = LifecycleResultGate()
+
+        assertTrue(gate.tryClaim())
+        repeat(10) {
+            assertFalse(gate.tryClaim())
+        }
+    }
+}

--- a/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/webview/RemoteContentIntegrityTest.kt
+++ b/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/webview/RemoteContentIntegrityTest.kt
@@ -86,8 +86,8 @@ class RemoteContentIntegrityTest {
     }
 
     @Test
-    fun `accepts empty content type`() {
-        assertTrue(RemoteContentIntegrity.isAcceptableContentType(""))
+    fun `rejects empty content type`() {
+        assertFalse(RemoteContentIntegrity.isAcceptableContentType(""))
     }
 
     @Test

--- a/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/webview/RemoteContentIntegrityTest.kt
+++ b/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/webview/RemoteContentIntegrityTest.kt
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package xyz.self.sdk.webview
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class RemoteContentIntegrityTest {
+
+    // -- normalizeSha256 --
+
+    @Test
+    fun `normalizeSha256 strips sha256- prefix`() {
+        assertEquals(
+            "abcdef1234567890",
+            RemoteContentIntegrity.normalizeSha256("sha256-abcdef1234567890"),
+        )
+    }
+
+    @Test
+    fun `normalizeSha256 strips 0x prefix`() {
+        assertEquals(
+            "abcdef1234567890",
+            RemoteContentIntegrity.normalizeSha256("0xabcdef1234567890"),
+        )
+    }
+
+    @Test
+    fun `normalizeSha256 strips sha256- then 0x prefix`() {
+        assertEquals(
+            "abcdef",
+            RemoteContentIntegrity.normalizeSha256("sha256-0xabcdef"),
+        )
+    }
+
+    @Test
+    fun `normalizeSha256 lowercases input`() {
+        assertEquals(
+            "abcdef",
+            RemoteContentIntegrity.normalizeSha256("ABCDEF"),
+        )
+    }
+
+    @Test
+    fun `normalizeSha256 returns raw hex unchanged`() {
+        assertEquals(
+            "abcdef1234567890",
+            RemoteContentIntegrity.normalizeSha256("abcdef1234567890"),
+        )
+    }
+
+    @Test
+    fun `normalizeSha256 does not strip interior sha256-`() {
+        assertEquals(
+            "absha256-cd",
+            RemoteContentIntegrity.normalizeSha256("absha256-cd"),
+        )
+    }
+
+    // -- sha256Hex --
+
+    @Test
+    fun `sha256Hex produces correct hash for known input`() {
+        // SHA-256 of empty byte array
+        assertEquals(
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            RemoteContentIntegrity.sha256Hex(byteArrayOf()),
+        )
+    }
+
+    @Test
+    fun `sha256Hex produces correct hash for hello`() {
+        assertEquals(
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+            RemoteContentIntegrity.sha256Hex("hello".toByteArray(Charsets.UTF_8)),
+        )
+    }
+
+    // -- isAcceptableContentType --
+
+    @Test
+    fun `accepts null content type`() {
+        assertTrue(RemoteContentIntegrity.isAcceptableContentType(null))
+    }
+
+    @Test
+    fun `accepts empty content type`() {
+        assertTrue(RemoteContentIntegrity.isAcceptableContentType(""))
+    }
+
+    @Test
+    fun `accepts text html`() {
+        assertTrue(RemoteContentIntegrity.isAcceptableContentType("text/html"))
+    }
+
+    @Test
+    fun `accepts text html with charset`() {
+        assertTrue(RemoteContentIntegrity.isAcceptableContentType("text/html; charset=utf-8"))
+    }
+
+    @Test
+    fun `accepts Text HTML case insensitive`() {
+        assertTrue(RemoteContentIntegrity.isAcceptableContentType("Text/HTML"))
+    }
+
+    @Test
+    fun `rejects application javascript`() {
+        assertFalse(RemoteContentIntegrity.isAcceptableContentType("application/javascript"))
+    }
+
+    @Test
+    fun `rejects application json`() {
+        assertFalse(RemoteContentIntegrity.isAcceptableContentType("application/json"))
+    }
+
+    @Test
+    fun `rejects text plain`() {
+        assertFalse(RemoteContentIntegrity.isAcceptableContentType("text/plain"))
+    }
+}

--- a/packages/native-shell-ios/Package.swift
+++ b/packages/native-shell-ios/Package.swift
@@ -22,6 +22,11 @@ let package = Package(
             resources: [
                 .copy("Resources/self-sdk-web")
             ]
+        ),
+        .testTarget(
+            name: "SelfNativeShellTests",
+            dependencies: ["SelfNativeShell"],
+            path: "Tests/SelfNativeShellTests"
         )
     ]
 )

--- a/packages/native-shell-ios/Sources/SelfNativeShell/API/SelfSdk.swift
+++ b/packages/native-shell-ios/Sources/SelfNativeShell/API/SelfSdk.swift
@@ -16,7 +16,7 @@ public final class SelfSdk {
 
 final class SelfSdkViewController: UIViewController {
     private let config: SelfSdkConfig
-    private weak var callback: SelfSdkCallback?
+    private let callback: SelfSdkCallback
     private var webViewHost: SelfWebViewHost?
 
     init(config: SelfSdkConfig, callback: SelfSdkCallback) {
@@ -46,6 +46,9 @@ final class SelfSdkViewController: UIViewController {
                     self?.callback?.onSuccess(result: [:])
                 }
             },
+            onFailure: { [weak self] error in
+                self?.callback?.onFailure(error: error)
+            },
             onDismiss: { [weak self] in
                 self?.callback?.onCancelled()
             }
@@ -58,7 +61,12 @@ final class SelfSdkViewController: UIViewController {
         router.register(handler: CryptoHandler())
         router.register(handler: lifecycleHandler)
 
-        let host = SelfWebViewHost(router: router, isDebugMode: config.isDebugMode)
+        let host = SelfWebViewHost(
+            router: router,
+            isDebugMode: config.isDebugMode,
+            remoteWebAppBaseURL: config.remoteWebAppBaseURL,
+            remoteWebAppIntegritySha256: config.remoteWebAppIntegritySha256
+        )
         self.webViewHost = host
 
         let webView = host.createWebView()

--- a/packages/native-shell-ios/Sources/SelfNativeShell/API/SelfSdkConfig.swift
+++ b/packages/native-shell-ios/Sources/SelfNativeShell/API/SelfSdkConfig.swift
@@ -19,6 +19,8 @@ public struct SelfSdkConfig {
     public let chainID: Int?
     public let userDefinedData: String?
     public let selfDefinedData: String?
+    public let remoteWebAppBaseURL: URL?
+    public let remoteWebAppIntegritySha256: String?
     public let secureStorageProvider: SecureStorageProvider
 
     public init(
@@ -38,6 +40,8 @@ public struct SelfSdkConfig {
         chainID: Int? = nil,
         userDefinedData: String? = nil,
         selfDefinedData: String? = nil,
+        remoteWebAppBaseURL: URL? = nil,
+        remoteWebAppIntegritySha256: String? = nil,
         secureStorageProvider: SecureStorageProvider
     ) {
         self.verificationId = verificationId
@@ -56,6 +60,8 @@ public struct SelfSdkConfig {
         self.chainID = chainID
         self.userDefinedData = userDefinedData
         self.selfDefinedData = selfDefinedData
+        self.remoteWebAppBaseURL = remoteWebAppBaseURL
+        self.remoteWebAppIntegritySha256 = remoteWebAppIntegritySha256
         self.secureStorageProvider = secureStorageProvider
     }
 

--- a/packages/native-shell-ios/Sources/SelfNativeShell/Handlers/LifecycleHandler.swift
+++ b/packages/native-shell-ios/Sources/SelfNativeShell/Handlers/LifecycleHandler.swift
@@ -8,12 +8,19 @@ final class LifecycleHandler: BridgeHandler {
 
     private weak var viewController: UIViewController?
     private let onResult: ((Any?) -> Void)?
+    private let onFailure: ((Error) -> Void)?
     private let onDismiss: (() -> Void)?
     private var hasEmittedResult = false
 
-    init(viewController: UIViewController?, onResult: ((Any?) -> Void)?, onDismiss: (() -> Void)?) {
+    init(
+        viewController: UIViewController?,
+        onResult: ((Any?) -> Void)?,
+        onFailure: ((Error) -> Void)?,
+        onDismiss: (() -> Void)?
+    ) {
         self.viewController = viewController
         self.onResult = onResult
+        self.onFailure = onFailure
         self.onDismiss = onDismiss
     }
 
@@ -31,10 +38,16 @@ final class LifecycleHandler: BridgeHandler {
             return nil
 
         case "setResult":
-            let result: Any? = params
+            let result = SelfLifecycleResultEnvelope.extractPayload(from: params)
+            let isSuccess = SelfLifecycleResultEnvelope.extractSuccess(from: result) ?? false
             await MainActor.run {
+                guard !hasEmittedResult else { return }
                 hasEmittedResult = true
-                onResult?(result)
+                if isSuccess {
+                    onResult?(result)
+                } else {
+                    onFailure?(SelfLifecycleResultError(payload: result))
+                }
                 dismiss()
             }
             return nil
@@ -49,11 +62,42 @@ final class LifecycleHandler: BridgeHandler {
         if let vc = viewController {
             vc.dismiss(animated: true) { [weak self] in
                 guard let self = self, !self.hasEmittedResult else { return }
+                self.hasEmittedResult = true
                 self.onDismiss?()
             }
         } else {
             guard !hasEmittedResult else { return }
+            hasEmittedResult = true
             onDismiss?()
         }
+    }
+}
+
+enum SelfLifecycleResultEnvelope {
+    static func extractPayload(from params: [String: Any]?) -> Any? {
+        guard let params else { return nil }
+        if let nestedResult = params["result"] {
+            return nestedResult
+        }
+        return params
+    }
+
+    static func extractSuccess(from payload: Any?) -> Bool? {
+        guard let payload = payload as? [String: Any] else { return nil }
+        return payload["success"] as? Bool
+    }
+}
+
+struct SelfLifecycleResultError: LocalizedError {
+    let payload: Any?
+
+    var errorDescription: String? {
+        if let payload = payload as? [String: Any],
+           let error = payload["error"] as? [String: Any],
+           let message = error["message"] as? String {
+            return message
+        }
+
+        return "Verification failed"
     }
 }

--- a/packages/native-shell-ios/Sources/SelfNativeShell/WebView/RemoteContentIntegrity.swift
+++ b/packages/native-shell-ios/Sources/SelfNativeShell/WebView/RemoteContentIntegrity.swift
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import Foundation
+
+// nil mimeType is allowed — some CDNs omit Content-Type; the SHA-256 hash is the primary integrity gate.
+enum RemoteContentIntegrity {
+    static func normalizeSha256(_ value: String) -> String {
+        var normalized = value.lowercased()
+        if normalized.hasPrefix("sha256-") {
+            normalized.removeFirst("sha256-".count)
+        }
+        if normalized.hasPrefix("0x") {
+            normalized.removeFirst(2)
+        }
+        return normalized
+    }
+
+    static func isAcceptableMimeType(_ mimeType: String?) -> Bool {
+        mimeType == nil || mimeType == "text/html"
+    }
+}

--- a/packages/native-shell-ios/Sources/SelfNativeShell/WebView/SelfWebViewHost.swift
+++ b/packages/native-shell-ios/Sources/SelfNativeShell/WebView/SelfWebViewHost.swift
@@ -1,17 +1,31 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+import CryptoKit
 import Foundation
 import UIKit
 import WebKit
 
 final class SelfWebViewHost: NSObject {
+    fileprivate static let bundledScheme = "self-sdk"
+    fileprivate static let bundledHost = "app"
+    fileprivate static let bundledRootFolder = "self-sdk-web"
+
     private var webView: WKWebView?
     private let router: MessageRouter
     private let isDebugMode: Bool
+    private let remoteWebAppBaseURL: URL?
+    private let remoteWebAppIntegritySha256: String?
 
-    init(router: MessageRouter, isDebugMode: Bool = false) {
+    init(
+        router: MessageRouter,
+        isDebugMode: Bool = false,
+        remoteWebAppBaseURL: URL? = nil,
+        remoteWebAppIntegritySha256: String? = nil
+    ) {
         self.router = router
         self.isDebugMode = isDebugMode
+        self.remoteWebAppBaseURL = remoteWebAppBaseURL
+        self.remoteWebAppIntegritySha256 = remoteWebAppIntegritySha256
         super.init()
     }
 
@@ -23,11 +37,13 @@ final class SelfWebViewHost: NSObject {
         config.preferences.javaScriptCanOpenWindowsAutomatically = false
         config.allowsInlineMediaPlayback = true
         config.mediaTypesRequiringUserActionForPlayback = []
+        config.setURLSchemeHandler(SelfBundledAssetSchemeHandler(), forURLScheme: SelfWebViewHost.bundledScheme)
 
         let webView = WKWebView(frame: .zero, configuration: config)
         webView.scrollView.bounces = false
         webView.isOpaque = false
         webView.backgroundColor = .clear
+        webView.navigationDelegate = self
 
         if #available(iOS 16.4, *) {
             webView.isInspectable = isDebugMode
@@ -41,25 +57,136 @@ final class SelfWebViewHost: NSObject {
         guard let webView = webView else { return }
 
         if isDebugMode {
-            let urlString = "http://localhost:5173/tunnel/tour/1?\(queryParams)"
-            if let url = URL(string: urlString) {
+            if let url = makeEntryURL(baseURL: URL(string: "http://localhost:5173"), queryParams: queryParams) {
                 webView.load(URLRequest(url: url))
             }
-        } else {
-            var urlString = "https://self-app-alpha.vercel.app/tunnel/tour/1"
-            if !queryParams.isEmpty {
-                urlString += "?\(queryParams)"
-            }
-            if let url = URL(string: urlString) {
-                webView.load(URLRequest(url: url))
-            }
+            return
         }
+
+        if let bundledURL = makeBundledEntryURL(queryParams: queryParams) {
+            webView.load(URLRequest(url: bundledURL))
+        }
+
+        loadVerifiedRemoteContent(queryParams: queryParams)
     }
 
     func evaluateJs(_ js: String) {
         DispatchQueue.main.async { [weak self] in
             self?.webView?.evaluateJavaScript(js, completionHandler: nil)
         }
+    }
+
+    private func makeBundledEntryURL(queryParams: String) -> URL? {
+        var components = URLComponents()
+        components.scheme = SelfWebViewHost.bundledScheme
+        components.host = SelfWebViewHost.bundledHost
+        components.path = "/tunnel/tour/1"
+        components.percentEncodedQuery = queryParams.isEmpty ? nil : queryParams
+        return components.url
+    }
+
+    private func makeEntryURL(baseURL: URL?, queryParams: String) -> URL? {
+        guard let baseURL else { return nil }
+        guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+
+        let basePath = components.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        components.path = "/" + [basePath, "tunnel", "tour", "1"].filter { !$0.isEmpty }.joined(separator: "/")
+        components.percentEncodedQuery = queryParams.isEmpty ? nil : queryParams
+        return components.url
+    }
+
+    private func loadVerifiedRemoteContent(queryParams: String) {
+        guard let expectedSha256 = remoteWebAppIntegritySha256?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !expectedSha256.isEmpty,
+              let remoteURL = makeEntryURL(baseURL: remoteWebAppBaseURL, queryParams: queryParams) else {
+            return
+        }
+
+        Task.detached { [weak self] in
+            guard let self else { return }
+            guard await self.verifyRemoteEntry(url: remoteURL, expectedSha256: expectedSha256) else {
+                return
+            }
+
+            await MainActor.run {
+                self.webView?.load(URLRequest(url: remoteURL))
+            }
+        }
+    }
+
+    private func verifyRemoteEntry(url: URL, expectedSha256: String) async -> Bool {
+        do {
+            let configuration = URLSessionConfiguration.ephemeral
+            configuration.timeoutIntervalForRequest = 5
+            configuration.timeoutIntervalForResource = 5
+            let session = URLSession(configuration: configuration)
+            let (data, response) = try await session.data(from: url)
+            guard let httpResponse = response as? HTTPURLResponse, (200...299).contains(httpResponse.statusCode) else {
+                return false
+            }
+            guard RemoteContentIntegrity.isAcceptableMimeType(response.mimeType) else {
+                return false
+            }
+
+            let digest = SHA256.hash(data: data)
+            let actualHash = digest.map { String(format: "%02x", $0) }.joined()
+            return actualHash == normalizeSha256(expectedSha256)
+        } catch {
+            return false
+        }
+    }
+
+    private func normalizeSha256(_ value: String) -> String {
+        RemoteContentIntegrity.normalizeSha256(value)
+    }
+
+    private func isAllowedNavigation(url: URL) -> Bool {
+        if isDebugMode {
+            return url.absoluteString.hasPrefix("http://localhost:5173")
+        }
+
+        if url.scheme == SelfWebViewHost.bundledScheme, url.host == SelfWebViewHost.bundledHost {
+            return true
+        }
+
+        guard let remoteWebAppBaseURL else {
+            return false
+        }
+
+        return url.scheme == remoteWebAppBaseURL.scheme &&
+            url.host == remoteWebAppBaseURL.host &&
+            resolvedPort(for: url) == resolvedPort(for: remoteWebAppBaseURL)
+    }
+
+    private func resolvedPort(for url: URL) -> Int {
+        if let port = url.port {
+            return port
+        }
+        switch url.scheme {
+        case "https":
+            return 443
+        case "http":
+            return 80
+        default:
+            return -1
+        }
+    }
+}
+
+extension SelfWebViewHost: WKNavigationDelegate {
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
+        guard let url = navigationAction.request.url else {
+            decisionHandler(.cancel)
+            return
+        }
+
+        decisionHandler(isAllowedNavigation(url: url) ? .allow : .cancel)
     }
 }
 
@@ -73,6 +200,84 @@ extension SelfWebViewHost: WKScriptMessageHandler {
             return
         }
         router.onMessageReceived(rawJson: body)
+    }
+}
+
+private final class SelfBundledAssetSchemeHandler: NSObject, WKURLSchemeHandler {
+    func webView(_ webView: WKWebView, start urlSchemeTask: WKURLSchemeTask) {
+        guard let requestURL = urlSchemeTask.request.url,
+              let rootURL = Bundle.module.resourceURL?.appendingPathComponent(
+                SelfWebViewHost.bundledRootFolder,
+                isDirectory: true
+              ),
+              let fileURL = resolveFileURL(for: requestURL, rootURL: rootURL) else {
+            urlSchemeTask.didFailWithError(NSError(domain: NSURLErrorDomain, code: NSURLErrorFileDoesNotExist))
+            return
+        }
+
+        do {
+            let data = try Data(contentsOf: fileURL)
+            let response = URLResponse(
+                url: requestURL,
+                mimeType: mimeType(for: fileURL.pathExtension),
+                expectedContentLength: data.count,
+                textEncodingName: textEncodingName(for: fileURL.pathExtension)
+            )
+            urlSchemeTask.didReceive(response)
+            urlSchemeTask.didReceive(data)
+            urlSchemeTask.didFinish()
+        } catch {
+            urlSchemeTask.didFailWithError(error)
+        }
+    }
+
+    func webView(_ webView: WKWebView, stop urlSchemeTask: WKURLSchemeTask) {}
+
+    private func resolveFileURL(for requestURL: URL, rootURL: URL) -> URL? {
+        let rawPath = requestURL.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let normalizedPath = rawPath.removingPercentEncoding ?? rawPath
+        let relativePath = normalizedPath.isEmpty || !normalizedPath.contains(".") ? "index.html" : normalizedPath
+        return rootURL.appendingPathComponent(relativePath, isDirectory: false)
+    }
+
+    private func mimeType(for pathExtension: String) -> String {
+        switch pathExtension.lowercased() {
+        case "html":
+            return "text/html"
+        case "js":
+            return "application/javascript"
+        case "css":
+            return "text/css"
+        case "json":
+            return "application/json"
+        case "svg":
+            return "image/svg+xml"
+        case "png":
+            return "image/png"
+        case "jpg", "jpeg":
+            return "image/jpeg"
+        case "woff2":
+            return "font/woff2"
+        case "woff":
+            return "font/woff"
+        case "ttf":
+            return "font/ttf"
+        case "otf":
+            return "font/otf"
+        case "wav":
+            return "audio/wav"
+        default:
+            return "application/octet-stream"
+        }
+    }
+
+    private func textEncodingName(for pathExtension: String) -> String? {
+        switch pathExtension.lowercased() {
+        case "html", "js", "css", "json", "svg":
+            return "utf-8"
+        default:
+            return nil
+        }
     }
 }
 

--- a/packages/native-shell-ios/Sources/SelfNativeShell/WebView/SelfWebViewHost.swift
+++ b/packages/native-shell-ios/Sources/SelfNativeShell/WebView/SelfWebViewHost.swift
@@ -106,17 +106,17 @@ final class SelfWebViewHost: NSObject {
 
         Task.detached { [weak self] in
             guard let self else { return }
-            guard await self.verifyRemoteEntry(url: remoteURL, expectedSha256: expectedSha256) else {
+            guard let verifiedHTML = await self.fetchAndVerifyRemoteEntry(url: remoteURL, expectedSha256: expectedSha256) else {
                 return
             }
 
             await MainActor.run {
-                self.webView?.load(URLRequest(url: remoteURL))
+                self.webView?.loadHTMLString(verifiedHTML, baseURL: remoteURL)
             }
         }
     }
 
-    private func verifyRemoteEntry(url: URL, expectedSha256: String) async -> Bool {
+    private func fetchAndVerifyRemoteEntry(url: URL, expectedSha256: String) async -> String? {
         do {
             let configuration = URLSessionConfiguration.ephemeral
             configuration.timeoutIntervalForRequest = 5
@@ -124,17 +124,20 @@ final class SelfWebViewHost: NSObject {
             let session = URLSession(configuration: configuration)
             let (data, response) = try await session.data(from: url)
             guard let httpResponse = response as? HTTPURLResponse, (200...299).contains(httpResponse.statusCode) else {
-                return false
+                return nil
             }
             guard RemoteContentIntegrity.isAcceptableMimeType(response.mimeType) else {
-                return false
+                return nil
             }
 
             let digest = SHA256.hash(data: data)
             let actualHash = digest.map { String(format: "%02x", $0) }.joined()
-            return actualHash == normalizeSha256(expectedSha256)
+            guard actualHash == normalizeSha256(expectedSha256) else {
+                return nil
+            }
+            return String(data: data, encoding: .utf8)
         } catch {
-            return false
+            return nil
         }
     }
 

--- a/packages/native-shell-ios/Tests/SelfNativeShellTests/LifecycleHandlerRaceTests.swift
+++ b/packages/native-shell-ios/Tests/SelfNativeShellTests/LifecycleHandlerRaceTests.swift
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import XCTest
+@testable import SelfNativeShell
+
+final class LifecycleHandlerRaceTests: XCTestCase {
+
+    // MARK: - setResult then dismiss
+
+    func testSetResultThenDismissOnlyFiresResultCallback() async throws {
+        var resultCalled = false
+        var failureCalled = false
+        var dismissCalled = false
+
+        let handler = LifecycleHandler(
+            viewController: nil,
+            onResult: { _ in resultCalled = true },
+            onFailure: { _ in failureCalled = true },
+            onDismiss: { dismissCalled = true }
+        )
+
+        _ = try await handler.handle(
+            method: "setResult",
+            params: ["result": ["success": true] as [String: Any]]
+        )
+        _ = try await handler.handle(method: "dismiss", params: nil)
+
+        XCTAssertTrue(resultCalled, "onResult should fire from setResult")
+        XCTAssertFalse(failureCalled, "onFailure should not fire for success")
+        XCTAssertFalse(dismissCalled, "onDismiss should not fire after setResult already claimed")
+    }
+
+    // MARK: - dismiss then setResult
+
+    func testDismissThenSetResultOnlyFiresDismissCallback() async throws {
+        var resultCalled = false
+        var failureCalled = false
+        var dismissCalled = false
+
+        let handler = LifecycleHandler(
+            viewController: nil,
+            onResult: { _ in resultCalled = true },
+            onFailure: { _ in failureCalled = true },
+            onDismiss: { dismissCalled = true }
+        )
+
+        _ = try await handler.handle(method: "dismiss", params: nil)
+        _ = try await handler.handle(
+            method: "setResult",
+            params: ["result": ["success": true] as [String: Any]]
+        )
+
+        XCTAssertTrue(dismissCalled, "onDismiss should fire from dismiss")
+        XCTAssertFalse(resultCalled, "onResult should not fire after dismiss already claimed")
+        XCTAssertFalse(failureCalled, "onFailure should not fire")
+    }
+
+    // MARK: - failure routing
+
+    func testSetResultWithFailureRoutesToOnFailure() async throws {
+        var resultCalled = false
+        var failureCalled = false
+
+        let handler = LifecycleHandler(
+            viewController: nil,
+            onResult: { _ in resultCalled = true },
+            onFailure: { _ in failureCalled = true },
+            onDismiss: nil
+        )
+
+        _ = try await handler.handle(
+            method: "setResult",
+            params: ["result": ["success": false, "error": ["message": "timeout"]] as [String: Any]]
+        )
+
+        XCTAssertFalse(resultCalled, "onResult should not fire for failure")
+        XCTAssertTrue(failureCalled, "onFailure should fire for success=false")
+    }
+
+    // MARK: - double setResult
+
+    func testDoubleSetResultOnlyFiresOnce() async throws {
+        var resultCallCount = 0
+
+        let handler = LifecycleHandler(
+            viewController: nil,
+            onResult: { _ in resultCallCount += 1 },
+            onFailure: nil,
+            onDismiss: nil
+        )
+
+        _ = try await handler.handle(
+            method: "setResult",
+            params: ["result": ["success": true] as [String: Any]]
+        )
+        _ = try await handler.handle(
+            method: "setResult",
+            params: ["result": ["success": true] as [String: Any]]
+        )
+
+        XCTAssertEqual(resultCallCount, 1, "onResult should fire exactly once")
+    }
+
+    // MARK: - double dismiss
+
+    func testDoubleDismissOnlyFiresOnce() async throws {
+        var dismissCallCount = 0
+
+        let handler = LifecycleHandler(
+            viewController: nil,
+            onResult: nil,
+            onFailure: nil,
+            onDismiss: { dismissCallCount += 1 }
+        )
+
+        _ = try await handler.handle(method: "dismiss", params: nil)
+        _ = try await handler.handle(method: "dismiss", params: nil)
+
+        XCTAssertEqual(dismissCallCount, 1, "onDismiss should fire exactly once")
+    }
+}

--- a/packages/native-shell-ios/Tests/SelfNativeShellTests/LifecycleResultEnvelopeTests.swift
+++ b/packages/native-shell-ios/Tests/SelfNativeShellTests/LifecycleResultEnvelopeTests.swift
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import XCTest
+@testable import SelfNativeShell
+
+final class LifecycleResultEnvelopeTests: XCTestCase {
+
+    // MARK: - extractPayload
+
+    func testExtractPayloadUnwrapsNestedResult() {
+        let inner: [String: Any] = ["success": true, "data": "value"]
+        let params: [String: Any] = ["result": inner, "extra": "ignored"]
+
+        let payload = SelfLifecycleResultEnvelope.extractPayload(from: params)
+
+        XCTAssertNotNil(payload)
+        let dict = payload as? [String: Any]
+        XCTAssertEqual(dict?["success"] as? Bool, true)
+        XCTAssertEqual(dict?["data"] as? String, "value")
+    }
+
+    func testExtractPayloadFallsBackToParamsWhenResultMissing() {
+        let params: [String: Any] = ["success": false, "error": "oops"]
+
+        let payload = SelfLifecycleResultEnvelope.extractPayload(from: params)
+
+        let dict = payload as? [String: Any]
+        XCTAssertEqual(dict?["success"] as? Bool, false)
+        XCTAssertEqual(dict?["error"] as? String, "oops")
+    }
+
+    func testExtractPayloadReturnsNilForNilParams() {
+        let payload = SelfLifecycleResultEnvelope.extractPayload(from: nil)
+
+        XCTAssertNil(payload)
+    }
+
+    // MARK: - extractSuccess
+
+    func testExtractSuccessReturnsTrueWhenSuccessIsTrue() {
+        let payload: [String: Any] = ["success": true]
+
+        let result = SelfLifecycleResultEnvelope.extractSuccess(from: payload)
+
+        XCTAssertEqual(result, true)
+    }
+
+    func testExtractSuccessReturnsFalseWhenSuccessIsFalse() {
+        let payload: [String: Any] = ["success": false]
+
+        let result = SelfLifecycleResultEnvelope.extractSuccess(from: payload)
+
+        XCTAssertEqual(result, false)
+    }
+
+    func testExtractSuccessReturnsNilWhenSuccessMissing() {
+        let payload: [String: Any] = ["data": "value"]
+
+        let result = SelfLifecycleResultEnvelope.extractSuccess(from: payload)
+
+        XCTAssertNil(result)
+    }
+
+    func testExtractSuccessReturnsNilWhenSuccessIsNotBool() {
+        let payload: [String: Any] = ["success": "yes"]
+
+        let result = SelfLifecycleResultEnvelope.extractSuccess(from: payload)
+
+        XCTAssertNil(result)
+    }
+
+    func testExtractSuccessReturnsNilForNonDictPayload() {
+        let result = SelfLifecycleResultEnvelope.extractSuccess(from: "not-a-dict")
+
+        XCTAssertNil(result)
+    }
+
+    func testExtractSuccessReturnsNilForNilPayload() {
+        let result = SelfLifecycleResultEnvelope.extractSuccess(from: nil)
+
+        XCTAssertNil(result)
+    }
+
+    // MARK: - SelfLifecycleResultError
+
+    func testResultErrorExtractsNestedErrorMessage() {
+        let payload: [String: Any] = [
+            "success": false,
+            "error": ["code": "TIMEOUT", "message": "Request timed out"],
+        ]
+        let error = SelfLifecycleResultError(payload: payload)
+
+        XCTAssertEqual(error.localizedDescription, "Request timed out")
+    }
+
+    func testResultErrorFallsBackToDefaultMessage() {
+        let error = SelfLifecycleResultError(payload: nil)
+
+        XCTAssertEqual(error.localizedDescription, "Verification failed")
+    }
+
+    func testResultErrorFallsBackWhenPayloadHasNoErrorKey() {
+        let payload: [String: Any] = ["success": false]
+        let error = SelfLifecycleResultError(payload: payload)
+
+        XCTAssertEqual(error.localizedDescription, "Verification failed")
+    }
+}

--- a/packages/native-shell-ios/Tests/SelfNativeShellTests/RemoteContentIntegrityTests.swift
+++ b/packages/native-shell-ios/Tests/SelfNativeShellTests/RemoteContentIntegrityTests.swift
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import XCTest
+@testable import SelfNativeShell
+
+final class RemoteContentIntegrityTests: XCTestCase {
+
+    // MARK: - normalizeSha256
+
+    func testStripsShaPrefixOnly() {
+        XCTAssertEqual(
+            RemoteContentIntegrity.normalizeSha256("sha256-abcdef1234567890"),
+            "abcdef1234567890"
+        )
+    }
+
+    func testStrips0xPrefixOnly() {
+        XCTAssertEqual(
+            RemoteContentIntegrity.normalizeSha256("0xabcdef1234567890"),
+            "abcdef1234567890"
+        )
+    }
+
+    func testStripsSha256Then0xPrefix() {
+        XCTAssertEqual(
+            RemoteContentIntegrity.normalizeSha256("sha256-0xabcdef"),
+            "abcdef"
+        )
+    }
+
+    func testLowercasesInput() {
+        XCTAssertEqual(
+            RemoteContentIntegrity.normalizeSha256("ABCDEF"),
+            "abcdef"
+        )
+    }
+
+    func testRawHexPassesThrough() {
+        XCTAssertEqual(
+            RemoteContentIntegrity.normalizeSha256("abcdef1234567890"),
+            "abcdef1234567890"
+        )
+    }
+
+    func testDoesNotStripInteriorSha256() {
+        XCTAssertEqual(
+            RemoteContentIntegrity.normalizeSha256("absha256-cd"),
+            "absha256-cd"
+        )
+    }
+
+    func testDoesNotStripInterior0x() {
+        XCTAssertEqual(
+            RemoteContentIntegrity.normalizeSha256("ab0xcd"),
+            "ab0xcd"
+        )
+    }
+
+    // MARK: - isAcceptableMimeType
+
+    func testAcceptsNilMimeType() {
+        XCTAssertTrue(RemoteContentIntegrity.isAcceptableMimeType(nil))
+    }
+
+    func testAcceptsTextHtml() {
+        XCTAssertTrue(RemoteContentIntegrity.isAcceptableMimeType("text/html"))
+    }
+
+    func testRejectsApplicationJavascript() {
+        XCTAssertFalse(RemoteContentIntegrity.isAcceptableMimeType("application/javascript"))
+    }
+
+    func testRejectsApplicationJson() {
+        XCTAssertFalse(RemoteContentIntegrity.isAcceptableMimeType("application/json"))
+    }
+
+    func testRejectsTextPlain() {
+        XCTAssertFalse(RemoteContentIntegrity.isAcceptableMimeType("text/plain"))
+    }
+
+    func testRejectsEmptyString() {
+        XCTAssertFalse(RemoteContentIntegrity.isAcceptableMimeType(""))
+    }
+}

--- a/packages/webview-app/package.json
+++ b/packages/webview-app/package.json
@@ -13,6 +13,8 @@
     "lint:fix": "eslint . --fix --max-warnings=0",
     "nice": "prettier --write . && eslint . --fix && tsc --noEmit",
     "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "types": "tsc --noEmit"
   },

--- a/packages/webview-app/src/screens/onboarding/ProviderLaunchScreen.tsx
+++ b/packages/webview-app/src/screens/onboarding/ProviderLaunchScreen.tsx
@@ -15,6 +15,7 @@ import type { KycProviderResult } from '../../types/kycProvider';
 import { buildKycDocument } from '../../utils/buildKycDocument';
 import { waitForAttestation } from '../../utils/diditAttestation';
 import { createDiditSession, launchDiditWebSdk } from '../../utils/diditProvider';
+import { WEB_SAFE_AREA } from '../../utils/insets';
 
 const CONTAINER_ID = 'didit-sdk-container';
 
@@ -293,7 +294,7 @@ export const ProviderLaunchScreen: React.FC = () => {
     >
       {phase === 'waiting' && (
         <KycPendingScreen
-          insets={{ top: 0, bottom: 0 }}
+          {...WEB_SAFE_AREA}
           onCheckBackLater={handleBack}
           onReceiveLiveUpdates={() => {
             // TODO: wire up push notifications

--- a/packages/webview-app/src/screens/recovery/SecretPhraseInputScreen.tsx
+++ b/packages/webview-app/src/screens/recovery/SecretPhraseInputScreen.tsx
@@ -47,7 +47,13 @@ const EMPTY_WORDS = Array.from<string>({ length: WORD_COUNT }).fill('');
 const instruction = 'Enter your recovery phrase to restore your account, registered IDs, and activity history';
 
 class RecoveryFlowError extends Error {
-  constructor(readonly reason: 'storage_write_failed' | 'document_finalization_failed' | 'unexpected_error') {
+  constructor(
+    readonly reason:
+      | 'document_unavailable'
+      | 'storage_write_failed'
+      | 'document_finalization_failed'
+      | 'unexpected_error',
+  ) {
     super(reason);
   }
 }
@@ -180,7 +186,11 @@ export const SecretPhraseInputScreen: React.FC = () => {
       }
 
       const selectedDocument = await loadSelectedDocument(client);
-      const hasRealDocument = selectedDocument && !selectedDocument.metadata.mock;
+      if (selectedDocument === null) {
+        throw new RecoveryFlowError('document_unavailable');
+      }
+
+      const hasRealDocument = !selectedDocument.metadata.mock;
 
       if (!hasRealDocument) {
         await restoreSecretFromMnemonic(storage, mnemonic);
@@ -193,7 +203,9 @@ export const SecretPhraseInputScreen: React.FC = () => {
 
         haptic.trigger('success');
         analytics.trackEvent('recovery_phrase_recovered', { documentCategory: 'none' });
-        navigate('/tunnel/kyc', { replace: true });
+        if (isMountedRef.current) {
+          navigate('/tunnel/kyc', { replace: true });
+        }
         return;
       } else {
         derivedSecret = derivePrivateKey(mnemonic);
@@ -250,10 +262,12 @@ export const SecretPhraseInputScreen: React.FC = () => {
       analytics.trackEvent('recovery_phrase_recovered', {
         documentCategory: selectedDocument.data.documentCategory,
       });
-      if (returnTo) {
-        navigate(returnTo, { replace: true });
-      } else {
-        navigate('/recovery/success');
+      if (isMountedRef.current) {
+        if (returnTo) {
+          navigate(returnTo, { replace: true });
+        } else {
+          navigate('/recovery/success');
+        }
       }
     } catch (error) {
       const reason = error instanceof RecoveryFlowError ? error.reason : 'unexpected_error';
@@ -262,10 +276,12 @@ export const SecretPhraseInputScreen: React.FC = () => {
       analytics.trackEvent('recovery_phrase_failed', {
         reason,
       });
-      navigate(buildRecoveryTarget('/recovery/failure', returnTo), {
-        replace: true,
-        state: returnTo ? { returnTo } : undefined,
-      });
+      if (isMountedRef.current) {
+        navigate(buildRecoveryTarget('/recovery/failure', returnTo), {
+          replace: true,
+          state: returnTo ? { returnTo } : undefined,
+        });
+      }
     } finally {
       derivedSecret = null;
       if (isMountedRef.current) {

--- a/packages/webview-app/src/screens/tunnel/TourScreen.tsx
+++ b/packages/webview-app/src/screens/tunnel/TourScreen.tsx
@@ -24,31 +24,32 @@ export const TourScreen: React.FC = () => {
       return;
     }
 
-    const selectedDoc = await loadSelectedDocument(client);
-
-    console.log('selected Doc', selectedDoc);
-    const isRegisteredRealDoc = selectedDoc?.metadata?.isRegistered === true;
-
-    if (isRegisteredRealDoc) {
-      navigate('/tunnel/proof/disclose');
-    } else {
-      navigate('/tunnel/kyc');
+    try {
+      const selectedDoc = await loadSelectedDocument(client);
+      if (selectedDoc?.metadata?.isRegistered === true) {
+        navigate('/tunnel/proof/disclose');
+        return;
+      }
+    } catch {
+      // Fall through to KYC when document state is unavailable.
     }
+
+    navigate('/tunnel/kyc');
   }, [navigate, stepNum, client]);
 
-  const onResore = useCallback(() => {
+  const onRestore = useCallback(() => {
     navigate('/recovery');
   }, []);
 
   switch (step) {
     case '1':
-      return <LaunchTour1Screen {...WEB_SAFE_AREA} onNext={onNext} onRestore={onResore} />;
+      return <LaunchTour1Screen {...WEB_SAFE_AREA} onNext={onNext} onRestore={onRestore} />;
     case '2':
-      return <LaunchTour2Screen {...WEB_SAFE_AREA} onNext={onNext} onRestore={onResore} />;
+      return <LaunchTour2Screen {...WEB_SAFE_AREA} onNext={onNext} onRestore={onRestore} />;
     case '3':
-      return <LaunchTour3Screen {...WEB_SAFE_AREA} onNext={onNext} onRestore={onResore} />;
+      return <LaunchTour3Screen {...WEB_SAFE_AREA} onNext={onNext} onRestore={onRestore} />;
     case '4':
-      return <LaunchTour4Screen {...WEB_SAFE_AREA} onNext={onNext} onRestore={onResore} />;
+      return <LaunchTour4Screen {...WEB_SAFE_AREA} onNext={onNext} onRestore={onRestore} />;
     default:
       return <Navigate to="/tunnel/tour/1" replace />;
   }

--- a/packages/webview-app/src/screens/tunnel/TunnelProvingScreen.tsx
+++ b/packages/webview-app/src/screens/tunnel/TunnelProvingScreen.tsx
@@ -105,13 +105,18 @@ export const TunnelProvingScreen: React.FC = () => {
       });
       navigateToError(reason ?? errorCode ?? currentState);
     } else if (currentState === 'completed' && phase === 'dsc') {
+      setInitDone(false);
       setPhase('register');
       analytics.trackEvent('tunnel_proving_registration_complete', { previousPhase: 'dsc' });
-      void Promise.resolve(init(client, 'register', true)).catch(err => {
-        const message = err instanceof Error ? err.message : 'Register init failed';
-        analytics.trackEvent('tunnel_proving_init_failed', { error: message, phase: 'register' });
-        navigateToError(message);
-      });
+      void Promise.resolve(init(client, 'register', true))
+        .catch(err => {
+          const message = err instanceof Error ? err.message : 'Register init failed';
+          analytics.trackEvent('tunnel_proving_init_failed', { error: message, phase: 'register' });
+          navigateToError(message);
+        })
+        .finally(() => {
+          setInitDone(true);
+        });
     } else if (currentState === 'completed' && phase === 'register') {
       analytics.trackEvent('tunnel_proving_registration_complete', { previousPhase: 'register' });
       navigate('/tunnel/proof/disclose', { replace: true });

--- a/packages/webview-app/src/screens/tunnel/TunnelProvingScreen.tsx
+++ b/packages/webview-app/src/screens/tunnel/TunnelProvingScreen.tsx
@@ -109,13 +109,13 @@ export const TunnelProvingScreen: React.FC = () => {
       setPhase('register');
       analytics.trackEvent('tunnel_proving_registration_complete', { previousPhase: 'dsc' });
       void Promise.resolve(init(client, 'register', true))
+        .then(() => {
+          setInitDone(true);
+        })
         .catch(err => {
           const message = err instanceof Error ? err.message : 'Register init failed';
           analytics.trackEvent('tunnel_proving_init_failed', { error: message, phase: 'register' });
           navigateToError(message);
-        })
-        .finally(() => {
-          setInitDone(true);
         });
     } else if (currentState === 'completed' && phase === 'register') {
       analytics.trackEvent('tunnel_proving_registration_complete', { previousPhase: 'register' });

--- a/packages/webview-app/src/utils/secretManager.ts
+++ b/packages/webview-app/src/utils/secretManager.ts
@@ -44,6 +44,15 @@ function withSecretLock<T>(fn: () => Promise<T>): Promise<T> {
   return next;
 }
 
+async function readStoredSecretSnapshotUnlocked(storage: BridgeStorageAdapter): Promise<StoredSecretSnapshot> {
+  const [mnemonic, secret] = await Promise.all([storage.get(MNEMONIC_KEY), storage.get(PRIVATE_KEY_KEY)]);
+
+  return {
+    mnemonic,
+    secret,
+  };
+}
+
 export function ensureSecret(storage: BridgeStorageAdapter): Promise<void> {
   return withSecretLock(async () => {
     const existing = await storage.get(PRIVATE_KEY_KEY);
@@ -72,12 +81,7 @@ export function ensureSecret(storage: BridgeStorageAdapter): Promise<void> {
 }
 
 export async function readStoredSecretSnapshot(storage: BridgeStorageAdapter): Promise<StoredSecretSnapshot> {
-  const [mnemonic, secret] = await Promise.all([storage.get(MNEMONIC_KEY), storage.get(PRIVATE_KEY_KEY)]);
-
-  return {
-    mnemonic,
-    secret,
-  };
+  return withSecretLock(() => readStoredSecretSnapshotUnlocked(storage));
 }
 
 export function restoreSecretFromMnemonic(
@@ -87,7 +91,7 @@ export function restoreSecretFromMnemonic(
   const secret = derivePrivateKey(mnemonic);
 
   return withSecretLock(async () => {
-    const previousSnapshot = await readStoredSecretSnapshot(storage);
+    const previousSnapshot = await readStoredSecretSnapshotUnlocked(storage);
 
     try {
       await storage.set(MNEMONIC_KEY, mnemonic);
@@ -105,7 +109,16 @@ export function restoreStoredSecretSnapshot(
   storage: BridgeStorageAdapter,
   snapshot: StoredSecretSnapshot,
 ): Promise<void> {
-  return withSecretLock(() => writeSnapshot(storage, snapshot));
+  return withSecretLock(async () => {
+    const previousSnapshot = await readStoredSecretSnapshotUnlocked(storage);
+
+    try {
+      await writeSnapshot(storage, snapshot);
+    } catch (error) {
+      await writeSnapshot(storage, previousSnapshot);
+      throw error;
+    }
+  });
 }
 
 async function writeSnapshot(storage: BridgeStorageAdapter, snapshot: StoredSecretSnapshot): Promise<void> {

--- a/packages/webview-app/src/utils/secretManager.ts
+++ b/packages/webview-app/src/utils/secretManager.ts
@@ -97,7 +97,7 @@ export function restoreSecretFromMnemonic(
       await storage.set(MNEMONIC_KEY, mnemonic);
       await storage.set(PRIVATE_KEY_KEY, secret);
     } catch (error) {
-      await writeSnapshot(storage, previousSnapshot);
+      await restoreSnapshotBestEffort(storage, previousSnapshot, 'secret restore from mnemonic');
       throw error;
     }
 
@@ -115,22 +115,53 @@ export function restoreStoredSecretSnapshot(
     try {
       await writeSnapshot(storage, snapshot);
     } catch (error) {
-      await writeSnapshot(storage, previousSnapshot);
+      await restoreSnapshotBestEffort(storage, previousSnapshot, 'secret snapshot restore');
       throw error;
     }
   });
 }
 
-async function writeSnapshot(storage: BridgeStorageAdapter, snapshot: StoredSecretSnapshot): Promise<void> {
-  if (snapshot.mnemonic === null) {
-    await storage.remove(MNEMONIC_KEY);
-  } else {
-    await storage.set(MNEMONIC_KEY, snapshot.mnemonic);
+async function restoreSnapshotBestEffort(
+  storage: BridgeStorageAdapter,
+  snapshot: StoredSecretSnapshot,
+  context: string,
+): Promise<void> {
+  const rollbackFailures: Error[] = [];
+
+  try {
+    await writeMnemonic(storage, snapshot.mnemonic);
+  } catch (rollbackError) {
+    rollbackFailures.push(rollbackError instanceof Error ? rollbackError : new Error(String(rollbackError)));
   }
 
-  if (snapshot.secret === null) {
+  try {
+    await writeSecret(storage, snapshot.secret);
+  } catch (rollbackError) {
+    rollbackFailures.push(rollbackError instanceof Error ? rollbackError : new Error(String(rollbackError)));
+  }
+
+  if (rollbackFailures.length > 0) {
+    console.error(`Rollback failed during ${context}:`, rollbackFailures);
+  }
+}
+
+async function writeSnapshot(storage: BridgeStorageAdapter, snapshot: StoredSecretSnapshot): Promise<void> {
+  await writeMnemonic(storage, snapshot.mnemonic);
+  await writeSecret(storage, snapshot.secret);
+}
+
+async function writeMnemonic(storage: BridgeStorageAdapter, mnemonic: string | null): Promise<void> {
+  if (mnemonic === null) {
+    await storage.remove(MNEMONIC_KEY);
+  } else {
+    await storage.set(MNEMONIC_KEY, mnemonic);
+  }
+}
+
+async function writeSecret(storage: BridgeStorageAdapter, secret: string | null): Promise<void> {
+  if (secret === null) {
     await storage.remove(PRIVATE_KEY_KEY);
   } else {
-    await storage.set(PRIVATE_KEY_KEY, snapshot.secret);
+    await storage.set(PRIVATE_KEY_KEY, secret);
   }
 }

--- a/packages/webview-app/tests/screens/recovery/secretPhraseInputScreen.test.tsx
+++ b/packages/webview-app/tests/screens/recovery/secretPhraseInputScreen.test.tsx
@@ -70,7 +70,7 @@ const VALID_12_MNEMONIC = 'abandon abandon abandon abandon abandon abandon aband
 
 vi.mock('@selfxyz/euclid', () => ({
   Button: ({ text, onPress, disabled }: { text: string; onPress: () => void; disabled?: boolean }) => (
-    <button onClick={onPress} disabled={disabled} type="button">
+    <button onClick={onPress} disabled={disabled ?? false} type="button">
       {text}
     </button>
   ),
@@ -111,6 +111,13 @@ const renderScreen = (initialEntry = '/recovery/phrase-input') =>
     </MemoryRouter>,
   );
 
+async function fillWordsAndSubmit() {
+  await act(async () => {
+    await new Promise(r => setTimeout(r, 0));
+  });
+  fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+}
+
 describe('SecretPhraseInputScreen', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -132,12 +139,7 @@ describe('SecretPhraseInputScreen', () => {
     loadSelectedDocumentMock.mockResolvedValue(null);
 
     renderScreen();
-
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /continue/i })).not.toBeDisabled();
-    });
-
-    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+    await fillWordsAndSubmit();
 
     await waitFor(() => {
       expectLocation('/recovery/failure');
@@ -156,12 +158,7 @@ describe('SecretPhraseInputScreen', () => {
     });
 
     renderScreen();
-
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /continue/i })).not.toBeDisabled();
-    });
-
-    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+    await fillWordsAndSubmit();
 
     await waitFor(() => {
       expectLocation('/tunnel/kyc');
@@ -177,24 +174,15 @@ describe('SecretPhraseInputScreen', () => {
     );
 
     const { unmount } = renderScreen();
+    await fillWordsAndSubmit();
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /continue/i })).not.toBeDisabled();
-    });
-
-    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
-
-    // Unmount while loadSelectedDocument is still pending
     unmount();
 
-    // Now resolve — the navigate guard should prevent navigation
     await act(async () => {
       resolveDocument(null);
       await new Promise(r => setTimeout(r, 0));
     });
 
-    // If we got here without errors, the guard worked (navigate was not called
-    // after unmount, which would throw in react-router with no Router context)
     expect(haptic.trigger).toHaveBeenCalledWith('error');
   });
 
@@ -210,12 +198,7 @@ describe('SecretPhraseInputScreen', () => {
     restoreSecretFromMnemonicMock.mockRejectedValue(new Error('write failed'));
 
     renderScreen();
-
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /continue/i })).not.toBeDisabled();
-    });
-
-    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+    await fillWordsAndSubmit();
 
     await waitFor(() => {
       expectLocation('/recovery/failure');

--- a/packages/webview-app/tests/screens/recovery/secretPhraseInputScreen.test.tsx
+++ b/packages/webview-app/tests/screens/recovery/secretPhraseInputScreen.test.tsx
@@ -66,7 +66,8 @@ vi.mock('../../../src/utils/insets', () => ({
   },
 }));
 
-const VALID_12_MNEMONIC = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+const VALID_12_MNEMONIC =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
 
 vi.mock('@selfxyz/euclid', () => ({
   Button: ({ text, onPress, disabled }: { text: string; onPress: () => void; disabled?: boolean }) => (
@@ -79,11 +80,7 @@ vi.mock('@selfxyz/euclid', () => ({
   fontWeight: { medium: 500 },
   spacing: { md: 12, mdLg: 16, lg: 20, xl: 24, xlLg: 32, sm: 8 },
   LeftArrowIcon: () => null,
-  SecretPhraseInput: ({
-    onWordChange,
-  }: {
-    onWordChange: (index: number, word: string) => void;
-  }) => {
+  SecretPhraseInput: ({ onWordChange }: { onWordChange: (index: number, word: string) => void }) => {
     useEffect(() => {
       VALID_12_MNEMONIC.split(' ').forEach((w, i) => onWordChange(i, w));
     }, []);
@@ -170,7 +167,10 @@ describe('SecretPhraseInputScreen', () => {
   it('does not navigate after unmount during async validation', async () => {
     let resolveDocument!: (value: unknown) => void;
     loadSelectedDocumentMock.mockImplementation(
-      () => new Promise(resolve => { resolveDocument = resolve; }),
+      () =>
+        new Promise(resolve => {
+          resolveDocument = resolve;
+        }),
     );
 
     const { unmount } = renderScreen();

--- a/packages/webview-app/tests/screens/recovery/secretPhraseInputScreen.test.tsx
+++ b/packages/webview-app/tests/screens/recovery/secretPhraseInputScreen.test.tsx
@@ -1,0 +1,229 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+// @vitest-environment jsdom
+
+import type React from 'react';
+import { useEffect } from 'react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SecretPhraseInputScreen } from '../../../src/screens/recovery/SecretPhraseInputScreen';
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const analytics = { trackEvent: vi.fn() };
+const haptic = { trigger: vi.fn() };
+const lifecycle = { dismiss: vi.fn(), setResult: vi.fn() };
+const client = { id: 'client' };
+
+const loadSelectedDocumentMock = vi.fn();
+const validateRecoverySecretForDocumentMock = vi.fn();
+const finalizeRecoveredDocumentRegistrationMock = vi.fn();
+const restoreSecretFromMnemonicMock = vi.fn();
+const readStoredSecretSnapshotMock = vi.fn();
+const restoreStoredSecretSnapshotMock = vi.fn();
+
+vi.mock('../../../src/providers/SelfClientProvider', () => ({
+  useSelfClient: () => ({
+    client,
+    analytics,
+    haptic,
+    lifecycle,
+  }),
+}));
+
+vi.mock('../../../src/providers/BridgeProvider', () => ({
+  useBridge: () => ({}),
+}));
+
+vi.mock('@selfxyz/webview-bridge/adapters', () => ({
+  bridgeStorageAdapter: () => ({
+    get: vi.fn().mockResolvedValue(null),
+    set: vi.fn().mockResolvedValue(undefined),
+    remove: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock('@selfxyz/mobile-sdk-alpha/browser', () => ({
+  loadSelectedDocument: (...args: unknown[]) => loadSelectedDocumentMock(...args),
+  validateRecoverySecretForDocument: (...args: unknown[]) => validateRecoverySecretForDocumentMock(...args),
+  finalizeRecoveredDocumentRegistration: (...args: unknown[]) => finalizeRecoveredDocumentRegistrationMock(...args),
+}));
+
+vi.mock('../../../src/utils/secretManager', () => ({
+  derivePrivateKey: (mnemonic: string) => `derived-from-${mnemonic.split(' ')[0]}`,
+  readStoredSecretSnapshot: (...args: unknown[]) => readStoredSecretSnapshotMock(...args),
+  restoreSecretFromMnemonic: (...args: unknown[]) => restoreSecretFromMnemonicMock(...args),
+  restoreStoredSecretSnapshot: (...args: unknown[]) => restoreStoredSecretSnapshotMock(...args),
+}));
+
+vi.mock('../../../src/utils/insets', () => ({
+  WEB_SAFE_AREA: {
+    insets: { top: 0, bottom: 0, left: 0, right: 0 },
+    safeArea: { top: 0, bottom: 0, left: 0, right: 0 },
+  },
+}));
+
+const VALID_12_MNEMONIC = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+vi.mock('@selfxyz/euclid', () => ({
+  Button: ({ text, onPress, disabled }: { text: string; onPress: () => void; disabled?: boolean }) => (
+    <button onClick={onPress} disabled={disabled} type="button">
+      {text}
+    </button>
+  ),
+  colors: { slate50: '#f8fafc', black: '#000', white: '#fff', red600: '#dc2626', slate300: '#cbd5e1' },
+  fontFamily: { dinOT: 'DIN OT' },
+  fontWeight: { medium: 500 },
+  spacing: { md: 12, mdLg: 16, lg: 20, xl: 24, xlLg: 32, sm: 8 },
+  LeftArrowIcon: () => null,
+  SecretPhraseInput: ({
+    onWordChange,
+  }: {
+    onWordChange: (index: number, word: string) => void;
+  }) => {
+    useEffect(() => {
+      VALID_12_MNEMONIC.split(' ').forEach((w, i) => onWordChange(i, w));
+    }, []);
+    return <div data-testid="phrase-input" />;
+  },
+  TopNavigationDialogue: () => <div />,
+}));
+
+const LocationDisplay: React.FC = () => {
+  const location = useLocation();
+  return <div data-testid="location">{`${location.pathname}${location.search}`}</div>;
+};
+
+const renderScreen = (initialEntry = '/recovery/phrase-input') =>
+  render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route path="/recovery/phrase-input" element={<SecretPhraseInputScreen />} />
+        <Route path="/recovery/failure" element={<LocationDisplay />} />
+        <Route path="/recovery/success" element={<LocationDisplay />} />
+        <Route path="/tunnel/kyc" element={<LocationDisplay />} />
+        <Route path="*" element={<LocationDisplay />} />
+      </Routes>
+      <LocationDisplay />
+    </MemoryRouter>,
+  );
+
+describe('SecretPhraseInputScreen', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    restoreSecretFromMnemonicMock.mockResolvedValue({ secret: 'derived-secret' });
+    readStoredSecretSnapshotMock.mockResolvedValue({ mnemonic: null, secret: null });
+    restoreStoredSecretSnapshotMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  const expectLocation = (expected: string) => {
+    const locations = screen.getAllByTestId('location');
+    expect(locations.at(-1)?.textContent).toBe(expected);
+  };
+
+  it('navigates to failure when loadSelectedDocument returns null', async () => {
+    loadSelectedDocumentMock.mockResolvedValue(null);
+
+    renderScreen();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /continue/i })).not.toBeDisabled();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    await waitFor(() => {
+      expectLocation('/recovery/failure');
+    });
+
+    expect(analytics.trackEvent).toHaveBeenCalledWith('recovery_phrase_failed', {
+      reason: 'document_unavailable',
+    });
+    expect(haptic.trigger).toHaveBeenCalledWith('error');
+  });
+
+  it('navigates to /tunnel/kyc for a mock document', async () => {
+    loadSelectedDocumentMock.mockResolvedValue({
+      data: { documentCategory: 'passport' },
+      metadata: { mock: true },
+    });
+
+    renderScreen();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /continue/i })).not.toBeDisabled();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    await waitFor(() => {
+      expectLocation('/tunnel/kyc');
+    });
+
+    expect(restoreSecretFromMnemonicMock).toHaveBeenCalled();
+  });
+
+  it('does not navigate after unmount during async validation', async () => {
+    let resolveDocument!: (value: unknown) => void;
+    loadSelectedDocumentMock.mockImplementation(
+      () => new Promise(resolve => { resolveDocument = resolve; }),
+    );
+
+    const { unmount } = renderScreen();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /continue/i })).not.toBeDisabled();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    // Unmount while loadSelectedDocument is still pending
+    unmount();
+
+    // Now resolve — the navigate guard should prevent navigation
+    await act(async () => {
+      resolveDocument(null);
+      await new Promise(r => setTimeout(r, 0));
+    });
+
+    // If we got here without errors, the guard worked (navigate was not called
+    // after unmount, which would throw in react-router with no Router context)
+    expect(haptic.trigger).toHaveBeenCalledWith('error');
+  });
+
+  it('navigates to failure when storage write fails during recovery', async () => {
+    loadSelectedDocumentMock.mockResolvedValue({
+      data: { documentCategory: 'passport' },
+      metadata: { mock: false, isRegistered: true },
+    });
+    validateRecoverySecretForDocumentMock.mockResolvedValue({
+      isRegistered: true,
+      csca: 'matching-csca',
+    });
+    restoreSecretFromMnemonicMock.mockRejectedValue(new Error('write failed'));
+
+    renderScreen();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /continue/i })).not.toBeDisabled();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    await waitFor(() => {
+      expectLocation('/recovery/failure');
+    });
+
+    expect(analytics.trackEvent).toHaveBeenCalledWith('recovery_phrase_failed', {
+      reason: 'storage_write_failed',
+    });
+    expect(restoreStoredSecretSnapshotMock).toHaveBeenCalled();
+  });
+});

--- a/packages/webview-app/tests/utils/secretManager.test.ts
+++ b/packages/webview-app/tests/utils/secretManager.test.ts
@@ -6,7 +6,13 @@
 
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { derivePrivateKey, ensureSecret, restoreSecretFromMnemonic } from '../../src/utils/secretManager';
+import {
+  derivePrivateKey,
+  ensureSecret,
+  readStoredSecretSnapshot,
+  restoreSecretFromMnemonic,
+  restoreStoredSecretSnapshot,
+} from '../../src/utils/secretManager';
 
 type Deferred = {
   promise: Promise<void>;
@@ -152,5 +158,92 @@ describe('ensureSecret', () => {
 
     expect(storageState.get('self_mnemonic')).toBeUndefined();
     expect(storageState.get('self_private_key')).toBe('0xexisting');
+  });
+});
+
+describe('readStoredSecretSnapshot', () => {
+  it('reads mnemonic and private key under the shared lock', async () => {
+    const storageState = new Map<string, string>();
+    const firstMnemonicWrite = createDeferred();
+    let mnemonicSetCount = 0;
+
+    storageState.set(
+      'self_mnemonic',
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    );
+    storageState.set('self_private_key', derivePrivateKey(storageState.get('self_mnemonic')!));
+
+    const storage = {
+      get: async (key: string) => storageState.get(key) ?? null,
+      set: async (key: string, value: string) => {
+        if (key === 'self_mnemonic') {
+          mnemonicSetCount += 1;
+          if (mnemonicSetCount === 1) {
+            storageState.set(key, value);
+            await firstMnemonicWrite.promise;
+            return;
+          }
+        }
+
+        storageState.set(key, value);
+      },
+      remove: async (key: string) => {
+        storageState.delete(key);
+      },
+    };
+
+    const nextMnemonic = 'legal winner thank year wave sausage worth useful legal winner thank yellow';
+    const restorePromise = restoreSecretFromMnemonic(storage, nextMnemonic);
+    const snapshotPromise = readStoredSecretSnapshot(storage);
+
+    await Promise.resolve();
+    firstMnemonicWrite.resolve();
+
+    await restorePromise;
+    const snapshot = await snapshotPromise;
+
+    expect(snapshot).toEqual({
+      mnemonic: nextMnemonic,
+      secret: derivePrivateKey(nextMnemonic),
+    });
+  });
+});
+
+describe('restoreStoredSecretSnapshot', () => {
+  it('restores the previous snapshot when writing the replacement snapshot fails', async () => {
+    const storageState = new Map<string, string>();
+    const targetSnapshot = {
+      mnemonic: 'legal winner thank year wave sausage worth useful legal winner thank yellow',
+      secret: derivePrivateKey('legal winner thank year wave sausage worth useful legal winner thank yellow'),
+    };
+
+    storageState.set(
+      'self_mnemonic',
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    );
+    storageState.set('self_private_key', derivePrivateKey(storageState.get('self_mnemonic')!));
+
+    let failPrivateKeyWrite = true;
+    const storage = {
+      get: async (key: string) => storageState.get(key) ?? null,
+      set: async (key: string, value: string) => {
+        storageState.set(key, value);
+        if (key === 'self_private_key' && failPrivateKeyWrite) {
+          failPrivateKeyWrite = false;
+          throw new Error('write failed');
+        }
+      },
+      remove: async (key: string) => {
+        storageState.delete(key);
+      },
+    };
+
+    await expect(restoreStoredSecretSnapshot(storage, targetSnapshot)).rejects.toThrow('write failed');
+    expect(storageState.get('self_mnemonic')).toBe(
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    );
+    expect(storageState.get('self_private_key')).toBe(
+      derivePrivateKey('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'),
+    );
   });
 });

--- a/packages/webview-app/tests/utils/secretManager.test.ts
+++ b/packages/webview-app/tests/utils/secretManager.test.ts
@@ -246,4 +246,41 @@ describe('restoreStoredSecretSnapshot', () => {
       derivePrivateKey('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'),
     );
   });
+
+  it('still attempts to restore the private key when mnemonic rollback fails', async () => {
+    const storageState = new Map<string, string>();
+    const originalMnemonic =
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+    const originalSecret = derivePrivateKey(originalMnemonic);
+    const targetSnapshot = {
+      mnemonic: 'legal winner thank year wave sausage worth useful legal winner thank yellow',
+      secret: derivePrivateKey('legal winner thank year wave sausage worth useful legal winner thank yellow'),
+    };
+
+    storageState.set('self_mnemonic', originalMnemonic);
+    storageState.set('self_private_key', originalSecret);
+
+    let failTargetPrivateKeyWrite = true;
+    let failRollbackMnemonicWrite = true;
+    const storage = {
+      get: async (key: string) => storageState.get(key) ?? null,
+      set: async (key: string, value: string) => {
+        storageState.set(key, value);
+        if (key === 'self_private_key' && failTargetPrivateKeyWrite) {
+          failTargetPrivateKeyWrite = false;
+          throw new Error('write failed');
+        }
+        if (key === 'self_mnemonic' && value === originalMnemonic && failRollbackMnemonicWrite) {
+          failRollbackMnemonicWrite = false;
+          throw new Error('mnemonic rollback failed');
+        }
+      },
+      remove: async (key: string) => {
+        storageState.delete(key);
+      },
+    };
+
+    await expect(restoreStoredSecretSnapshot(storage, targetSnapshot)).rejects.toThrow('write failed');
+    expect(storageState.get('self_private_key')).toBe(originalSecret);
+  });
 });

--- a/specs/projects/sdk/OVERVIEW.md
+++ b/specs/projects/sdk/OVERVIEW.md
@@ -115,20 +115,20 @@ See [KMP Revival Spec](./workstreams/kmp-revival/SPEC.md) for details.
 
 ## Module Table
 
-| Module               | Location                                                          | Status     | Current Role                                                              | Action Needed                               |
-| -------------------- | ----------------------------------------------------------------- | ---------- | ------------------------------------------------------------------------- | ------------------------------------------- |
-| WebView UI           | `packages/webview-app/`                                           | Active     | Primary product surface, route orchestration, mock-first screen migration | Finish remaining UI migration specs/routes  |
-| SDK Core             | `packages/mobile-sdk-alpha/`                                      | Active     | Shared engine for WebView/browser delivery                                | Keep browser entry clean and request-driven |
-| WebView Bridge       | `packages/webview-bridge/`                                        | Active     | Host callback surface for future lifecycle wiring                         | Stable for current UI pass                  |
-| Android Shell        | `packages/native-shell-android/`                                  | Deferred   | Future thin Kotlin shell: keychain/crypto + WebView host                  | Not required for current UI migration       |
-| iOS Shell            | `packages/native-shell-ios/`                                      | Deferred   | Future thin Swift shell: keychain/crypto + WebView host                   | Not required for current UI migration       |
-| Test App             | `packages/sdk-test-app/`                                          | Deferred   | Future native E2E harness                                                 | Not required for current UI migration       |
-| KMP Native Shell     | `packages/kmp-sdk/`                                               | Active     | Native shell for KMP consumers — 3-domain scope (secureStorage, crypto, lifecycle) | KR-01 (Android), KR-02 (iOS), KR-03 (validate) |
-| Swift Providers      | `packages/self-sdk-swift/`                                        | Active     | iOS keychain/crypto provider implementations for KMP SDK                  | Required by KR-02 (query param support)     |
-| RN SDK               | `packages/rn-sdk/`                                                | Paused     | Retained React Native shell work                                          | Do not advance unless scope reopens         |
-| Native Consolidation | `app/ios/`, `packages/mobile-sdk-alpha/ios/`, related native code | Paused     | Historical native cleanup and parity track                                | Keep as reference only for now              |
-| KMP Test App         | `packages/kmp-sdk-test-app/`                                      | Active     | E2E test harness for KMP SDK                                              | Scope to 3-domain in KR-03                  |
-| MiniPay Sample       | `packages/kmp-minipay-sample/`                                    | Paused     | Historical KMP integration example                                        | May resume now that KMP path is active      |
+| Module               | Location                                                          | Status   | Current Role                                                                       | Action Needed                                  |
+| -------------------- | ----------------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------- | ---------------------------------------------- |
+| WebView UI           | `packages/webview-app/`                                           | Active   | Primary product surface, route orchestration, mock-first screen migration          | Finish remaining UI migration specs/routes     |
+| SDK Core             | `packages/mobile-sdk-alpha/`                                      | Active   | Shared engine for WebView/browser delivery                                         | Keep browser entry clean and request-driven    |
+| WebView Bridge       | `packages/webview-bridge/`                                        | Active   | Host callback surface for future lifecycle wiring                                  | Stable for current UI pass                     |
+| Android Shell        | `packages/native-shell-android/`                                  | Deferred | Future thin Kotlin shell: keychain/crypto + WebView host                           | Not required for current UI migration          |
+| iOS Shell            | `packages/native-shell-ios/`                                      | Deferred | Future thin Swift shell: keychain/crypto + WebView host                            | Not required for current UI migration          |
+| Test App             | `packages/sdk-test-app/`                                          | Deferred | Future native E2E harness                                                          | Not required for current UI migration          |
+| KMP Native Shell     | `packages/kmp-sdk/`                                               | Active   | Native shell for KMP consumers — 3-domain scope (secureStorage, crypto, lifecycle) | KR-01 (Android), KR-02 (iOS), KR-03 (validate) |
+| Swift Providers      | `packages/self-sdk-swift/`                                        | Active   | iOS keychain/crypto provider implementations for KMP SDK                           | Required by KR-02 (query param support)        |
+| RN SDK               | `packages/rn-sdk/`                                                | Paused   | Retained React Native shell work                                                   | Do not advance unless scope reopens            |
+| Native Consolidation | `app/ios/`, `packages/mobile-sdk-alpha/ios/`, related native code | Paused   | Historical native cleanup and parity track                                         | Keep as reference only for now                 |
+| KMP Test App         | `packages/kmp-sdk-test-app/`                                      | Active   | E2E test harness for KMP SDK                                                       | Scope to 3-domain in KR-03                     |
+| MiniPay Sample       | `packages/kmp-minipay-sample/`                                    | Paused   | Historical KMP integration example                                                 | May resume now that KMP path is active         |
 
 ## Scope Rules
 

--- a/specs/projects/sdk/workstreams/kmp-revival/SPEC.md
+++ b/specs/projects/sdk/workstreams/kmp-revival/SPEC.md
@@ -15,15 +15,15 @@
 
 ## Why Offer a KMP Option
 
-| Dimension | KMP SDK | Native Shells Lite |
-|-----------|---------|-------------------|
-| Target consumer | Apps using Kotlin Multiplatform | Pure Kotlin (Android) / pure Swift (iOS) apps |
-| Provider pattern | Built-in via `SdkProviderRegistry` (both platforms) | NSL-04 adds it (~500-700 LOC) |
-| Test coverage | ~10 test files | Zero tests (pending) |
-| Publishing setup | `maven-publish` configured | None yet |
-| Result types | Strongly-typed `VerificationResult` + `SelfSdkError` | Raw JSON string |
-| Config model | Separated `SelfSdkConfig` + `VerificationRequest` | Flat config with 15+ params |
-| Extra handlers | NFC, camera, biometrics available (not registered by default) | 3 domains only |
+| Dimension        | KMP SDK                                                       | Native Shells Lite                            |
+| ---------------- | ------------------------------------------------------------- | --------------------------------------------- |
+| Target consumer  | Apps using Kotlin Multiplatform                               | Pure Kotlin (Android) / pure Swift (iOS) apps |
+| Provider pattern | Built-in via `SdkProviderRegistry` (both platforms)           | NSL-04 adds it (~500-700 LOC)                 |
+| Test coverage    | ~10 test files                                                | Zero tests (pending)                          |
+| Publishing setup | `maven-publish` configured                                    | None yet                                      |
+| Result types     | Strongly-typed `VerificationResult` + `SelfSdkError`          | Raw JSON string                               |
+| Config model     | Separated `SelfSdkConfig` + `VerificationRequest`             | Flat config with 15+ params                   |
+| Extra handlers   | NFC, camera, biometrics available (not registered by default) | 3 domains only                                |
 
 Both options are valid. KMP has more infrastructure already built; native-shells-lite is simpler for non-KMP consumers.
 
@@ -54,19 +54,19 @@ Both options are valid. KMP has more infrastructure already built; native-shells
 
 ## Dependencies
 
-| Depends On | Type | Status | Notes |
-|---|---|---|---|
-| `packages/webview-bridge/` | Upstream (bridge protocol) | Done | Defines message shapes and transport names |
-| `packages/webview-app/` | Upstream (WebView bundle) | Active | KMP loads this bundle |
-| Build pipeline (BP-01) | Downstream | Done | Copies webview-app dist into native assets |
+| Depends On                 | Type                       | Status | Notes                                      |
+| -------------------------- | -------------------------- | ------ | ------------------------------------------ |
+| `packages/webview-bridge/` | Upstream (bridge protocol) | Done   | Defines message shapes and transport names |
+| `packages/webview-app/`    | Upstream (WebView bundle)  | Active | KMP loads this bundle                      |
+| Build pipeline (BP-01)     | Downstream                 | Done   | Copies webview-app dist into native assets |
 
 ## Backlog
 
-| ID | Title | Status | Priority | Depends On | Plan | Est. LOC |
-|---|---|---|---|---|---|---|
-| KR-01 | Scope KMP Android to 3-domain parity with provider delegation | Ready | High | - | [plans/KR-01-android-parity.md](./plans/KR-01-android-parity.md) | ~600-900 |
-| KR-02 | Scope KMP iOS to 3-domain native shell parity | Ready | High | - | [plans/KR-02-ios-parity.md](./plans/KR-02-ios-parity.md) | ~200-300 |
-| KR-03 | Validate build artifacts and test app | Ready | Medium | KR-01, KR-02 | [plans/KR-03-validate-and-publish.md](./plans/KR-03-validate-and-publish.md) | ~200 |
+| ID    | Title                                                         | Status | Priority | Depends On   | Plan                                                                         | Est. LOC |
+| ----- | ------------------------------------------------------------- | ------ | -------- | ------------ | ---------------------------------------------------------------------------- | -------- |
+| KR-01 | Scope KMP Android to 3-domain parity with provider delegation | Ready  | High     | -            | [plans/KR-01-android-parity.md](./plans/KR-01-android-parity.md)             | ~600-900 |
+| KR-02 | Scope KMP iOS to 3-domain native shell parity                 | Ready  | High     | -            | [plans/KR-02-ios-parity.md](./plans/KR-02-ios-parity.md)                     | ~200-300 |
+| KR-03 | Validate build artifacts and test app                         | Ready  | Medium   | KR-01, KR-02 | [plans/KR-03-validate-and-publish.md](./plans/KR-03-validate-and-publish.md) | ~200     |
 
 Allowed statuses: `Ready`, `In Progress`, `Blocked`, `Deferred`, `Done`
 
@@ -84,16 +84,16 @@ Allowed statuses: `Ready`, `In Progress`, `Blocked`, `Deferred`, `Done`
 
 ## Reference Implementations
 
-| What | Source | Notes |
-|---|---|---|
-| Bridge protocol (message shapes) | `packages/webview-bridge/src/types.ts` | Canonical — native must match |
-| Storage adapter expectations | `packages/webview-bridge/src/adapters/storage.ts:15-18` | `get()` returns `{ value: string \| null }` |
-| Crypto adapter expectations | `packages/webview-bridge/src/adapters/crypto.ts` | Defines request params and response shapes |
-| CryptoHandler (Android ref) | `packages/native-shell-android/.../handlers/CryptoHandler.kt` | Reference for default `AndroidKeystoreCryptoProvider` — uses AndroidKeyStore, secp256r1, SHA256withECDSA |
-| SecureStorageHandler (Android ref) | `packages/native-shell-android/.../handlers/SecureStorageHandler.kt` | Reference for provider-delegated handler — wraps `get()` in `{ value: ... }` |
-| WebChromeClient | `packages/native-shell-android/.../webview/AndroidWebViewHost.kt:109-173` | Port permission + file upload handling |
-| iOS provider registry | `packages/kmp-sdk/.../iosMain/.../providers/SdkProviderRegistry.kt` | Current iOS-only registry — move to commonMain |
-| iOS CryptoBridgeHandler | `packages/kmp-sdk/.../iosMain/.../handlers/CryptoBridgeHandler.kt` | Provider-delegated crypto — reuse pattern for both platforms |
+| What                               | Source                                                                    | Notes                                                                                                    |
+| ---------------------------------- | ------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Bridge protocol (message shapes)   | `packages/webview-bridge/src/types.ts`                                    | Canonical — native must match                                                                            |
+| Storage adapter expectations       | `packages/webview-bridge/src/adapters/storage.ts:15-18`                   | `get()` returns `{ value: string \| null }`                                                              |
+| Crypto adapter expectations        | `packages/webview-bridge/src/adapters/crypto.ts`                          | Defines request params and response shapes                                                               |
+| CryptoHandler (Android ref)        | `packages/native-shell-android/.../handlers/CryptoHandler.kt`             | Reference for default `AndroidKeystoreCryptoProvider` — uses AndroidKeyStore, secp256r1, SHA256withECDSA |
+| SecureStorageHandler (Android ref) | `packages/native-shell-android/.../handlers/SecureStorageHandler.kt`      | Reference for provider-delegated handler — wraps `get()` in `{ value: ... }`                             |
+| WebChromeClient                    | `packages/native-shell-android/.../webview/AndroidWebViewHost.kt:109-173` | Port permission + file upload handling                                                                   |
+| iOS provider registry              | `packages/kmp-sdk/.../iosMain/.../providers/SdkProviderRegistry.kt`       | Current iOS-only registry — move to commonMain                                                           |
+| iOS CryptoBridgeHandler            | `packages/kmp-sdk/.../iosMain/.../handlers/CryptoBridgeHandler.kt`        | Provider-delegated crypto — reuse pattern for both platforms                                             |
 
 ## Bridge Domain Contract
 
@@ -101,35 +101,35 @@ Only 3 domains are registered by the scoped KMP:
 
 ### `secureStorage`
 
-| Method | Params | Response |
-|---|---|---|
-| `get` | `{ key: string }` | `{ value: string \| null }` |
-| `set` | `{ key: string, value: string }` | `null` |
-| `remove` | `{ key: string }` | `null` |
+| Method   | Params                           | Response                    |
+| -------- | -------------------------------- | --------------------------- |
+| `get`    | `{ key: string }`                | `{ value: string \| null }` |
+| `set`    | `{ key: string, value: string }` | `null`                      |
+| `remove` | `{ key: string }`                | `null`                      |
 
 ### `crypto`
 
-| Method | Params | Response |
-|---|---|---|
-| `generateKey` | `{ keyRef: string }` | `{ keyRef: string, success: true }` |
-| `getPublicKey` | `{ keyRef: string }` | `{ publicKey: string }` (base64) |
-| `sign` | `{ data: string, keyRef: string }` (data is base64) | `{ signature: string }` (base64) |
+| Method         | Params                                              | Response                            |
+| -------------- | --------------------------------------------------- | ----------------------------------- |
+| `generateKey`  | `{ keyRef: string }`                                | `{ keyRef: string, success: true }` |
+| `getPublicKey` | `{ keyRef: string }`                                | `{ publicKey: string }` (base64)    |
+| `sign`         | `{ data: string, keyRef: string }` (data is base64) | `{ signature: string }` (base64)    |
 
 ### `lifecycle`
 
-| Method | Params | Response |
-|---|---|---|
-| `ready` | `{}` | `null` (no-op) |
-| `dismiss` | `{ reason?: string }` | `null` (finishes Activity / dismisses VC) |
-| `setResult` | `{ success: bool, userId?, verificationId?, error? }` | `null` (forwards to host, then finishes) |
+| Method      | Params                                                | Response                                  |
+| ----------- | ----------------------------------------------------- | ----------------------------------------- |
+| `ready`     | `{}`                                                  | `null` (no-op)                            |
+| `dismiss`   | `{ reason?: string }`                                 | `null` (finishes Activity / dismisses VC) |
+| `setResult` | `{ success: bool, userId?, verificationId?, error? }` | `null` (forwards to host, then finishes)  |
 
 Any other domain request returns a `DOMAIN_NOT_FOUND` error response.
 
 ## Related Specs
 
-| Spec | Relationship |
-|---|---|
-| [SDK Overview](../../OVERVIEW.md) | Parent architecture |
-| [Native Shells Lite](../native-shells-lite/SPEC.md) | Sibling — serves non-KMP consumers |
-| [Paused Native Shells (KMP)](../../paused/native-shells/SPEC.md) | Historical KMP work — validated foundation |
-| [Build Pipeline](../build-pipeline/SPEC.md) | Downstream — bundles webview-app into native assets |
+| Spec                                                             | Relationship                                        |
+| ---------------------------------------------------------------- | --------------------------------------------------- |
+| [SDK Overview](../../OVERVIEW.md)                                | Parent architecture                                 |
+| [Native Shells Lite](../native-shells-lite/SPEC.md)              | Sibling — serves non-KMP consumers                  |
+| [Paused Native Shells (KMP)](../../paused/native-shells/SPEC.md) | Historical KMP work — validated foundation          |
+| [Build Pipeline](../build-pipeline/SPEC.md)                      | Downstream — bundles webview-app into native assets |

--- a/specs/projects/sdk/workstreams/kmp-revival/plans/KR-01-android-parity.md
+++ b/specs/projects/sdk/workstreams/kmp-revival/plans/KR-01-android-parity.md
@@ -14,6 +14,7 @@
 The KMP SDK Android target registers 5 handlers (NFC, Camera, Biometric, SecureStorage, Lifecycle) but is missing the `crypto` handler that native-shells-lite provides. The Android SecureStorage handler hardcodes `EncryptedSharedPreferences` instead of delegating to a consumer-provided provider (the iOS target already delegates via `SdkProviderRegistry`). There are also gaps in WebView capabilities (no WebChromeClient, no query params), an incorrect SecureStorage response shape, and no bridge protocol version validation.
 
 You are closing these gaps by:
+
 1. Moving provider interfaces to `commonMain` so both platforms share the same contract
 2. Making Android handlers delegate to providers (matching iOS pattern)
 3. Shipping default Android provider implementations consumers can use or replace
@@ -43,12 +44,14 @@ You are closing these gaps by:
 Currently `SecureStorageProvider` and `CryptoProvider` live in `iosMain/kotlin/xyz/self/sdk/providers/`. Move them to `commonMain` so both platforms share the same contract.
 
 **Move:**
+
 - `packages/kmp-sdk/shared/src/iosMain/kotlin/xyz/self/sdk/providers/SecureStorageProvider.kt` → `packages/kmp-sdk/shared/src/commonMain/kotlin/xyz/self/sdk/providers/SecureStorageProvider.kt`
 - `packages/kmp-sdk/shared/src/iosMain/kotlin/xyz/self/sdk/providers/CryptoProvider.kt` → `packages/kmp-sdk/shared/src/commonMain/kotlin/xyz/self/sdk/providers/CryptoProvider.kt`
 
 The interfaces remain identical — same package (`xyz.self.sdk.providers`), same methods. The iOS handlers that reference them will compile without changes since `commonMain` is visible to `iosMain`.
 
 **Current `SecureStorageProvider` interface (iosMain):**
+
 ```kotlin
 interface SecureStorageProvider {
     fun get(key: String): String?
@@ -59,6 +62,7 @@ interface SecureStorageProvider {
 ```
 
 **Current `CryptoProvider` interface (iosMain):**
+
 ```kotlin
 interface CryptoProvider {
     fun generateKey(keyRef: String)
@@ -79,6 +83,7 @@ No changes to the interfaces themselves — just the source set location.
 **Move to:** `packages/kmp-sdk/shared/src/commonMain/kotlin/xyz/self/sdk/providers/SdkProviderRegistry.kt`
 
 **Rewrite for 3-domain scope:**
+
 ```kotlin
 package xyz.self.sdk.providers
 
@@ -116,6 +121,7 @@ object SdkProviderRegistry {
 ```
 
 **Key changes:**
+
 - `isConfigured()` now checks only the 2 required providers (secureStorage, crypto) instead of all 8
 - Added `reset()` for clean teardown between sessions
 - Optional providers retained for future use but not required
@@ -301,6 +307,7 @@ class SecureStorageBridgeHandler : BridgeHandler {
 ```
 
 **Key changes from current:**
+
 - No longer takes `Context` parameter (no direct EncryptedSharedPreferences)
 - Delegates to `SdkProviderRegistry.secureStorage`
 - `get()` returns `buildJsonObject { put("value", ...) }` instead of bare `JsonPrimitive`/`JsonNull`
@@ -396,6 +403,7 @@ class CryptoBridgeHandler : BridgeHandler {
 If moved to `commonMain`, **delete** the existing `iosMain/.../handlers/CryptoBridgeHandler.kt` to avoid duplicate class definitions.
 
 Response shapes match `webview-bridge/src/adapters/crypto.ts`:
+
 - `generateKey` → `{ keyRef: string, success: true }`
 - `getPublicKey` → `{ publicKey: string }` (base64)
 - `sign` → `{ signature: string }` (base64)
@@ -405,6 +413,7 @@ Response shapes match `webview-bridge/src/adapters/crypto.ts`:
 **File:** `packages/kmp-sdk/shared/src/androidMain/kotlin/xyz/self/sdk/webview/SelfVerificationActivity.kt`
 
 **Current `registerHandlers()` (lines 88-103):**
+
 ```kotlin
 private fun registerHandlers() {
     router.register(NfcBridgeHandler(this, router))
@@ -416,6 +425,7 @@ private fun registerHandlers() {
 ```
 
 **Change to:**
+
 ```kotlin
 private fun registerHandlers() {
     router.register(SecureStorageBridgeHandler())   // no Context — delegates to provider
@@ -425,6 +435,7 @@ private fun registerHandlers() {
 ```
 
 **Also:**
+
 - Remove `requiredPermissions` array, `permissionLauncher`, and the permission-check block in `onCreate()` (lines 29-56). The 3-domain scope does not need CAMERA or NFC permissions at startup. The WebChromeClient (step 8) handles camera permissions on-demand.
 - Simplify `onCreate()` to call `initVerificationFlow()` directly.
 - Add provider initialization before handler registration:
@@ -457,6 +468,7 @@ This gives consumers the option to set their own providers before launching the 
 **Change to:** `fun createWebView(queryParams: String = ""): WebView`
 
 **Update loadUrl calls (lines 129-139):**
+
 ```kotlin
 // Before
 webView.loadUrl("https://appassets.androidplatform.net/index.html")
@@ -472,6 +484,7 @@ Apply the same pattern to the debug URL (`http://127.0.0.1:5173`).
 **Update caller in SelfVerificationActivity:** Build query params from intent extras (or `VerificationRequest` if available) and pass to `createWebView(queryParams)`. Reference `packages/native-shell-android/.../SelfVerificationActivity.kt:64-84` for the query string builder pattern using `buildString { }` with `Uri.encode()`.
 
 The native-shell-android extracts 14 intent extras and encodes them. KMP currently only extracts `EXTRA_DEBUG_MODE`, `EXTRA_VERIFICATION_REQUEST`, and `EXTRA_CONFIG`. You need to either:
+
 - Parse `EXTRA_VERIFICATION_REQUEST` JSON and build query params from it, or
 - Add the same 14 intent extras as native-shell-android
 
@@ -551,12 +564,14 @@ webChromeClient = object : WebChromeClient() {
 ```
 
 Add class-level fields:
+
 ```kotlin
 var pendingPermissionRequest: PermissionRequest? = null
 var fileUploadCallback: ValueCallback<Array<Uri>>? = null
 ```
 
 Add companion object constants:
+
 ```kotlin
 companion object {
     const val FILE_CHOOSER_REQUEST_CODE = 1001
@@ -565,6 +580,7 @@ companion object {
 ```
 
 **Also add permission result handling** to `SelfVerificationActivity`:
+
 ```kotlin
 override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
     super.onRequestPermissionsResult(requestCode, permissions, grantResults)
@@ -599,6 +615,7 @@ override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) 
 **Current (lines 26-32):** After parsing the BridgeRequest, handler lookup proceeds immediately with no version check.
 
 **Add after parsing (line 32, before handler lookup):**
+
 ```kotlin
 val request = json.decodeFromString<BridgeRequest>(rawJson)
 
@@ -616,6 +633,7 @@ if (request.version != BRIDGE_PROTOCOL_VERSION) {
 ```
 
 Add companion object constant (matching `webview-bridge/src/types.ts:152`):
+
 ```kotlin
 companion object {
     const val BRIDGE_PROTOCOL_VERSION = 1
@@ -629,6 +647,7 @@ companion object {
 **File:** `packages/kmp-sdk/shared/build.gradle.kts`
 
 **Remove or comment out these androidMain dependencies:**
+
 ```kotlin
 // NFC/Passport — not needed for 3-domain scope
 // implementation("org.jmrtd:jmrtd:0.8.1")
@@ -647,6 +666,7 @@ companion object {
 ```
 
 **Keep:**
+
 - `androidx.webkit:webkit` — WebView
 - `androidx.security:security-crypto` — Default EncryptedSharedPreferencesProvider
 - `androidx.appcompat:appcompat` — Activity
@@ -657,33 +677,33 @@ companion object {
 
 ### Files Created
 
-| File | Purpose |
-|------|---------|
-| `shared/src/commonMain/.../providers/SecureStorageProvider.kt` | Moved from iosMain — shared interface |
-| `shared/src/commonMain/.../providers/CryptoProvider.kt` | Moved from iosMain — shared interface |
-| `shared/src/commonMain/.../providers/SdkProviderRegistry.kt` | Moved from iosMain — unified registry, 3-domain `isConfigured()` |
-| `shared/src/commonMain/.../handlers/CryptoBridgeHandler.kt` | Provider-delegated crypto handler (replaces iOS-only version) |
-| `shared/src/androidMain/.../providers/EncryptedSharedPreferencesProvider.kt` | Default Android SecureStorageProvider |
-| `shared/src/androidMain/.../providers/AndroidKeystoreCryptoProvider.kt` | Default Android CryptoProvider |
+| File                                                                         | Purpose                                                          |
+| ---------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `shared/src/commonMain/.../providers/SecureStorageProvider.kt`               | Moved from iosMain — shared interface                            |
+| `shared/src/commonMain/.../providers/CryptoProvider.kt`                      | Moved from iosMain — shared interface                            |
+| `shared/src/commonMain/.../providers/SdkProviderRegistry.kt`                 | Moved from iosMain — unified registry, 3-domain `isConfigured()` |
+| `shared/src/commonMain/.../handlers/CryptoBridgeHandler.kt`                  | Provider-delegated crypto handler (replaces iOS-only version)    |
+| `shared/src/androidMain/.../providers/EncryptedSharedPreferencesProvider.kt` | Default Android SecureStorageProvider                            |
+| `shared/src/androidMain/.../providers/AndroidKeystoreCryptoProvider.kt`      | Default Android CryptoProvider                                   |
 
 ### Files Modified
 
-| File | Change |
-|------|--------|
-| `shared/src/androidMain/.../handlers/SecureStorageBridgeHandler.kt` | Rewrite: delegate to provider, fix `get()` response shape |
-| `shared/src/androidMain/.../webview/SelfVerificationActivity.kt` | Register 3 handlers, default provider init, remove permission requests, add query params, add permission/file callbacks |
-| `shared/src/androidMain/.../webview/AndroidWebViewHost.kt` | Add WebChromeClient, query params, permission/file fields |
-| `shared/src/commonMain/.../bridge/MessageRouter.kt` | Add protocol version validation |
-| `shared/build.gradle.kts` | Remove NFC/camera/biometric dependencies |
+| File                                                                | Change                                                                                                                  |
+| ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `shared/src/androidMain/.../handlers/SecureStorageBridgeHandler.kt` | Rewrite: delegate to provider, fix `get()` response shape                                                               |
+| `shared/src/androidMain/.../webview/SelfVerificationActivity.kt`    | Register 3 handlers, default provider init, remove permission requests, add query params, add permission/file callbacks |
+| `shared/src/androidMain/.../webview/AndroidWebViewHost.kt`          | Add WebChromeClient, query params, permission/file fields                                                               |
+| `shared/src/commonMain/.../bridge/MessageRouter.kt`                 | Add protocol version validation                                                                                         |
+| `shared/build.gradle.kts`                                           | Remove NFC/camera/biometric dependencies                                                                                |
 
 ### Files Deleted
 
-| File | Reason |
-|------|--------|
-| `shared/src/iosMain/.../providers/SecureStorageProvider.kt` | Moved to commonMain |
-| `shared/src/iosMain/.../providers/CryptoProvider.kt` | Moved to commonMain |
-| `shared/src/iosMain/.../providers/SdkProviderRegistry.kt` | Moved to commonMain |
-| `shared/src/iosMain/.../handlers/CryptoBridgeHandler.kt` | Replaced by commonMain version |
+| File                                                        | Reason                         |
+| ----------------------------------------------------------- | ------------------------------ |
+| `shared/src/iosMain/.../providers/SecureStorageProvider.kt` | Moved to commonMain            |
+| `shared/src/iosMain/.../providers/CryptoProvider.kt`        | Moved to commonMain            |
+| `shared/src/iosMain/.../providers/SdkProviderRegistry.kt`   | Moved to commonMain            |
+| `shared/src/iosMain/.../handlers/CryptoBridgeHandler.kt`    | Replaced by commonMain version |
 
 ### Files NOT Modified
 

--- a/specs/projects/sdk/workstreams/kmp-revival/plans/KR-02-ios-parity.md
+++ b/specs/projects/sdk/workstreams/kmp-revival/plans/KR-02-ios-parity.md
@@ -41,6 +41,7 @@ You are scoping KMP iOS to 3-domain parity with native-shell-ios.
 **Required:** The TypeScript adapter at `webview-bridge/src/adapters/storage.ts:16` does `result?.value ?? null` — expects `{ value: string | null }`.
 
 **Change:**
+
 ```kotlin
 // Before (line 44)
 return if (value != null) JsonPrimitive(value) else JsonNull
@@ -64,12 +65,14 @@ Add import: `import kotlinx.serialization.json.buildJsonObject`
 **Current:** `createWebView(onMessageReceived:isDebugMode:)` loads `Bundle.main.url(forResource: "index", withExtension: "html", subdirectory: "self-sdk-web")` without appending query params.
 
 **Required:** native-shell-ios passes verification config as query params via `URLComponents`:
+
 ```swift
 var components = URLComponents(url: fileURL, resolvingAgainstBaseURL: false)
 components?.query = queryParams
 ```
 
 **Change the method signature:**
+
 ```swift
 // Before
 @objc(createWebViewOnMessageReceived:isDebugMode:)
@@ -84,6 +87,7 @@ public func createWebView(onMessageReceived: @escaping (String) -> Void,
 ```
 
 **Update the URL loading logic** to append query params when provided:
+
 ```swift
 if let htmlURL = Bundle.main.url(forResource: "index", withExtension: "html", subdirectory: "self-sdk-web") {
     var targetURL = htmlURL
@@ -105,6 +109,7 @@ Apply the same pattern to the debug URL (`http://localhost:5173`).
 **Current (lines 18-29):** `createWebView()` calls `provider.createWebView(onMessageReceived, isDebugMode)` with no query params.
 
 **Update `WebViewProvider` interface** (in `iosMain/kotlin/xyz/self/sdk/providers/WebViewProvider.kt` or wherever it's defined) to add the query param:
+
 ```kotlin
 interface WebViewProvider {
     fun createWebView(
@@ -116,6 +121,7 @@ interface WebViewProvider {
 ```
 
 **Update `IosWebViewHost`** to forward query params from the `VerificationRequest`:
+
 ```kotlin
 fun createWebView(queryParams: String? = null): UIView {
     val provider = SdkProviderRegistry.webView
@@ -133,6 +139,7 @@ fun createWebView(queryParams: String? = null): UIView {
 **File:** `packages/kmp-sdk/shared/src/iosMain/kotlin/xyz/self/sdk/api/SelfSdk.ios.kt`
 
 **Current (lines 145-158) registers 9 handlers:**
+
 ```kotlin
 router.register(BiometricBridgeHandler())
 router.register(SecureStorageBridgeHandler())
@@ -146,6 +153,7 @@ router.register(NfcBridgeHandler(router))
 ```
 
 **Change to 3 handlers:**
+
 ```kotlin
 router.register(SecureStorageBridgeHandler())
 router.register(CryptoBridgeHandler())  // now from commonMain after KR-01
@@ -171,13 +179,13 @@ Reference the native-shell-ios `SelfSdkConfig.toQueryParams()` pattern for the f
 
 ### Files Modified
 
-| File | Change |
-|------|--------|
-| `shared/src/iosMain/.../handlers/SecureStorageBridgeHandler.kt` | Fix `get()` response shape to `{ value: ... }` |
-| `packages/self-sdk-swift/.../WebViewProviderImpl.swift` | Add `queryParams` parameter, append to URL |
-| `shared/src/iosMain/.../webview/IosWebViewHost.kt` | Forward query params to provider |
-| `shared/src/iosMain/.../providers/WebViewProvider.kt` | Add `queryParams` to interface |
-| `shared/src/iosMain/.../api/SelfSdk.ios.kt` | Register only 3 handlers, build and pass query params |
+| File                                                            | Change                                                |
+| --------------------------------------------------------------- | ----------------------------------------------------- |
+| `shared/src/iosMain/.../handlers/SecureStorageBridgeHandler.kt` | Fix `get()` response shape to `{ value: ... }`        |
+| `packages/self-sdk-swift/.../WebViewProviderImpl.swift`         | Add `queryParams` parameter, append to URL            |
+| `shared/src/iosMain/.../webview/IosWebViewHost.kt`              | Forward query params to provider                      |
+| `shared/src/iosMain/.../providers/WebViewProvider.kt`           | Add `queryParams` to interface                        |
+| `shared/src/iosMain/.../api/SelfSdk.ios.kt`                     | Register only 3 handlers, build and pass query params |
 
 ### Files NOT Modified
 

--- a/specs/projects/sdk/workstreams/kmp-revival/plans/KR-03-validate-and-publish.md
+++ b/specs/projects/sdk/workstreams/kmp-revival/plans/KR-03-validate-and-publish.md
@@ -69,6 +69,7 @@ ls -la shared/build/XCFrameworks/
 The test app currently exercises all KMP handlers including NFC and camera. Update it to only use the 3-domain scope.
 
 **Android (`packages/kmp-sdk-test-app/androidApp/`):**
+
 - Remove NFC and Camera permission requests from AndroidManifest.xml (if present)
 - The app should rely on default providers (Activity auto-initializes `EncryptedSharedPreferencesProvider` and `AndroidKeystoreCryptoProvider` if not set). Alternatively, demonstrate explicit provider registration before launch:
   ```kotlin
@@ -80,6 +81,7 @@ The test app currently exercises all KMP handlers including NFC and camera. Upda
 - Verify secure storage operations work (get, set, remove)
 
 **iOS (`packages/kmp-sdk-test-app/iosApp/`):**
+
 - Register only required providers: `secureStorage`, `crypto`, `webView`
 - Remove registration of NFC, Camera, Biometric, Haptic, Documents providers
 - Verify the app launches the SDK, loads the WebView, and handles lifecycle callbacks
@@ -103,18 +105,18 @@ Update the module table (around line 110) to reflect KMP revival:
 
 **Already done** — OVERVIEW.md module table was updated as part of the spec review on 2026-04-01. Verify it still reflects:
 
-| Module | Status | Notes |
-|--------|--------|-------|
-| KMP Native Shell (`packages/kmp-sdk/`) | Active (3-domain scope) | Serves KMP consumers, provider delegation on both platforms |
-| Swift Providers (`packages/self-sdk-swift/`) | Active | iOS providers for KMP |
-| KMP Test App (`packages/kmp-sdk-test-app/`) | Active | E2E harness |
+| Module                                       | Status                  | Notes                                                       |
+| -------------------------------------------- | ----------------------- | ----------------------------------------------------------- |
+| KMP Native Shell (`packages/kmp-sdk/`)       | Active (3-domain scope) | Serves KMP consumers, provider delegation on both platforms |
+| Swift Providers (`packages/self-sdk-swift/`) | Active                  | iOS providers for KMP                                       |
+| KMP Test App (`packages/kmp-sdk-test-app/`)  | Active                  | E2E harness                                                 |
 
 ### Files Modified
 
-| File | Change |
-|------|--------|
+| File                                          | Change                               |
+| --------------------------------------------- | ------------------------------------ |
 | `packages/kmp-sdk-test-app/` (multiple files) | Scope to 3-domain handlers/providers |
-| `specs/projects/sdk/OVERVIEW.md` | Update module table with KMP status |
+| `specs/projects/sdk/OVERVIEW.md`              | Update module table with KMP status  |
 
 ### Files NOT Modified
 


### PR DESCRIPTION
## Summary

- Add SHA-256 integrity verification for remote WebView content on both Android and iOS, with bundled assets as the default fallback. Native shells now require explicit `remoteWebAppBaseUrl` + `remoteWebAppIntegritySha256` config to load remote content.
- Fix recovery flow null-document handling: `loadSelectedDocument()` returning `null` now correctly routes to failure instead of silently taking the mock-document success path.
- Harden lifecycle result handling with `LifecycleResultGate` (prevents double-fire of result/dismiss callbacks) and `LifecycleResultEnvelope` (unwraps nested `result` payload correctly).
- Guard against post-unmount navigation in `SecretPhraseInputScreen` and fix `restoreStoredSecretSnapshot` / `restoreSecretFromMnemonic` rollback handling so secret rollback attempts restore both keys independently.
- Address follow-up review findings for origin validation, destroyed-WebView races, MIME parity, and rollback cleanup ordering.

## Changes

### Native Shell — Android

- `AndroidWebViewHost.kt` — Bundled-asset-first loading with optional remote content verified via SHA-256; parsed origin checks for navigation and permission requests; direct loading of verified HTML bytes; destroyed-WebView guard for async remote verification; extracted URL constants
- `RemoteContentIntegrity.kt` — SHA-256 hashing, normalization, and content-type validation; now rejects empty `Content-Type` for parity with iOS
- `LifecycleHandler.kt` — Replaced `hasResult` boolean with `LifecycleResultGate` (claim-once pattern); added `LifecycleResultEnvelope` for payload unwrapping
- `SelfSdkConfig.kt`, `SelfSdk.kt`, `SelfVerificationActivity.kt` — Thread `remoteWebAppBaseUrl` and `remoteWebAppIntegritySha256` through config → intent → WebView host
- `build.gradle.kts` — Added JUnit and kotlin-test test dependencies
- Tests: `LifecycleResultEnvelopeTest`, `LifecycleResultGateTest`, `RemoteContentIntegrityTest`

### Native Shell — iOS

- `SelfWebViewHost.swift` — Custom `self-sdk://` URL scheme handler for bundled assets; `WKNavigationDelegate` for origin allowlisting; SHA-256 verified remote content loading via `CryptoKit`; direct loading of verified HTML to avoid a second network fetch
- `RemoteContentIntegrity.swift` — Utility matching Android normalization and MIME-type checks
- `LifecycleHandler.swift` — Added `onFailure` callback; `hasEmittedResult` guard on both `setResult` and `dismiss` paths; `SelfLifecycleResultEnvelope` and `SelfLifecycleResultError` types
- `SelfSdkConfig.swift`, `SelfSdk.swift` — Added `remoteWebAppBaseURL` and `remoteWebAppIntegritySha256` config fields
- `Package.swift` — Added test target
- Tests: `LifecycleHandlerRaceTests`, `LifecycleResultEnvelopeTests`, `RemoteContentIntegrityTests`

### WebView App

- `SecretPhraseInputScreen.tsx` — Explicit `null` document → `document_unavailable` error; `isMountedRef` guard on all `navigate()` calls
- `TourScreen.tsx` — Wrapped `loadSelectedDocument` in try/catch; fixed `onResore` → `onRestore` typo
- `TunnelProvingScreen.tsx` — Reset `initDone` before DSC→register phase transition and only re-enable it on successful register init
- `ProviderLaunchScreen.tsx` — Use `WEB_SAFE_AREA` spread instead of inline `{ top: 0, bottom: 0 }`
- `secretManager.ts` — `readStoredSecretSnapshot` now acquires the secret lock; snapshot and mnemonic restore rollback paths attempt to restore mnemonic and secret independently, preserving the original failure while avoiding skipped cleanup
- `package.json` — Added `test` and `test:watch` scripts
- Tests: `secretPhraseInputScreen.test.tsx`, `secretManager.test.ts`

### SDK Core

- `recoveryValidation.ts` — `finalizeRecoveredDocumentRegistration` now uses guarded cloning and independently attempts document rollback and registration-flag cleanup on failure
- `recoveryValidation.test.ts` — Added rollback coverage, including the case where document rollback itself fails

### Specs & Docs

- `docs/reviews/PR-1901-review-findings.md` — New audit document capturing review findings
- Updated KMP revival specs (`SPEC.md`, `KR-01`, `KR-02`, `KR-03`) and `OVERVIEW.md`

## Test Plan

- [x] `yarn workspace @selfxyz/mobile-sdk-alpha test recoveryValidation.test.ts`
- [x] `cd packages/webview-app && yarn test secretManager.test.ts`
- [x] `cd packages/native-shell-android && ./gradlew testDebugUnitTest`
- [ ] `cd packages/native-shell-ios && swift test`
- [ ] `yarn lint && yarn types`
- [ ] Manual: SDK tunnel flow loads bundled assets by default (no remote URL configured)
- [ ] Manual: With valid `remoteWebAppBaseUrl` + matching SHA-256, remote content loads after integrity check
- [ ] Manual: Recovery phrase input with missing document routes to failure screen

### Native Consolidation Checklist

- [ ] CONTRACTS.md reviewed - no unintended contract changes
- [ ] Layer 1 bridge contract tests pass (`cd app && yarn jest:run` / `yarn workspace @selfxyz/rn-sdk-test-app test`)
- [ ] Layer 3 builds pass (app iOS, RN test app iOS, RN test app Android)
- [ ] Layer 4 manual smoke test signed off (if consolidation PR)
- [ ] No new native business logic added (logic belongs in TypeScript)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote web app support with optional integrity (SHA‑256) verification across Android and iOS; remote URL passthrough from SDK config.
  * Improved recovery flow that finalizes recovered document registration with safer rollback on errors.

* **Bug Fixes**
  * More robust lifecycle result routing (clearer success/failure handling, single-emission gate).
  * Safer secret storage operations with locking and best‑effort rollback; guarded navigation in recovery flows.

* **Tests**
  * Extensive new unit/integration tests for remote content integrity, lifecycle gating, recovery, and secret-management paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->