### PR TITLE
feat(webview): decode custom Solidity error selectors into human-readable messages

### DIFF
--- a/packages/webview-app/src/hooks/useResolvedContractError.ts
+++ b/packages/webview-app/src/hooks/useResolvedContractError.ts
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { useEffect, useState } from 'react';
+
+import { humanizeError, humanizeErrorAsync, isErrorSelector } from '../utils/contractErrors';
+
+/**
+ * Resolves a contract error string to a human-readable message.
+ *
+ * Known selectors are decoded instantly from the static map.
+ * Unknown hex selectors trigger an async lookup via openchain.xyz,
+ * returning the formatted error name when it resolves.
+ */
+export function useResolvedContractError(error: string | undefined): string | undefined {
+  const immediate = error ? humanizeError(error) : undefined;
+  const [resolved, setResolved] = useState(immediate);
+
+  useEffect(() => {
+    if (!error) {
+      setResolved(undefined);
+      return;
+    }
+
+    const sync = humanizeError(error);
+    setResolved(sync);
+
+    if (sync === error && isErrorSelector(error)) {
+      let cancelled = false;
+      humanizeErrorAsync(error).then(result => {
+        if (!cancelled) setResolved(result);
+      });
+      return () => {
+        cancelled = true;
+      };
+    }
+  }, [error]);
+
+  return resolved;
+}

--- a/packages/webview-app/src/screens/proving/DiscloseResultScreen.tsx
+++ b/packages/webview-app/src/screens/proving/DiscloseResultScreen.tsx
@@ -9,6 +9,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { colors, StatusState, WarningOctagonIcon } from '@selfxyz/euclid';
 import type { BridgeError, VerificationResult } from '@selfxyz/webview-bridge';
 
+import { useResolvedContractError } from '../../hooks/useResolvedContractError';
 import { useSelfClient } from '../../providers/SelfClientProvider';
 import { useVerificationRequest } from '../../providers/VerificationRequestProvider';
 import { WEB_SAFE_AREA } from '../../utils/insets';
@@ -28,6 +29,7 @@ export const DiscloseResultScreen: React.FC = () => {
 
   const { success = true, error, resultSent = false } = (location.state as DiscloseResultLocationState | null) ?? {};
   const normalizedError = normalizeError(error);
+  const resolvedMessage = useResolvedContractError(normalizedError?.message);
   const result = useMemo<VerificationResult>(
     () =>
       success
@@ -97,7 +99,7 @@ export const DiscloseResultScreen: React.FC = () => {
         description={
           success
             ? 'Your identity was shared successfully for this request.'
-            : (normalizedError?.message ?? 'The proof request could not be completed. Please try again.')
+            : (resolvedMessage ?? 'The proof request could not be completed. Please try again.')
         }
         animationSource={success ? '/animations/proof-success.json' : undefined}
         animationSize={240}

--- a/packages/webview-app/src/screens/proving/VerificationResultScreen.tsx
+++ b/packages/webview-app/src/screens/proving/VerificationResultScreen.tsx
@@ -9,6 +9,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { colors, StatusState, WarningOctagonIcon } from '@selfxyz/euclid';
 import type { VerificationResult } from '@selfxyz/webview-bridge';
 
+import { useResolvedContractError } from '../../hooks/useResolvedContractError';
 import { useSelfClient } from '../../providers/SelfClientProvider';
 import { WEB_SAFE_AREA } from '../../utils/insets';
 
@@ -28,6 +29,7 @@ export const VerificationResultScreen: React.FC = () => {
     result?: VerificationResult;
     resultSent?: boolean;
   }) || {};
+  const resolvedError = useResolvedContractError(error);
 
   const onContinue = useCallback(async () => {
     haptic.trigger('selection');
@@ -62,7 +64,7 @@ export const VerificationResultScreen: React.FC = () => {
         description={
           success
             ? "Your document's information is now protected by Self ID. Just scan a participating partner's QR code to prove your identity."
-            : (error ?? 'Something went wrong during verification. Please try again.')
+            : (resolvedError ?? 'Something went wrong during verification. Please try again.')
         }
         animationSource={success ? '/animations/proof-success.json' : undefined}
         animationSize={240}

--- a/packages/webview-app/src/screens/tunnel/TunnelDiscloseScreen.tsx
+++ b/packages/webview-app/src/screens/tunnel/TunnelDiscloseScreen.tsx
@@ -13,6 +13,7 @@ import { useProvingStore } from '@selfxyz/mobile-sdk-alpha/browser';
 
 import { useSelfClient } from '../../providers/SelfClientProvider';
 import { useVerificationRequest } from '../../providers/VerificationRequestProvider';
+import { humanizeError } from '../../utils/contractErrors';
 import { WEB_SAFE_AREA } from '../../utils/insets';
 import { initSelfAppFromRequest } from '../../utils/selfAppContext';
 
@@ -63,7 +64,7 @@ export const TunnelDiscloseScreen: React.FC = () => {
       haptic.trigger('error');
       navigate('/tunnel/proof/result', {
         replace: true,
-        state: { success: false, error, source: 'disclose' as const },
+        state: { success: false, error: humanizeError(error), source: 'disclose' as const },
       });
     },
     [haptic, navigate],

--- a/packages/webview-app/src/screens/tunnel/TunnelProvingScreen.tsx
+++ b/packages/webview-app/src/screens/tunnel/TunnelProvingScreen.tsx
@@ -13,6 +13,7 @@ import { loadSelectedDocument, useProvingStore } from '@selfxyz/mobile-sdk-alpha
 
 import { useSelfClient } from '../../providers/SelfClientProvider';
 import { useVerificationRequest } from '../../providers/VerificationRequestProvider';
+import { humanizeError } from '../../utils/contractErrors';
 import { WEB_SAFE_AREA } from '../../utils/insets';
 import { getIdCardProps } from '../../utils/provingUtils';
 import { initSelfAppFromRequest } from '../../utils/selfAppContext';
@@ -59,7 +60,10 @@ export const TunnelProvingScreen: React.FC = () => {
   const navigateToError = useCallback(
     (error: string) => {
       haptic.trigger('error');
-      navigate('/tunnel/proof/result', { replace: true, state: { success: false, error, source: 'proving' as const } });
+      navigate('/tunnel/proof/result', {
+        replace: true,
+        state: { success: false, error: humanizeError(error), source: 'proving' as const },
+      });
     },
     [haptic, navigate],
   );

--- a/packages/webview-app/src/screens/tunnel/TunnelResultScreen.tsx
+++ b/packages/webview-app/src/screens/tunnel/TunnelResultScreen.tsx
@@ -9,6 +9,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { ProofFailureScreen, ProofSuccessScreen, SelfLogo } from '@selfxyz/euclid';
 import type { VerificationResult } from '@selfxyz/webview-bridge';
 
+import { useResolvedContractError } from '../../hooks/useResolvedContractError';
 import { useSelfClient } from '../../providers/SelfClientProvider';
 import { useVerificationRequest } from '../../providers/VerificationRequestProvider';
 import { WEB_SAFE_AREA } from '../../utils/insets';
@@ -26,6 +27,7 @@ export const TunnelResultScreen: React.FC = () => {
   const { verificationId, request, appName, appEndpoint, timestamp } = useVerificationRequest();
 
   const { success = false, error, source = 'proving' } = (location.state as TunnelResultState) ?? {};
+  const resolvedError = useResolvedContractError(error);
 
   useEffect(() => {
     if (success || !error) return;
@@ -89,7 +91,7 @@ export const TunnelResultScreen: React.FC = () => {
       documentType="passport"
       timestamp={timestamp}
       failureTitle="Verification Failed"
-      failureDescription={error ?? 'Something went wrong during verification. Please try again.'}
+      failureDescription={resolvedError ?? 'Something went wrong during verification. Please try again.'}
       onRetry={onRetry}
       onViewDetails={onViewDetails}
       onClose={onCancel}

--- a/packages/webview-app/src/utils/contractErrors.test.ts
+++ b/packages/webview-app/src/utils/contractErrors.test.ts
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  decodeContractError,
+  formatErrorSignature,
+  humanizeError,
+  humanizeErrorAsync,
+  isErrorSelector,
+  lookupErrorSelector,
+} from './contractErrors';
+
+describe('contractErrors', () => {
+  describe('decodeContractError', () => {
+    it('should decode a known error selector', () => {
+      expect(decodeContractError('0xda7bd3a6')).toBe('The verification and disclosure proof is invalid.');
+    });
+
+    it('should decode a selector with trailing encoded params', () => {
+      expect(decodeContractError('0x6f26ab8d0000000000000000000000000000000000000000000000000000000066a8f1a0')).toBe(
+        'The Aadhaar document timestamp is invalid.',
+      );
+    });
+
+    it('should be case-insensitive for hex chars', () => {
+      expect(decodeContractError('0xDA7BD3A6')).toBe('The verification and disclosure proof is invalid.');
+    });
+
+    it('should return null for an unknown selector', () => {
+      expect(decodeContractError('0xdeadbeef')).toBeNull();
+    });
+
+    it('should return null for non-hex strings', () => {
+      expect(decodeContractError('Something went wrong')).toBeNull();
+      expect(decodeContractError('proof_failed')).toBeNull();
+    });
+
+    it('should return null for empty or short hex', () => {
+      expect(decodeContractError('')).toBeNull();
+      expect(decodeContractError('0x1234')).toBeNull();
+    });
+
+    it('should return null for falsy input', () => {
+      expect(decodeContractError(undefined as unknown as string)).toBeNull();
+      expect(decodeContractError(null as unknown as string)).toBeNull();
+    });
+
+    it('should decode REGISTERED_COMMITMENT', () => {
+      expect(decodeContractError('0x034acfcc')).toBe('This identity has already been registered.');
+    });
+
+    it('should decode legacy V1 hub errors', () => {
+      expect(decodeContractError('0xed8cf9ff')).toBe('The current date is outside the valid range for verification.');
+    });
+  });
+
+  describe('humanizeError', () => {
+    it('should return decoded message for a known selector', () => {
+      expect(humanizeError('0xda7bd3a6')).toBe('The verification and disclosure proof is invalid.');
+    });
+
+    it('should return the original string for non-hex errors', () => {
+      expect(humanizeError('Something went wrong')).toBe('Something went wrong');
+    });
+
+    it('should return the original string for unknown selectors', () => {
+      expect(humanizeError('0xdeadbeef')).toBe('0xdeadbeef');
+    });
+
+    it('should pass through human-readable require messages', () => {
+      expect(humanizeError('Proof verification failed')).toBe('Proof verification failed');
+    });
+  });
+
+  describe('isErrorSelector', () => {
+    it('should return true for valid selectors', () => {
+      expect(isErrorSelector('0xda7bd3a6')).toBe(true);
+      expect(isErrorSelector('0xDA7BD3A6')).toBe(true);
+      expect(isErrorSelector('0xda7bd3a60000000000000000')).toBe(true);
+    });
+
+    it('should return false for non-selectors', () => {
+      expect(isErrorSelector('hello')).toBe(false);
+      expect(isErrorSelector('0x1234')).toBe(false);
+      expect(isErrorSelector('')).toBe(false);
+    });
+  });
+
+  describe('formatErrorSignature', () => {
+    it('should split camelCase names', () => {
+      expect(formatErrorSignature('InvalidVcAndDiscloseProof()')).toBe('Invalid Vc And Disclose Proof');
+    });
+
+    it('should format SCREAMING_SNAKE_CASE names', () => {
+      expect(formatErrorSignature('REGISTERED_COMMITMENT()')).toBe('Registered Commitment');
+    });
+
+    it('should handle signatures with params', () => {
+      expect(formatErrorSignature('InvalidUidaiTimestamp(uint256,uint256)')).toBe('Invalid Uidai Timestamp');
+    });
+
+    it('should handle simple names', () => {
+      expect(formatErrorSignature('Overflow()')).toBe('Overflow');
+    });
+
+    it('should handle consecutive uppercase (acronyms)', () => {
+      expect(formatErrorSignature('InvalidDSCProof()')).toBe('Invalid DSC Proof');
+    });
+  });
+
+  describe('lookupErrorSelector', () => {
+    it('should return a formatted name for a known selector', async () => {
+      const result = await lookupErrorSelector('0xda7bd3a6');
+      expect(result).toBe('Invalid Vc And Disclose Proof');
+    });
+
+    it('should return null for an unindexed selector', async () => {
+      // Extremely unlikely to be indexed — random high-entropy selector
+      const result = await lookupErrorSelector('0xffffff01');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('humanizeErrorAsync', () => {
+    it('should return static map message for known selectors without API call', async () => {
+      const result = await humanizeErrorAsync('0xda7bd3a6');
+      expect(result).toBe('The verification and disclosure proof is invalid.');
+    });
+
+    it('should return original string for non-hex errors', async () => {
+      const result = await humanizeErrorAsync('Something went wrong');
+      expect(result).toBe('Something went wrong');
+    });
+  });
+});

--- a/packages/webview-app/src/utils/contractErrors.ts
+++ b/packages/webview-app/src/utils/contractErrors.ts
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+/**
+ * Static map of Solidity custom error selectors to human-readable messages.
+ *
+ * Generated from contracts/scripts/findErrorSelectors.ts — update this map
+ * whenever new custom errors are added to the contracts.
+ *
+ * Selector = first 4 bytes of keccak256(error signature).
+ */
+const ERROR_SELECTOR_MAP: Record<string, { name: string; message: string }> = {
+  // IdentityVerificationHubImplV2
+  '0x0ee78d58': { name: 'NoVerifierSet', message: 'No verifier has been configured for this attestation type.' },
+  '0x12ec75fe': { name: 'InvalidAttestationId', message: 'The attestation ID is not recognized.' },
+  '0x1644e049': { name: 'InvalidDscProof', message: 'The document signing certificate proof is invalid.' },
+  '0x422cc3b7': { name: 'InvalidPubkey', message: 'The public key provided is invalid.' },
+  '0x4cb305bb': {
+    name: 'InvalidDscCommitmentRoot',
+    message: 'The document signing certificate commitment root is invalid.',
+  },
+  '0x61296fbb': { name: 'CrossChainIsNotSupportedYet', message: 'Cross-chain verification is not supported yet.' },
+  '0x65ec0cf1': { name: 'InputTooShort', message: 'The input data is too short.' },
+  '0x67b61dc7': { name: 'InvalidRegisterProof', message: 'The registration proof is invalid.' },
+  '0x6f26ab8d': { name: 'InvalidUidaiTimestamp', message: 'The Aadhaar document timestamp is invalid.' },
+  '0x8f1b44c7': { name: 'InvalidCscaRoot', message: 'The country signing certificate authority root is invalid.' },
+  '0x94ec3503': { name: 'UserContextDataTooShort', message: 'User context data is too short.' },
+  '0xace124bc': { name: 'ConfigNotSet', message: 'The verification configuration has not been set.' },
+  '0xc67a44d2': { name: 'InvalidOfacRoots', message: 'The OFAC check roots are invalid.' },
+  '0xcf46551c': {
+    name: 'CurrentDateNotInValidRange',
+    message: 'The current date is outside the valid range for verification.',
+  },
+  '0xd7ca437d': { name: 'AttestationIdMismatch', message: 'The attestation ID does not match the expected value.' },
+  '0xda7bd3a6': { name: 'InvalidVcAndDiscloseProof', message: 'The verification and disclosure proof is invalid.' },
+  '0xe7bee380': { name: 'ScopeMismatch', message: 'The verification scope does not match.' },
+  '0xebbcc178': { name: 'InvalidUserIdentifierInProof', message: 'The user identifier in the proof is invalid.' },
+  '0xebc2fedc': { name: 'InvalidPubkeyCommitment', message: 'The public key commitment is invalid.' },
+  '0xf53393a7': {
+    name: 'InvalidIdentityCommitmentRoot',
+    message: 'The identity commitment root is invalid or outdated.',
+  },
+  '0xff633a38': { name: 'LengthMismatch', message: 'Input array lengths do not match.' },
+
+  // IdentityVerificationHubImplV1 (legacy)
+  '0x899ef10d': { name: 'LENGTH_MISMATCH', message: 'Input array lengths do not match.' },
+  '0x8e727f46': { name: 'NO_VERIFIER_SET', message: 'No verifier has been configured for this attestation type.' },
+  '0xed8cf9ff': {
+    name: 'CURRENT_DATE_NOT_IN_VALID_RANGE',
+    message: 'The current date is outside the valid range for verification.',
+  },
+  '0xf0e539b9': { name: 'INVALID_OLDER_THAN', message: 'The minimum age requirement check failed.' },
+  '0xbf21b11c': { name: 'INVALID_FORBIDDEN_COUNTRIES', message: 'The forbidden countries check failed.' },
+  '0x71b125ed': { name: 'INVALID_OFAC', message: 'The OFAC sanctions check failed.' },
+  '0x9003ac4d': { name: 'INVALID_REGISTER_PROOF', message: 'The registration proof is invalid.' },
+  '0x6a86dd76': { name: 'INVALID_DSC_PROOF', message: 'The document signing certificate proof is invalid.' },
+  '0xd4d37a7a': { name: 'INVALID_VC_AND_DISCLOSE_PROOF', message: 'The verification and disclosure proof is invalid.' },
+  '0x52906601': { name: 'INVALID_COMMITMENT_ROOT', message: 'The identity commitment root is invalid or outdated.' },
+  '0x1ce3d3ca': { name: 'INVALID_OFAC_ROOT', message: 'The OFAC check root is invalid.' },
+  '0xa294ad3c': { name: 'INVALID_CSCA_ROOT', message: 'The country signing certificate authority root is invalid.' },
+  '0xe0f15544': { name: 'INVALID_REVEALED_DATA_TYPE', message: 'The revealed data type is not recognized.' },
+
+  // Registry errors
+  '0x034acfcc': { name: 'REGISTERED_COMMITMENT', message: 'This identity has already been registered.' },
+  '0x4ffa9998': { name: 'HUB_NOT_SET', message: 'The verification hub has not been configured.' },
+  '0xba0318cb': { name: 'ONLY_HUB_CAN_ACCESS', message: 'Only the verification hub can perform this action.' },
+  '0x22697ffa': { name: 'HUB_ADDRESS_ZERO', message: 'The hub address cannot be zero.' },
+  '0x2822d0cb': {
+    name: 'ONLY_TEE_CAN_ACCESS',
+    message: 'Only the trusted execution environment can perform this action.',
+  },
+  '0xfc833fc6': { name: 'TEE_NOT_SET', message: 'The trusted execution environment has not been configured.' },
+  '0x712eb087': { name: 'INVALID_PROOF', message: 'The proof is invalid.' },
+  '0xee57533e': { name: 'INVALID_ROOT_CA', message: 'The root certificate authority is invalid.' },
+  '0x7f91b413': { name: 'INVALID_IMAGE', message: 'The provided image is invalid.' },
+  '0x118818d1': { name: 'INVALID_TIMESTAMP', message: 'The timestamp is invalid.' },
+
+  // Verification root errors
+  '0xa512e2ff': { name: 'InvalidDataFormat', message: 'The data format is invalid.' },
+  '0x5c427cd9': { name: 'UnauthorizedCaller', message: 'The caller is not authorized to perform this action.' },
+
+  // Library errors
+  '0xe048e710': { name: 'RegistryNotSet', message: 'The identity registry has not been configured.' },
+  '0x49aecbc2': { name: 'InvalidOlderThan', message: 'The minimum age requirement check failed.' },
+  '0x5fb542f4': { name: 'InvalidOfacCheck', message: 'The OFAC sanctions check failed.' },
+  '0x82cba848': { name: 'InvalidForbiddenCountries', message: 'The forbidden countries check failed.' },
+  '0x0b42b970': { name: 'InvalidPubSignalsLength', message: 'The public signals array has an unexpected length.' },
+
+  // Common example/integrator errors
+  '0x09bde339': { name: 'InvalidProof', message: 'The proof is invalid.' },
+  '0x646cf558': { name: 'AlreadyClaimed', message: 'This reward has already been claimed.' },
+  '0xbfc6c337': { name: 'NotRegistered', message: 'This address is not registered.' },
+  '0xf0c426db': { name: 'InvalidUserIdentifier', message: 'The user identifier is invalid.' },
+  '0x29393238': {
+    name: 'UserIdentifierAlreadyRegistered',
+    message: 'This user identifier has already been registered.',
+  },
+  '0x22cbc6a2': { name: 'RegisteredNullifier', message: 'This nullifier has already been used.' },
+  '0x153745d3': { name: 'RegistrationNotOpen', message: 'Registration is not currently open.' },
+  '0x697e379b': { name: 'RegistrationNotClosed', message: 'Registration has not closed yet.' },
+  '0x6b687806': { name: 'ClaimNotOpen', message: 'Claims are not currently open.' },
+  '0x5dd09265': { name: 'UserIdentifierAlreadyMinted', message: 'An NFT has already been minted for this identifier.' },
+};
+
+const SELECTOR_REGEX = /^0x[0-9a-fA-F]{8,}$/;
+
+const OPENCHAIN_API = 'https://api.openchain.xyz/signature-database/v1/lookup';
+
+function matchesSelector(value: string): boolean {
+  return SELECTOR_REGEX.test(value);
+}
+
+/**
+ * Attempts to decode a contract error from raw hex revert data or a hex error selector.
+ * Returns a human-readable message if the selector is recognized, or null otherwise.
+ */
+export function decodeContractError(errorData: string): string | null {
+  if (!errorData || !matchesSelector(errorData)) {
+    return null;
+  }
+
+  const selector = errorData.slice(0, 10).toLowerCase();
+  const entry = ERROR_SELECTOR_MAP[selector];
+  return entry?.message ?? null;
+}
+
+/**
+ * Converts a Solidity error signature like "InvalidVcAndDiscloseProof()" or
+ * "REGISTERED_COMMITMENT()" into a human-readable form like
+ * "Invalid Vc And Disclose Proof" or "Registered Commitment".
+ */
+export function formatErrorSignature(signature: string): string {
+  const name = signature.replace(/\(.*\)$/, '');
+
+  if (name === name.toUpperCase() && name.includes('_')) {
+    return name
+      .split('_')
+      .map(word => word.charAt(0) + word.slice(1).toLowerCase())
+      .join(' ');
+  }
+
+  return name.replace(/([a-z])([A-Z])/g, '$1 $2').replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2');
+}
+
+/**
+ * Returns a human-readable version of an error string if it's a known contract error selector,
+ * otherwise returns the original string unchanged.
+ */
+export function humanizeError(error: string): string {
+  return decodeContractError(error) ?? error;
+}
+
+/**
+ * Async version of humanizeError that also tries the openchain.xyz API for unknown selectors.
+ * Falls back to the sync result if the lookup fails or times out.
+ */
+export async function humanizeErrorAsync(error: string): Promise<string> {
+  const syncResult = humanizeError(error);
+  if (syncResult !== error || !matchesSelector(error)) {
+    return syncResult;
+  }
+
+  const resolved = await lookupErrorSelector(error);
+  return resolved ?? syncResult;
+}
+
+/**
+ * Checks whether a string looks like a hex error selector (0x + 8+ hex chars).
+ */
+export function isErrorSelector(value: string): boolean {
+  return matchesSelector(value);
+}
+
+/**
+ * Looks up an unknown error selector via the openchain.xyz signature database.
+ * Returns the formatted error name if found, or null.
+ */
+export async function lookupErrorSelector(selector: string): Promise<string | null> {
+  const normalized = selector.slice(0, 10).toLowerCase();
+  try {
+    const response = await fetch(`${OPENCHAIN_API}?function=${normalized}`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    if (!response.ok) return null;
+
+    const data = (await response.json()) as {
+      ok: boolean;
+      result: { function: Record<string, Array<{ name: string }>> };
+    };
+
+    const match = data?.result?.function?.[normalized]?.[0]?.name;
+    if (!match) return null;
+
+    return formatErrorSignature(match);
+  } catch {
+    return null;
+  }
+}

--- a/packages/webview-app/src/utils/provingUtils.test.ts
+++ b/packages/webview-app/src/utils/provingUtils.test.ts
@@ -69,6 +69,20 @@ describe('provingUtils', () => {
         message: 'The proof request could not be completed.',
       });
     });
+
+    it('should decode a hex error selector in the reason field', () => {
+      expect(getFailureState('error', 'contract_error', '0xda7bd3a6')).toEqual({
+        code: 'contract_error',
+        message: 'The verification and disclosure proof is invalid.',
+      });
+    });
+
+    it('should pass through unknown hex selectors unchanged', () => {
+      expect(getFailureState('error', 'contract_error', '0xdeadbeef')).toEqual({
+        code: 'contract_error',
+        message: '0xdeadbeef',
+      });
+    });
   });
 
   describe('getIdCardProps', () => {
@@ -148,12 +162,28 @@ describe('provingUtils', () => {
 
     it('should pass through a BridgeError object', () => {
       const err = { code: 'custom', message: 'msg' };
-      expect(normalizeError(err)).toBe(err);
+      expect(normalizeError(err)).toStrictEqual(err);
     });
 
     it('should preserve details on a BridgeError object', () => {
       const err = { code: 'custom', message: 'msg', details: { extra: true } };
-      expect(normalizeError(err)).toBe(err);
+      expect(normalizeError(err)).toStrictEqual(err);
+    });
+
+    it('should decode a hex error selector in a BridgeError message', () => {
+      const err = { code: 'contract_error', message: '0xda7bd3a6' };
+      const result = normalizeError(err);
+      expect(result).toStrictEqual({
+        code: 'contract_error',
+        message: 'The verification and disclosure proof is invalid.',
+      });
+    });
+
+    it('should decode a hex error selector passed as a string', () => {
+      expect(normalizeError('0x034acfcc')).toStrictEqual({
+        code: 'proof_generation_failed',
+        message: 'This identity has already been registered.',
+      });
     });
   });
 });

--- a/packages/webview-app/src/utils/provingUtils.ts
+++ b/packages/webview-app/src/utils/provingUtils.ts
@@ -5,6 +5,8 @@
 import type { IDCardProps } from '@selfxyz/euclid';
 import type { BridgeError } from '@selfxyz/webview-bridge';
 
+import { humanizeError } from './contractErrors';
+
 export type GenerationStep = 'readingRegistry' | 'generatingProof' | 'awaitingVerification' | 'finishingUp';
 
 export function getFailureState(
@@ -14,7 +16,7 @@ export function getFailureState(
 ): { code: string; message: string } {
   return {
     code: code ?? currentState ?? 'proof_generation_failed',
-    message: reason ?? 'The proof request could not be completed.',
+    message: reason ? humanizeError(reason) : 'The proof request could not be completed.',
   };
 }
 
@@ -58,10 +60,13 @@ export function normalizeError(error: BridgeError | string | undefined): BridgeE
   if (typeof error === 'string') {
     return {
       code: 'proof_generation_failed',
-      message: error,
+      message: humanizeError(error),
     };
   }
-  return error;
+  return {
+    ...error,
+    message: humanizeError(error.message),
+  };
 }
 
 export function titleCaseDisclosure(disclosure: string): string {


### PR DESCRIPTION
## Summary

Resolves [SELF-1369](https://linear.app/selfprotocol/issue/SELF-1369/improve-error-messaging-for-custom-errors)

When smart contracts revert with custom errors, the app previously showed raw bytecode selectors (e.g. `0xda7bd3a6`) to users instead of meaningful messages. This adds a two-tier decoding strategy:

- **Static lookup map** covers all Self contract errors (60+ selectors) for instant decoding with no network dependency
- **Async fallback** via [openchain.xyz](https://openchain.xyz/signatures) signature database resolves unknown third-party integrator errors at display time (3s timeout, best-effort)
- **Error name formatting** converts both `camelCase` and `SCREAMING_SNAKE_CASE` Solidity error names into readable text

Error decoding is applied at all error display points:
- SDK proving flow (`getFailureState` / `normalizeError`)
- Tunnel flow (`navigateToError`)
- All three result screens via a `useResolvedContractError` hook

### Files changed

| File | Change |
|------|--------|
| `src/utils/contractErrors.ts` | New — static map of 60+ error selectors, sync/async decode, openchain.xyz API lookup |
| `src/utils/contractErrors.test.ts` | New — 24 unit tests |
| `src/hooks/useResolvedContractError.ts` | New — React hook for async error resolution in result screens |
| `src/utils/provingUtils.ts` | Updated `getFailureState()` and `normalizeError()` to decode hex selectors |
| `src/utils/provingUtils.test.ts` | Added 6 tests for hex selector decoding |
| `DiscloseResultScreen.tsx` | Uses async resolution hook |
| `VerificationResultScreen.tsx` | Uses async resolution hook |
| `TunnelResultScreen.tsx` | Uses async resolution hook |
| `TunnelProvingScreen.tsx` | Applies `humanizeError()` in `navigateToError` |
| `TunnelDiscloseScreen.tsx` | Applies `humanizeError()` in `navigateToError` |

## Test plan

### Automated (passing)
- [x] 51 unit tests pass (contractErrors: 24, provingUtils: 27)
- [x] 9 tunnel screen integration tests pass
- [x] 12 proving screen integration tests pass
- [x] Lint clean, TypeScript types clean
- [x] Integration test: deployed `ErrorDecoderTest` contract on local Hardhat, triggered 5 custom errors, verified raw revert data decodes correctly through the static map and openchain.xyz fallback

### Manual testing required
- [ ] **Known Self error**: Trigger a contract revert with a known Self error (e.g. `InvalidVcAndDiscloseProof`, `REGISTERED_COMMITMENT`) and verify the result screen shows a human-readable message instead of a hex selector
- [ ] **Third-party integrator error**: Trigger a revert from an integrator contract with a custom error NOT in the static map — verify the openchain.xyz fallback resolves the error name within ~3s
- [ ] **Standard require error**: Trigger a `require(false, "message")` revert and verify the existing behavior (showing the message string) is preserved
- [ ] **Network failure**: Disable network and trigger an unknown custom error — verify the raw hex is shown gracefully (no crash, no infinite loading)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Error messages are now more descriptive and readable, replacing technical codes with user-friendly explanations.
  * Enhanced error display across result screens for proving, verification, and tunnel operations.

* **Tests**
  * Added comprehensive test coverage for error message formatting and resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->