### PR TITLE
Add native shell CI workflow and unit test suites

### DIFF
--- a/.github/workflows/native-shells-ci.yml
+++ b/.github/workflows/native-shells-ci.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Run Swift package tests
         run: |
           xcodebuild \
-            -scheme SelfNativeShell-Package \
+            -scheme SelfNativeShell \
             -destination "id=${{ steps.sim.outputs.id }}" \
             -resultBundlePath TestResults.xcresult \
             test

--- a/.github/workflows/native-shells-ci.yml
+++ b/.github/workflows/native-shells-ci.yml
@@ -1,0 +1,94 @@
+name: Native Shells CI
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - "packages/native-shell-android/**"
+      - "packages/native-shell-ios/**"
+      - ".github/workflows/native-shells-ci.yml"
+      - ".github/actions/**"
+  push:
+    branches: [dev, staging, main]
+    paths:
+      - "packages/native-shell-android/**"
+      - "packages/native-shell-ios/**"
+      - ".github/workflows/native-shells-ci.yml"
+      - ".github/actions/**"
+  workflow_dispatch: {}
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      android: ${{ steps.filter.outputs.android }}
+      ios: ${{ steps.filter.outputs.ios }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            android:
+              - "packages/native-shell-android/**"
+              - ".github/workflows/native-shells-ci.yml"
+              - ".github/actions/**"
+            ios:
+              - "packages/native-shell-ios/**"
+              - ".github/workflows/native-shells-ci.yml"
+              - ".github/actions/**"
+
+  native-shell-android-tests:
+    needs: changes
+    if: needs.changes.outputs.android == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: packages/native-shell-android
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      - uses: ./.github/actions/cache-gradle
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-disabled: true
+      - run: ./gradlew testDebugUnitTest
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: native-shell-android-test-results
+          path: |
+            packages/native-shell-android/build/reports/tests/
+            packages/native-shell-android/build/test-results/
+
+  native-shell-ios-tests:
+    needs: changes
+    if: needs.changes.outputs.ios == 'true'
+    runs-on: namespace-profile-apple-silicon-6cpu
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: packages/native-shell-ios
+    steps:
+      - uses: actions/checkout@v4
+      - name: Find iOS Simulator
+        id: sim
+        uses: ./.github/actions/find-ios-simulator
+      - name: Run Swift package tests
+        run: |
+          xcodebuild \
+            -scheme SelfNativeShell-Package \
+            -destination "id=${{ steps.sim.outputs.id }}" \
+            -resultBundlePath TestResults.xcresult \
+            test
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: native-shell-ios-test-results
+          path: packages/native-shell-ios/TestResults.xcresult

--- a/packages/native-shell-android/build.gradle.kts
+++ b/packages/native-shell-android/build.gradle.kts
@@ -34,6 +34,10 @@ android {
     kotlinOptions {
         jvmTarget = "17"
     }
+
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
 }
 
 tasks.register("validateWebViewBundle") {
@@ -59,5 +63,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
 
+    testImplementation("junit:junit:4.13.2")
     testImplementation("org.jetbrains.kotlin:kotlin-test:1.9.22")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
 }

--- a/packages/native-shell-android/build.gradle.kts
+++ b/packages/native-shell-android/build.gradle.kts
@@ -37,6 +37,7 @@ android {
 
     testOptions {
         unitTests.isReturnDefaultValues = true
+        unitTests.isIncludeAndroidResources = true
     }
 }
 
@@ -66,4 +67,5 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.jetbrains.kotlin:kotlin-test:1.9.22")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+    testImplementation("org.robolectric:robolectric:4.12.2")
 }

--- a/packages/native-shell-android/build.gradle.kts
+++ b/packages/native-shell-android/build.gradle.kts
@@ -58,4 +58,6 @@ dependencies {
     implementation("androidx.webkit:webkit:1.9.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+
+    testImplementation("org.jetbrains.kotlin:kotlin-test:1.9.22")
 }

--- a/packages/native-shell-android/src/main/kotlin/xyz/self/sdk/handlers/LifecycleHandler.kt
+++ b/packages/native-shell-android/src/main/kotlin/xyz/self/sdk/handlers/LifecycleHandler.kt
@@ -15,7 +15,7 @@ import xyz.self.sdk.webview.SelfVerificationActivity
 
 class LifecycleHandler(private val activity: Activity) : BridgeHandler {
     override val domain = BridgeDomain.LIFECYCLE
-    private var hasResult = false
+    internal val resultGate = LifecycleResultGate()
 
     override suspend fun handle(
         method: String,
@@ -29,7 +29,7 @@ class LifecycleHandler(private val activity: Activity) : BridgeHandler {
 
     private fun dismiss(): JsonElement? {
         activity.runOnUiThread {
-            if (!hasResult) {
+            if (resultGate.tryClaim()) {
                 activity.setResult(Activity.RESULT_CANCELED)
             }
             activity.finish()
@@ -39,15 +39,38 @@ class LifecycleHandler(private val activity: Activity) : BridgeHandler {
 
     private fun setResult(params: Map<String, JsonElement>): JsonElement? {
         activity.runOnUiThread {
-            hasResult = true
+            if (!resultGate.tryClaim()) return@runOnUiThread
             val intent = Intent()
-            val resultJson = JsonObject(params)
-            intent.putExtra(SelfVerificationActivity.EXTRA_RESULT_DATA, resultJson.toString())
-            val isSuccess = params["success"]?.jsonPrimitive?.booleanOrNull != false
+            val resultPayload = LifecycleResultEnvelope.extractPayload(params)
+            intent.putExtra(SelfVerificationActivity.EXTRA_RESULT_DATA, resultPayload.toString())
+            val isSuccess = LifecycleResultEnvelope.extractSuccess(resultPayload)
             val resultCode = if (isSuccess) Activity.RESULT_OK else Activity.RESULT_FIRST_USER
             activity.setResult(resultCode, intent)
             activity.finish()
         }
         return null
     }
+}
+
+internal class LifecycleResultGate {
+    private var claimed = false
+
+    fun tryClaim(): Boolean {
+        if (claimed) return false
+        claimed = true
+        return true
+    }
+
+    val isClaimed: Boolean get() = claimed
+}
+
+internal object LifecycleResultEnvelope {
+    fun extractPayload(params: Map<String, JsonElement>): JsonObject =
+        when (val nestedResult = params["result"]) {
+            is JsonObject -> nestedResult
+            else -> JsonObject(params)
+        }
+
+    fun extractSuccess(payload: JsonObject): Boolean =
+        payload["success"]?.jsonPrimitive?.booleanOrNull == true
 }

--- a/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/bridge/BridgeModelsTest.kt
+++ b/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/bridge/BridgeModelsTest.kt
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package xyz.self.sdk.bridge
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+
+class BridgeModelsTest {
+
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    @Test
+    fun `BridgeRequest decodes from JSON`() {
+        val raw = """
+            {
+                "type": "request",
+                "version": 1,
+                "id": "req-1",
+                "domain": "secureStorage",
+                "method": "get",
+                "params": {"key": "token"},
+                "timestamp": 1000
+            }
+        """.trimIndent()
+
+        val req = json.decodeFromString<BridgeRequest>(raw)
+
+        assertEquals("request", req.type)
+        assertEquals(1, req.version)
+        assertEquals("req-1", req.id)
+        assertEquals(BridgeDomain.SECURE_STORAGE, req.domain)
+        assertEquals("get", req.method)
+        assertEquals(JsonPrimitive("token"), req.params["key"])
+        assertEquals(1000L, req.timestamp)
+    }
+
+    @Test
+    fun `BridgeRequest decodes with empty params`() {
+        val raw = """
+            {
+                "type": "request",
+                "version": 1,
+                "id": "req-2",
+                "domain": "lifecycle",
+                "method": "ready",
+                "params": {},
+                "timestamp": 2000
+            }
+        """.trimIndent()
+
+        val req = json.decodeFromString<BridgeRequest>(raw)
+
+        assertEquals(BridgeDomain.LIFECYCLE, req.domain)
+        assertTrue(req.params.isEmpty())
+    }
+
+    @Test
+    fun `BridgeResponse roundtrips through JSON`() {
+        val resp = BridgeResponse(
+            id = "resp-1",
+            domain = BridgeDomain.CRYPTO,
+            requestId = "req-1",
+            success = true,
+            data = JsonPrimitive("result-data"),
+        )
+
+        val encoded = json.encodeToString(resp)
+        val decoded = json.decodeFromString<BridgeResponse>(encoded)
+
+        assertEquals("response", decoded.type)
+        assertEquals(BRIDGE_PROTOCOL_VERSION, decoded.version)
+        assertEquals("resp-1", decoded.id)
+        assertEquals(BridgeDomain.CRYPTO, decoded.domain)
+        assertEquals("req-1", decoded.requestId)
+        assertTrue(decoded.success)
+        assertEquals(JsonPrimitive("result-data"), decoded.data)
+        assertNull(decoded.error)
+    }
+
+    @Test
+    fun `BridgeResponse with error roundtrips`() {
+        val resp = BridgeResponse(
+            id = "resp-2",
+            domain = BridgeDomain.SECURE_STORAGE,
+            requestId = "req-2",
+            success = false,
+            error = BridgeError(code = "MISSING_KEY", message = "Key required"),
+        )
+
+        val encoded = json.encodeToString(resp)
+        val decoded = json.decodeFromString<BridgeResponse>(encoded)
+
+        assertEquals(false, decoded.success)
+        assertNull(decoded.data)
+        assertEquals("MISSING_KEY", decoded.error?.code)
+        assertEquals("Key required", decoded.error?.message)
+    }
+
+    @Test
+    fun `BridgeEvent roundtrips through JSON`() {
+        val event = BridgeEvent(
+            id = "evt-1",
+            domain = BridgeDomain.NFC,
+            event = "tagDetected",
+            data = JsonPrimitive("tag-data"),
+        )
+
+        val encoded = json.encodeToString(event)
+        val decoded = json.decodeFromString<BridgeEvent>(encoded)
+
+        assertEquals("event", decoded.type)
+        assertEquals(BRIDGE_PROTOCOL_VERSION, decoded.version)
+        assertEquals("evt-1", decoded.id)
+        assertEquals(BridgeDomain.NFC, decoded.domain)
+        assertEquals("tagDetected", decoded.event)
+        assertEquals(JsonPrimitive("tag-data"), decoded.data)
+    }
+
+    @Test
+    fun `BridgeDomain serializes to lowercase`() {
+        val encoded = json.encodeToString(BridgeDomain.SECURE_STORAGE)
+        assertEquals("\"secureStorage\"", encoded)
+    }
+
+    @Test
+    fun `all BridgeDomain values roundtrip`() {
+        for (domain in BridgeDomain.entries) {
+            val encoded = json.encodeToString(domain)
+            val decoded = json.decodeFromString<BridgeDomain>(encoded)
+            assertEquals(domain, decoded)
+        }
+    }
+}

--- a/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/bridge/MessageRouterEscapeTest.kt
+++ b/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/bridge/MessageRouterEscapeTest.kt
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package xyz.self.sdk.bridge
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MessageRouterEscapeTest {
+
+    @Test
+    fun `escapeForJs escapes backslashes single quotes and line breaks`() {
+        val raw = "path\\to'file\nnext\rline"
+
+        val escaped = MessageRouter.escapeForJs(raw)
+
+        assertEquals("'path\\\\to\\'file\\nnext\\rline'", escaped)
+    }
+
+    @Test
+    fun `escapeForJs escapes unicode line separators`() {
+        val raw = "before\u2028middle\u2029after"
+
+        val escaped = MessageRouter.escapeForJs(raw)
+
+        assertEquals("'before\\u2028middle\\u2029after'", escaped)
+    }
+}

--- a/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/bridge/MessageRouterTest.kt
+++ b/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/bridge/MessageRouterTest.kt
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package xyz.self.sdk.bridge
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MessageRouterTest {
+
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    private fun makeRequest(
+        domain: BridgeDomain = BridgeDomain.SECURE_STORAGE,
+        method: String = "get",
+        params: Map<String, JsonElement> = emptyMap(),
+        version: Int = BRIDGE_PROTOCOL_VERSION,
+        id: String = "req-1",
+    ): String = json.encodeToString(
+        BridgeRequest(
+            type = "request",
+            version = version,
+            id = id,
+            domain = domain,
+            method = method,
+            params = params,
+            timestamp = 1000L,
+        ),
+    )
+
+    private fun parseResponse(js: String): BridgeResponse {
+        val jsonStr = js
+            .removePrefix("window.SelfNativeBridge._handleResponse(")
+            .removeSuffix(")")
+            .let { unescapeJs(it) }
+        return json.decodeFromString<BridgeResponse>(jsonStr)
+    }
+
+    private fun unescapeJs(escaped: String): String {
+        val inner = escaped.removeSurrounding("'")
+        return inner
+            .replace("\\\\'", "'")
+            .replace("\\\\n", "\n")
+            .replace("\\\\r", "\r")
+            .replace("\\\\u2028", "\u2028")
+            .replace("\\\\u2029", "\u2029")
+            .replace("\\\\\\\\", "\\")
+    }
+
+    @Test
+    fun `unsupported version sends error response`() = runTest {
+        val sent = mutableListOf<String>()
+        val router = MessageRouter(sendToWebView = { sent.add(it) }, scope = this)
+
+        router.onMessageReceived(makeRequest(version = 999))
+        advanceUntilIdle()
+
+        assertEquals(1, sent.size)
+        val resp = parseResponse(sent[0])
+        assertEquals(false, resp.success)
+        assertEquals("UNSUPPORTED_VERSION", resp.error?.code)
+        assertEquals("req-1", resp.requestId)
+    }
+
+    @Test
+    fun `unknown domain sends error response`() = runTest {
+        val sent = mutableListOf<String>()
+        val router = MessageRouter(sendToWebView = { sent.add(it) }, scope = this)
+
+        router.onMessageReceived(makeRequest(domain = BridgeDomain.NFC))
+        advanceUntilIdle()
+
+        assertEquals(1, sent.size)
+        val resp = parseResponse(sent[0])
+        assertEquals(false, resp.success)
+        assertEquals("DOMAIN_NOT_FOUND", resp.error?.code)
+    }
+
+    @Test
+    fun `successful handler call sends success response`() = runTest {
+        val sent = mutableListOf<String>()
+        val router = MessageRouter(sendToWebView = { sent.add(it) }, scope = this)
+        router.register(StubHandler(BridgeDomain.SECURE_STORAGE, result = JsonPrimitive("ok")))
+
+        router.onMessageReceived(makeRequest())
+        advanceUntilIdle()
+
+        assertEquals(1, sent.size)
+        val resp = parseResponse(sent[0])
+        assertTrue(resp.success)
+        assertEquals("req-1", resp.requestId)
+    }
+
+    @Test
+    fun `handler exception sends error response with code`() = runTest {
+        val sent = mutableListOf<String>()
+        val router = MessageRouter(sendToWebView = { sent.add(it) }, scope = this)
+        router.register(StubHandler(
+            BridgeDomain.SECURE_STORAGE,
+            error = BridgeHandlerException("MISSING_KEY", "Key parameter required"),
+        ))
+
+        router.onMessageReceived(makeRequest())
+        advanceUntilIdle()
+
+        assertEquals(1, sent.size)
+        val resp = parseResponse(sent[0])
+        assertEquals(false, resp.success)
+        assertEquals("MISSING_KEY", resp.error?.code)
+        assertEquals("Key parameter required", resp.error?.message)
+    }
+
+    @Test
+    fun `generic exception sends INTERNAL_ERROR response`() = runTest {
+        val sent = mutableListOf<String>()
+        val router = MessageRouter(sendToWebView = { sent.add(it) }, scope = this)
+        router.register(StubHandler(
+            BridgeDomain.SECURE_STORAGE,
+            error = RuntimeException("disk full"),
+        ))
+
+        router.onMessageReceived(makeRequest())
+        advanceUntilIdle()
+
+        assertEquals(1, sent.size)
+        val resp = parseResponse(sent[0])
+        assertEquals(false, resp.success)
+        assertEquals("INTERNAL_ERROR", resp.error?.code)
+        assertTrue(resp.error?.message?.contains("disk full") == true)
+    }
+
+    @Test
+    fun `malformed json is silently dropped`() = runTest {
+        val sent = mutableListOf<String>()
+        val router = MessageRouter(sendToWebView = { sent.add(it) }, scope = this)
+
+        router.onMessageReceived("{not valid json")
+        advanceUntilIdle()
+
+        assertTrue(sent.isEmpty())
+    }
+
+    @Test
+    fun `register replaces existing handler for same domain`() = runTest {
+        val sent = mutableListOf<String>()
+        val router = MessageRouter(sendToWebView = { sent.add(it) }, scope = this)
+        router.register(StubHandler(BridgeDomain.SECURE_STORAGE, result = JsonPrimitive("first")))
+        router.register(StubHandler(BridgeDomain.SECURE_STORAGE, result = JsonPrimitive("second")))
+
+        router.onMessageReceived(makeRequest())
+        advanceUntilIdle()
+
+        val resp = parseResponse(sent[0])
+        assertTrue(resp.success)
+        assertEquals(JsonPrimitive("second"), resp.data)
+    }
+
+    @Test
+    fun `pushEvent sends formatted event to webview`() = runTest {
+        val sent = mutableListOf<String>()
+        val router = MessageRouter(sendToWebView = { sent.add(it) }, scope = this)
+
+        router.pushEvent(BridgeDomain.NFC, "tagDetected", JsonPrimitive("abc"))
+
+        assertEquals(1, sent.size)
+        assertTrue(sent[0].startsWith("window.SelfNativeBridge._handleEvent("))
+    }
+
+    private class StubHandler(
+        override val domain: BridgeDomain,
+        private val result: JsonElement? = null,
+        private val error: Exception? = null,
+    ) : BridgeHandler {
+        override suspend fun handle(method: String, params: Map<String, JsonElement>): JsonElement? {
+            if (error != null) throw error
+            return result
+        }
+    }
+}

--- a/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/handlers/CryptoHandlerTest.kt
+++ b/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/handlers/CryptoHandlerTest.kt
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package xyz.self.sdk.handlers
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import xyz.self.sdk.bridge.BridgeDomain
+
+class CryptoHandlerTest {
+
+    @Test
+    fun `domain is CRYPTO`() {
+        // CryptoHandler constructor initializes AndroidKeyStore which is unavailable
+        // in JVM unit tests. We verify the domain constant directly.
+        assertEquals("crypto", BridgeDomain.CRYPTO.name.lowercase())
+    }
+}

--- a/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/handlers/LifecycleHandlerTest.kt
+++ b/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/handlers/LifecycleHandlerTest.kt
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package xyz.self.sdk.handlers
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import xyz.self.sdk.bridge.BridgeDomain
+
+class LifecycleHandlerTest {
+
+    @Test
+    fun `domain is LIFECYCLE`() {
+        // LifecycleHandler requires an Activity, so we can only verify the domain
+        // via reflection or by constructing with a mock. Since Activity is an Android
+        // class unavailable in JVM unit tests, we verify the domain constant directly.
+        assertEquals("lifecycle", BridgeDomain.LIFECYCLE.name.lowercase())
+    }
+}

--- a/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/handlers/LifecycleHandlerTest.kt
+++ b/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/handlers/LifecycleHandlerTest.kt
@@ -2,17 +2,74 @@
 
 package xyz.self.sdk.handlers
 
+import android.app.Activity
+import kotlin.test.assertNotNull
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import xyz.self.sdk.bridge.BridgeDomain
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import xyz.self.sdk.webview.SelfVerificationActivity
 
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
 class LifecycleHandlerTest {
 
     @Test
-    fun `domain is LIFECYCLE`() {
-        // LifecycleHandler requires an Activity, so we can only verify the domain
-        // via reflection or by constructing with a mock. Since Activity is an Android
-        // class unavailable in JVM unit tests, we verify the domain constant directly.
-        assertEquals("lifecycle", BridgeDomain.LIFECYCLE.name.lowercase())
+    fun `dismiss sets cancelled result and finishes activity`() = runTest {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val handler = LifecycleHandler(activity)
+
+        handler.handle("dismiss", emptyMap())
+
+        val shadow = shadowOf(activity)
+        assertEquals(Activity.RESULT_CANCELED, shadow.resultCode)
+        assertEquals(true, activity.isFinishing)
+    }
+
+    @Test
+    fun `setResult success sets ok result with payload`() = runTest {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val handler = LifecycleHandler(activity)
+
+        handler.handle(
+            "setResult",
+            mapOf(
+                "success" to JsonPrimitive(true),
+                "verificationId" to JsonPrimitive("ver_123"),
+            ),
+        )
+
+        val shadow = shadowOf(activity)
+        assertEquals(Activity.RESULT_OK, shadow.resultCode)
+        assertEquals(true, activity.isFinishing)
+        val resultIntent = shadow.resultIntent
+        assertNotNull(resultIntent)
+        val resultJson = resultIntent.getStringExtra(SelfVerificationActivity.EXTRA_RESULT_DATA)
+        assertNotNull(resultJson)
+        assertEquals(true, resultJson.contains("\"success\":true"))
+        assertEquals(true, resultJson.contains("\"verificationId\":\"ver_123\""))
+    }
+
+    @Test
+    fun `setResult failure sets first user result`() = runTest {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val handler = LifecycleHandler(activity)
+
+        handler.handle(
+            "setResult",
+            mapOf(
+                "success" to JsonPrimitive(false),
+                "error" to JsonPrimitive("denied"),
+            ),
+        )
+
+        val shadow = shadowOf(activity)
+        assertEquals(Activity.RESULT_FIRST_USER, shadow.resultCode)
+        assertEquals(true, activity.isFinishing)
     }
 }

--- a/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/handlers/LifecycleResultEnvelopeTest.kt
+++ b/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/handlers/LifecycleResultEnvelopeTest.kt
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package xyz.self.sdk.handlers
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+class LifecycleResultEnvelopeTest {
+
+    @Test
+    fun `extractPayload unwraps nested result object`() {
+        val inner = buildJsonObject { put("success", true); put("data", "value") }
+        val params = mapOf("result" to inner, "extra" to JsonPrimitive("ignored"))
+
+        val payload = LifecycleResultEnvelope.extractPayload(params)
+
+        assertEquals(inner, payload)
+    }
+
+    @Test
+    fun `extractPayload falls back to wrapping params when result is missing`() {
+        val params = mapOf("success" to JsonPrimitive(false), "error" to JsonPrimitive("oops"))
+
+        val payload = LifecycleResultEnvelope.extractPayload(params)
+
+        assertEquals(JsonObject(params), payload)
+    }
+
+    @Test
+    fun `extractPayload falls back to wrapping params when result is not a JsonObject`() {
+        val params = mapOf("result" to JsonPrimitive("not-an-object"), "success" to JsonPrimitive(true))
+
+        val payload = LifecycleResultEnvelope.extractPayload(params)
+
+        assertEquals(JsonObject(params), payload)
+    }
+
+    @Test
+    fun `extractSuccess returns true when success is true`() {
+        val payload = buildJsonObject { put("success", true) }
+
+        assertTrue(LifecycleResultEnvelope.extractSuccess(payload))
+    }
+
+    @Test
+    fun `extractSuccess returns false when success is false`() {
+        val payload = buildJsonObject { put("success", false) }
+
+        assertFalse(LifecycleResultEnvelope.extractSuccess(payload))
+    }
+
+    @Test
+    fun `extractSuccess returns false when success field is missing`() {
+        val payload = buildJsonObject { put("data", "value") }
+
+        assertFalse(LifecycleResultEnvelope.extractSuccess(payload))
+    }
+
+    @Test
+    fun `extractSuccess returns false when success is not a boolean`() {
+        val payload = buildJsonObject { put("success", "yes") }
+
+        assertFalse(LifecycleResultEnvelope.extractSuccess(payload))
+    }
+
+    @Test
+    fun `extractSuccess returns false for empty payload`() {
+        val payload = buildJsonObject {}
+
+        assertFalse(LifecycleResultEnvelope.extractSuccess(payload))
+    }
+}

--- a/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/handlers/LifecycleResultGateTest.kt
+++ b/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/handlers/LifecycleResultGateTest.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package xyz.self.sdk.handlers
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LifecycleResultGateTest {
+
+    @Test
+    fun `first tryClaim succeeds`() {
+        val gate = LifecycleResultGate()
+
+        assertTrue(gate.tryClaim())
+        assertTrue(gate.isClaimed)
+    }
+
+    @Test
+    fun `second tryClaim fails after first claim`() {
+        val gate = LifecycleResultGate()
+
+        assertTrue(gate.tryClaim())
+        assertFalse(gate.tryClaim())
+    }
+
+    @Test
+    fun `isClaimed is false before any claim`() {
+        val gate = LifecycleResultGate()
+
+        assertFalse(gate.isClaimed)
+    }
+
+    @Test
+    fun `dismiss-then-setResult scenario - second caller is rejected`() {
+        val gate = LifecycleResultGate()
+
+        // dismiss claims the gate
+        val dismissClaimed = gate.tryClaim()
+        // setResult tries to claim after dismiss
+        val setResultClaimed = gate.tryClaim()
+
+        assertTrue(dismissClaimed, "dismiss should win the gate")
+        assertFalse(setResultClaimed, "setResult should be rejected after dismiss")
+    }
+
+    @Test
+    fun `setResult-then-dismiss scenario - dismiss does not reclaim`() {
+        val gate = LifecycleResultGate()
+
+        // setResult claims the gate
+        val setResultClaimed = gate.tryClaim()
+        // dismiss tries to claim after setResult
+        val dismissClaimed = gate.tryClaim()
+
+        assertTrue(setResultClaimed, "setResult should win the gate")
+        assertFalse(dismissClaimed, "dismiss should not reclaim after setResult")
+    }
+
+    @Test
+    fun `many claims after first all fail`() {
+        val gate = LifecycleResultGate()
+
+        assertTrue(gate.tryClaim())
+        repeat(10) {
+            assertFalse(gate.tryClaim())
+        }
+    }
+}

--- a/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/handlers/SecureStorageHandlerTest.kt
+++ b/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/handlers/SecureStorageHandlerTest.kt
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package xyz.self.sdk.handlers
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import xyz.self.sdk.api.SecureStorageProvider
+import xyz.self.sdk.bridge.BridgeHandlerException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SecureStorageHandlerTest {
+
+    @Test
+    fun `get returns stored value`() = runTest {
+        val provider = FakeSecureStorageProvider()
+        provider.values["token"] = "abc123"
+        val handler = SecureStorageHandler(provider)
+
+        val result = handler.handle("get", mapOf("key" to JsonPrimitive("token"))) as JsonObject
+
+        assertEquals(JsonPrimitive("abc123"), result["value"])
+    }
+
+    @Test
+    fun `get returns null when key is missing`() = runTest {
+        val handler = SecureStorageHandler(FakeSecureStorageProvider())
+
+        val result = handler.handle("get", mapOf("key" to JsonPrimitive("missing"))) as JsonObject
+
+        assertEquals(JsonNull, result["value"])
+    }
+
+    @Test
+    fun `set stores value`() = runTest {
+        val provider = FakeSecureStorageProvider()
+        val handler = SecureStorageHandler(provider)
+
+        val result = handler.handle(
+            "set",
+            mapOf("key" to JsonPrimitive("token"), "value" to JsonPrimitive("abc123")),
+        )
+
+        assertNull(result)
+        assertEquals("abc123", provider.values["token"])
+    }
+
+    @Test
+    fun `remove deletes value`() = runTest {
+        val provider = FakeSecureStorageProvider()
+        provider.values["token"] = "abc123"
+        val handler = SecureStorageHandler(provider)
+
+        val result = handler.handle("remove", mapOf("key" to JsonPrimitive("token")))
+
+        assertNull(result)
+        assertEquals(false, provider.values.containsKey("token"))
+    }
+
+    @Test
+    fun `missing key raises bridge error`() = runTest {
+        val handler = SecureStorageHandler(FakeSecureStorageProvider())
+
+        val error = assertFailsWith<BridgeHandlerException> {
+            handler.handle("get", emptyMap())
+        }
+
+        assertEquals("MISSING_KEY", error.code)
+    }
+
+    @Test
+    fun `missing value raises bridge error`() = runTest {
+        val handler = SecureStorageHandler(FakeSecureStorageProvider())
+
+        val error = assertFailsWith<BridgeHandlerException> {
+            handler.handle("set", mapOf("key" to JsonPrimitive("token")))
+        }
+
+        assertEquals("MISSING_VALUE", error.code)
+    }
+
+    private class FakeSecureStorageProvider : SecureStorageProvider {
+        val values = mutableMapOf<String, String>()
+
+        override fun get(key: String): String? = values[key]
+
+        override fun set(key: String, value: String) {
+            values[key] = value
+        }
+
+        override fun remove(key: String) {
+            values.remove(key)
+        }
+    }
+}

--- a/packages/native-shell-ios/Package.swift
+++ b/packages/native-shell-ios/Package.swift
@@ -22,6 +22,11 @@ let package = Package(
             resources: [
                 .copy("Resources/self-sdk-web")
             ]
+        ),
+        .testTarget(
+            name: "SelfNativeShellTests",
+            dependencies: ["SelfNativeShell"],
+            path: "Tests/SelfNativeShellTests"
         )
     ]
 )

--- a/packages/native-shell-ios/Sources/SelfNativeShell/API/SelfSdk.swift
+++ b/packages/native-shell-ios/Sources/SelfNativeShell/API/SelfSdk.swift
@@ -16,7 +16,7 @@ public final class SelfSdk {
 
 final class SelfSdkViewController: UIViewController {
     private let config: SelfSdkConfig
-    private weak var callback: SelfSdkCallback?
+    private let callback: SelfSdkCallback
     private var webViewHost: SelfWebViewHost?
 
     init(config: SelfSdkConfig, callback: SelfSdkCallback) {
@@ -37,20 +37,21 @@ final class SelfSdkViewController: UIViewController {
     }
 
     private func setupWebView() {
+        let callback = self.callback
         let lifecycleHandler = LifecycleHandler(
             viewController: self,
-            onResult: { [weak self] result in
+            onResult: { result in
                 if let dict = result as? [String: Any] {
-                    self?.callback?.onSuccess(result: dict)
+                    callback.onSuccess(result: dict)
                 } else {
-                    self?.callback?.onSuccess(result: [:])
+                    callback.onSuccess(result: [:])
                 }
             },
-            onFailure: { [weak self] error in
-                self?.callback?.onFailure(error: error)
+            onFailure: { error in
+                callback.onFailure(error: error)
             },
-            onDismiss: { [weak self] in
-                self?.callback?.onCancelled()
+            onDismiss: {
+                callback.onCancelled()
             }
         )
 

--- a/packages/native-shell-ios/Sources/SelfNativeShell/API/SelfSdk.swift
+++ b/packages/native-shell-ios/Sources/SelfNativeShell/API/SelfSdk.swift
@@ -46,6 +46,9 @@ final class SelfSdkViewController: UIViewController {
                     self?.callback?.onSuccess(result: [:])
                 }
             },
+            onFailure: { [weak self] error in
+                self?.callback?.onFailure(error: error)
+            },
             onDismiss: { [weak self] in
                 self?.callback?.onCancelled()
             }

--- a/packages/native-shell-ios/Sources/SelfNativeShell/Handlers/LifecycleHandler.swift
+++ b/packages/native-shell-ios/Sources/SelfNativeShell/Handlers/LifecycleHandler.swift
@@ -65,8 +65,8 @@ final class LifecycleHandler: BridgeHandler {
                 return
             }
             hasEmittedResult = true
-            vc.dismiss(animated: true) { [weak self] in
-                self?.onDismiss?()
+            vc.dismiss(animated: true) {
+                self.onDismiss?()
             }
         } else {
             guard !hasEmittedResult else { return }

--- a/packages/native-shell-ios/Sources/SelfNativeShell/Handlers/LifecycleHandler.swift
+++ b/packages/native-shell-ios/Sources/SelfNativeShell/Handlers/LifecycleHandler.swift
@@ -60,10 +60,13 @@ final class LifecycleHandler: BridgeHandler {
     @MainActor
     private func dismiss() {
         if let vc = viewController {
+            guard !hasEmittedResult else {
+                vc.dismiss(animated: true)
+                return
+            }
+            hasEmittedResult = true
             vc.dismiss(animated: true) { [weak self] in
-                guard let self = self, !self.hasEmittedResult else { return }
-                self.hasEmittedResult = true
-                self.onDismiss?()
+                self?.onDismiss?()
             }
         } else {
             guard !hasEmittedResult else { return }

--- a/packages/native-shell-ios/Sources/SelfNativeShell/Handlers/LifecycleHandler.swift
+++ b/packages/native-shell-ios/Sources/SelfNativeShell/Handlers/LifecycleHandler.swift
@@ -8,12 +8,19 @@ final class LifecycleHandler: BridgeHandler {
 
     private weak var viewController: UIViewController?
     private let onResult: ((Any?) -> Void)?
+    private let onFailure: ((Error) -> Void)?
     private let onDismiss: (() -> Void)?
     private var hasEmittedResult = false
 
-    init(viewController: UIViewController?, onResult: ((Any?) -> Void)?, onDismiss: (() -> Void)?) {
+    init(
+        viewController: UIViewController?,
+        onResult: ((Any?) -> Void)?,
+        onFailure: ((Error) -> Void)?,
+        onDismiss: (() -> Void)?
+    ) {
         self.viewController = viewController
         self.onResult = onResult
+        self.onFailure = onFailure
         self.onDismiss = onDismiss
     }
 
@@ -31,10 +38,16 @@ final class LifecycleHandler: BridgeHandler {
             return nil
 
         case "setResult":
-            let result: Any? = params
+            let result = SelfLifecycleResultEnvelope.extractPayload(from: params)
+            let isSuccess = SelfLifecycleResultEnvelope.extractSuccess(from: result) ?? false
             await MainActor.run {
+                guard !hasEmittedResult else { return }
                 hasEmittedResult = true
-                onResult?(result)
+                if isSuccess {
+                    onResult?(result)
+                } else {
+                    onFailure?(SelfLifecycleResultError(payload: result))
+                }
                 dismiss()
             }
             return nil
@@ -49,11 +62,42 @@ final class LifecycleHandler: BridgeHandler {
         if let vc = viewController {
             vc.dismiss(animated: true) { [weak self] in
                 guard let self = self, !self.hasEmittedResult else { return }
+                self.hasEmittedResult = true
                 self.onDismiss?()
             }
         } else {
             guard !hasEmittedResult else { return }
+            hasEmittedResult = true
             onDismiss?()
         }
+    }
+}
+
+enum SelfLifecycleResultEnvelope {
+    static func extractPayload(from params: [String: Any]?) -> Any? {
+        guard let params else { return nil }
+        if let nestedResult = params["result"] {
+            return nestedResult
+        }
+        return params
+    }
+
+    static func extractSuccess(from payload: Any?) -> Bool? {
+        guard let payload = payload as? [String: Any] else { return nil }
+        return payload["success"] as? Bool
+    }
+}
+
+struct SelfLifecycleResultError: LocalizedError {
+    let payload: Any?
+
+    var errorDescription: String? {
+        if let payload = payload as? [String: Any],
+           let error = payload["error"] as? [String: Any],
+           let message = error["message"] as? String {
+            return message
+        }
+
+        return "Verification failed"
     }
 }

--- a/packages/native-shell-ios/Tests/SelfNativeShellTests/BridgeModelsTests.swift
+++ b/packages/native-shell-ios/Tests/SelfNativeShellTests/BridgeModelsTests.swift
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import XCTest
+@testable import SelfNativeShell
+
+final class BridgeModelsTests: XCTestCase {
+
+    // MARK: - BridgeRequest decoding
+
+    func testBridgeRequestDecodesFromJSON() throws {
+        let json = """
+        {
+            "type": "request",
+            "version": 1,
+            "id": "req-1",
+            "domain": "secureStorage",
+            "method": "get",
+            "params": {"key": "token"},
+            "timestamp": 1000.0
+        }
+        """.data(using: .utf8)!
+
+        let request = try JSONDecoder().decode(BridgeRequest.self, from: json)
+
+        XCTAssertEqual(request.type, "request")
+        XCTAssertEqual(request.version, 1)
+        XCTAssertEqual(request.id, "req-1")
+        XCTAssertEqual(request.domain, .secureStorage)
+        XCTAssertEqual(request.method, "get")
+        XCTAssertEqual(request.params?["key"]?.value as? String, "token")
+        XCTAssertEqual(request.timestamp, 1000.0)
+    }
+
+    func testBridgeRequestDecodesWithNilParams() throws {
+        let json = """
+        {
+            "type": "request",
+            "version": 1,
+            "id": "req-2",
+            "domain": "lifecycle",
+            "method": "ready",
+            "timestamp": 2000.0
+        }
+        """.data(using: .utf8)!
+
+        let request = try JSONDecoder().decode(BridgeRequest.self, from: json)
+
+        XCTAssertEqual(request.domain, .lifecycle)
+        XCTAssertNil(request.params)
+    }
+
+    // MARK: - BridgeResponse
+
+    func testSuccessResponseFactory() {
+        let request = BridgeRequest(
+            type: "request", version: 1, id: "req-1",
+            domain: .crypto, method: "generateKey",
+            params: nil, timestamp: 1000.0
+        )
+
+        let response = BridgeResponse.success(request: request, result: ["keyRef": "key1"])
+
+        XCTAssertEqual(response.type, "response")
+        XCTAssertEqual(response.version, 1)
+        XCTAssertEqual(response.domain, .crypto)
+        XCTAssertEqual(response.requestId, "req-1")
+        XCTAssertTrue(response.success)
+        XCTAssertNil(response.error)
+    }
+
+    func testFailureResponseFactory() {
+        let request = BridgeRequest(
+            type: "request", version: 1, id: "req-2",
+            domain: .secureStorage, method: "get",
+            params: nil, timestamp: 2000.0
+        )
+
+        let response = BridgeResponse.failure(
+            request: request, code: "MISSING_KEY", message: "Key required"
+        )
+
+        XCTAssertFalse(response.success)
+        XCTAssertNil(response.data)
+        XCTAssertEqual(response.error?.code, "MISSING_KEY")
+        XCTAssertEqual(response.error?.message, "Key required")
+    }
+
+    func testBridgeResponseRoundtrips() throws {
+        let request = BridgeRequest(
+            type: "request", version: 1, id: "req-1",
+            domain: .crypto, method: "sign",
+            params: nil, timestamp: 1000.0
+        )
+        let original = BridgeResponse.success(request: request, result: "signed-data")
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(BridgeResponse.self, from: data)
+
+        XCTAssertEqual(decoded.type, "response")
+        XCTAssertEqual(decoded.domain, .crypto)
+        XCTAssertEqual(decoded.requestId, "req-1")
+        XCTAssertTrue(decoded.success)
+    }
+
+    // MARK: - BridgeDomain
+
+    func testAllDomainsDecodeFromRawValues() throws {
+        let domains: [(String, BridgeDomain)] = [
+            ("nfc", .nfc),
+            ("biometrics", .biometrics),
+            ("secureStorage", .secureStorage),
+            ("camera", .camera),
+            ("crypto", .crypto),
+            ("haptic", .haptic),
+            ("analytics", .analytics),
+            ("lifecycle", .lifecycle),
+            ("documents", .documents),
+            ("navigation", .navigation),
+        ]
+
+        for (rawValue, expected) in domains {
+            let json = "\"\(rawValue)\"".data(using: .utf8)!
+            let decoded = try JSONDecoder().decode(BridgeDomain.self, from: json)
+            XCTAssertEqual(decoded, expected, "Failed for \(rawValue)")
+        }
+    }
+
+    // MARK: - AnyCodable
+
+    func testAnyCodableDecodesString() throws {
+        let json = "\"hello\"".data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(AnyCodable.self, from: json)
+        XCTAssertEqual(decoded.value as? String, "hello")
+    }
+
+    func testAnyCodableDecodesInt() throws {
+        let json = "42".data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(AnyCodable.self, from: json)
+        XCTAssertEqual(decoded.value as? Int, 42)
+    }
+
+    func testAnyCodableDecodesBool() throws {
+        let json = "true".data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(AnyCodable.self, from: json)
+        XCTAssertEqual(decoded.value as? Bool, true)
+    }
+
+    func testAnyCodableDecodesNull() throws {
+        let json = "null".data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(AnyCodable.self, from: json)
+        XCTAssertTrue(decoded.value is NSNull)
+    }
+
+    func testAnyCodableDecodesArray() throws {
+        let json = "[1, 2, 3]".data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(AnyCodable.self, from: json)
+        let array = decoded.value as? [Any]
+        XCTAssertEqual(array?.count, 3)
+    }
+
+    func testAnyCodableDecodesDict() throws {
+        let json = "{\"a\": 1}".data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(AnyCodable.self, from: json)
+        let dict = decoded.value as? [String: Any]
+        XCTAssertNotNil(dict?["a"])
+    }
+
+    func testAnyCodableRoundtripsString() throws {
+        let original = AnyCodable("test")
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(AnyCodable.self, from: data)
+        XCTAssertEqual(decoded.value as? String, "test")
+    }
+
+    // MARK: - BridgeHandlerError
+
+    func testBridgeHandlerErrorCodes() {
+        XCTAssertEqual(BridgeHandlerError.unknownMethod("foo").code, "UNKNOWN_METHOD")
+        XCTAssertEqual(BridgeHandlerError.missingParam("bar").code, "MISSING_PARAM")
+        XCTAssertEqual(BridgeHandlerError.operationFailed("baz").code, "OPERATION_FAILED")
+    }
+
+    func testBridgeHandlerErrorDescriptions() {
+        XCTAssertEqual(
+            BridgeHandlerError.unknownMethod("foo").errorDescription,
+            "Unknown method: foo"
+        )
+        XCTAssertEqual(
+            BridgeHandlerError.missingParam("bar").errorDescription,
+            "Missing parameter: bar"
+        )
+        XCTAssertEqual(
+            BridgeHandlerError.operationFailed("baz").errorDescription,
+            "baz"
+        )
+    }
+}

--- a/packages/native-shell-ios/Tests/SelfNativeShellTests/CryptoHandlerTests.swift
+++ b/packages/native-shell-ios/Tests/SelfNativeShellTests/CryptoHandlerTests.swift
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import XCTest
+@testable import SelfNativeShell
+
+final class CryptoHandlerTests: XCTestCase {
+
+    func testDomainIsCrypto() {
+        let handler = CryptoHandler()
+        XCTAssertEqual(handler.domain, .crypto)
+    }
+
+    func testGenerateKeyThrowsWhenKeyRefMissing() async {
+        let handler = CryptoHandler()
+
+        do {
+            _ = try await handler.handle(method: "generateKey", params: nil)
+            XCTFail("Expected missingParam error")
+        } catch let error as BridgeHandlerError {
+            XCTAssertEqual(error.code, "MISSING_PARAM")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testGetPublicKeyThrowsWhenKeyRefMissing() async {
+        let handler = CryptoHandler()
+
+        do {
+            _ = try await handler.handle(method: "getPublicKey", params: nil)
+            XCTFail("Expected missingParam error")
+        } catch let error as BridgeHandlerError {
+            XCTAssertEqual(error.code, "MISSING_PARAM")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testSignThrowsWhenKeyRefMissing() async {
+        let handler = CryptoHandler()
+
+        do {
+            _ = try await handler.handle(method: "sign", params: ["data": "dGVzdA=="])
+            XCTFail("Expected missingParam error")
+        } catch let error as BridgeHandlerError {
+            XCTAssertEqual(error.code, "MISSING_PARAM")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testSignThrowsWhenDataMissing() async {
+        let handler = CryptoHandler()
+
+        do {
+            _ = try await handler.handle(method: "sign", params: ["keyRef": "key1"])
+            XCTFail("Expected missingParam error")
+        } catch let error as BridgeHandlerError {
+            XCTAssertEqual(error.code, "MISSING_PARAM")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testUnknownMethodThrows() async {
+        let handler = CryptoHandler()
+
+        do {
+            _ = try await handler.handle(method: "deleteKey", params: nil)
+            XCTFail("Expected unknownMethod error")
+        } catch let error as BridgeHandlerError {
+            XCTAssertEqual(error.code, "UNKNOWN_METHOD")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+}

--- a/packages/native-shell-ios/Tests/SelfNativeShellTests/LifecycleHandlerRaceTests.swift
+++ b/packages/native-shell-ios/Tests/SelfNativeShellTests/LifecycleHandlerRaceTests.swift
@@ -1,11 +1,34 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+import UIKit
 import XCTest
 @testable import SelfNativeShell
 
-final class LifecycleHandlerRaceTests: XCTestCase {
+// MARK: - Mock UIViewController
 
-    // MARK: - setResult then dismiss
+private final class MockViewController: UIViewController {
+    var dismissCallCount = 0
+    private var pendingCompletions: [() -> Void] = []
+
+    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        dismissCallCount += 1
+        if let completion {
+            pendingCompletions.append(completion)
+        }
+    }
+
+    func simulateDismissCompletions() {
+        let completions = pendingCompletions
+        pendingCompletions = []
+        for completion in completions {
+            completion()
+        }
+    }
+}
+
+// MARK: - Tests (viewController: nil)
+
+final class LifecycleHandlerRaceTests: XCTestCase {
 
     func testSetResultThenDismissOnlyFiresResultCallback() async throws {
         var resultCalled = false
@@ -30,8 +53,6 @@ final class LifecycleHandlerRaceTests: XCTestCase {
         XCTAssertFalse(dismissCalled, "onDismiss should not fire after setResult already claimed")
     }
 
-    // MARK: - dismiss then setResult
-
     func testDismissThenSetResultOnlyFiresDismissCallback() async throws {
         var resultCalled = false
         var failureCalled = false
@@ -55,8 +76,6 @@ final class LifecycleHandlerRaceTests: XCTestCase {
         XCTAssertFalse(failureCalled, "onFailure should not fire")
     }
 
-    // MARK: - failure routing
-
     func testSetResultWithFailureRoutesToOnFailure() async throws {
         var resultCalled = false
         var failureCalled = false
@@ -76,8 +95,6 @@ final class LifecycleHandlerRaceTests: XCTestCase {
         XCTAssertFalse(resultCalled, "onResult should not fire for failure")
         XCTAssertTrue(failureCalled, "onFailure should fire for success=false")
     }
-
-    // MARK: - double setResult
 
     func testDoubleSetResultOnlyFiresOnce() async throws {
         var resultCallCount = 0
@@ -101,8 +118,6 @@ final class LifecycleHandlerRaceTests: XCTestCase {
         XCTAssertEqual(resultCallCount, 1, "onResult should fire exactly once")
     }
 
-    // MARK: - double dismiss
-
     func testDoubleDismissOnlyFiresOnce() async throws {
         var dismissCallCount = 0
 
@@ -117,5 +132,132 @@ final class LifecycleHandlerRaceTests: XCTestCase {
         _ = try await handler.handle(method: "dismiss", params: nil)
 
         XCTAssertEqual(dismissCallCount, 1, "onDismiss should fire exactly once")
+    }
+}
+
+// MARK: - Tests (viewController path)
+
+@MainActor
+final class LifecycleHandlerViewControllerRaceTests: XCTestCase {
+
+    func testSetResultThenDismissWithVC() async throws {
+        let vc = MockViewController()
+        var resultCalled = false
+        var dismissCalled = false
+
+        let handler = LifecycleHandler(
+            viewController: vc,
+            onResult: { _ in resultCalled = true },
+            onFailure: nil,
+            onDismiss: { dismissCalled = true }
+        )
+
+        _ = try await handler.handle(
+            method: "setResult",
+            params: ["result": ["success": true] as [String: Any]]
+        )
+
+        XCTAssertTrue(resultCalled, "onResult should fire from setResult")
+        XCTAssertEqual(vc.dismissCallCount, 1, "vc.dismiss should be called once by setResult")
+
+        // Second dismiss via bridge should still dismiss the VC but not fire onDismiss
+        _ = try await handler.handle(method: "dismiss", params: nil)
+
+        XCTAssertEqual(vc.dismissCallCount, 2, "vc.dismiss called again for the explicit dismiss")
+        XCTAssertFalse(dismissCalled, "onDismiss must not fire — setResult already claimed the gate")
+    }
+
+    func testDismissThenSetResultWithVC_gateClaimedBeforeCompletion() async throws {
+        let vc = MockViewController()
+        var resultCalled = false
+        var dismissCalled = false
+
+        let handler = LifecycleHandler(
+            viewController: vc,
+            onResult: { _ in resultCalled = true },
+            onFailure: nil,
+            onDismiss: { dismissCalled = true }
+        )
+
+        // dismiss claims the gate immediately, before vc.dismiss completion fires
+        _ = try await handler.handle(method: "dismiss", params: nil)
+
+        XCTAssertEqual(vc.dismissCallCount, 1)
+        XCTAssertFalse(dismissCalled, "onDismiss should not fire yet — waiting for completion")
+
+        // setResult arrives while vc.dismiss animation is in-flight
+        _ = try await handler.handle(
+            method: "setResult",
+            params: ["result": ["success": true] as [String: Any]]
+        )
+
+        XCTAssertFalse(resultCalled, "onResult must not fire — dismiss already claimed the gate")
+
+        // vc.dismiss completion fires
+        vc.simulateDismissCompletions()
+
+        XCTAssertTrue(dismissCalled, "onDismiss should fire from completion")
+        XCTAssertFalse(resultCalled, "onResult must still not have fired")
+    }
+
+    func testDismissWithVC_completionFiresOnDismiss() async throws {
+        let vc = MockViewController()
+        var dismissCalled = false
+
+        let handler = LifecycleHandler(
+            viewController: vc,
+            onResult: nil,
+            onFailure: nil,
+            onDismiss: { dismissCalled = true }
+        )
+
+        _ = try await handler.handle(method: "dismiss", params: nil)
+        XCTAssertFalse(dismissCalled, "onDismiss should not fire until vc.dismiss completes")
+
+        vc.simulateDismissCompletions()
+        XCTAssertTrue(dismissCalled, "onDismiss should fire from vc.dismiss completion")
+    }
+
+    func testDoubleDismissWithVC_onlyFiresOnce() async throws {
+        let vc = MockViewController()
+        var dismissCallCount = 0
+
+        let handler = LifecycleHandler(
+            viewController: vc,
+            onResult: nil,
+            onFailure: nil,
+            onDismiss: { dismissCallCount += 1 }
+        )
+
+        _ = try await handler.handle(method: "dismiss", params: nil)
+        _ = try await handler.handle(method: "dismiss", params: nil)
+
+        // Both calls dismiss the VC, but only the first claims the gate
+        XCTAssertEqual(vc.dismissCallCount, 2)
+
+        vc.simulateDismissCompletions()
+        XCTAssertEqual(dismissCallCount, 1, "onDismiss should fire exactly once")
+    }
+
+    func testFailureRoutingWithVC() async throws {
+        let vc = MockViewController()
+        var resultCalled = false
+        var failureCalled = false
+
+        let handler = LifecycleHandler(
+            viewController: vc,
+            onResult: { _ in resultCalled = true },
+            onFailure: { _ in failureCalled = true },
+            onDismiss: nil
+        )
+
+        _ = try await handler.handle(
+            method: "setResult",
+            params: ["result": ["success": false, "error": ["message": "denied"]] as [String: Any]]
+        )
+
+        XCTAssertFalse(resultCalled)
+        XCTAssertTrue(failureCalled, "onFailure should fire for success=false with VC present")
+        XCTAssertEqual(vc.dismissCallCount, 1, "vc.dismiss should be called after setResult")
     }
 }

--- a/packages/native-shell-ios/Tests/SelfNativeShellTests/LifecycleHandlerRaceTests.swift
+++ b/packages/native-shell-ios/Tests/SelfNativeShellTests/LifecycleHandlerRaceTests.swift
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import XCTest
+@testable import SelfNativeShell
+
+final class LifecycleHandlerRaceTests: XCTestCase {
+
+    // MARK: - setResult then dismiss
+
+    func testSetResultThenDismissOnlyFiresResultCallback() async throws {
+        var resultCalled = false
+        var failureCalled = false
+        var dismissCalled = false
+
+        let handler = LifecycleHandler(
+            viewController: nil,
+            onResult: { _ in resultCalled = true },
+            onFailure: { _ in failureCalled = true },
+            onDismiss: { dismissCalled = true }
+        )
+
+        _ = try await handler.handle(
+            method: "setResult",
+            params: ["result": ["success": true] as [String: Any]]
+        )
+        _ = try await handler.handle(method: "dismiss", params: nil)
+
+        XCTAssertTrue(resultCalled, "onResult should fire from setResult")
+        XCTAssertFalse(failureCalled, "onFailure should not fire for success")
+        XCTAssertFalse(dismissCalled, "onDismiss should not fire after setResult already claimed")
+    }
+
+    // MARK: - dismiss then setResult
+
+    func testDismissThenSetResultOnlyFiresDismissCallback() async throws {
+        var resultCalled = false
+        var failureCalled = false
+        var dismissCalled = false
+
+        let handler = LifecycleHandler(
+            viewController: nil,
+            onResult: { _ in resultCalled = true },
+            onFailure: { _ in failureCalled = true },
+            onDismiss: { dismissCalled = true }
+        )
+
+        _ = try await handler.handle(method: "dismiss", params: nil)
+        _ = try await handler.handle(
+            method: "setResult",
+            params: ["result": ["success": true] as [String: Any]]
+        )
+
+        XCTAssertTrue(dismissCalled, "onDismiss should fire from dismiss")
+        XCTAssertFalse(resultCalled, "onResult should not fire after dismiss already claimed")
+        XCTAssertFalse(failureCalled, "onFailure should not fire")
+    }
+
+    // MARK: - failure routing
+
+    func testSetResultWithFailureRoutesToOnFailure() async throws {
+        var resultCalled = false
+        var failureCalled = false
+
+        let handler = LifecycleHandler(
+            viewController: nil,
+            onResult: { _ in resultCalled = true },
+            onFailure: { _ in failureCalled = true },
+            onDismiss: nil
+        )
+
+        _ = try await handler.handle(
+            method: "setResult",
+            params: ["result": ["success": false, "error": ["message": "timeout"]] as [String: Any]]
+        )
+
+        XCTAssertFalse(resultCalled, "onResult should not fire for failure")
+        XCTAssertTrue(failureCalled, "onFailure should fire for success=false")
+    }
+
+    // MARK: - double setResult
+
+    func testDoubleSetResultOnlyFiresOnce() async throws {
+        var resultCallCount = 0
+
+        let handler = LifecycleHandler(
+            viewController: nil,
+            onResult: { _ in resultCallCount += 1 },
+            onFailure: nil,
+            onDismiss: nil
+        )
+
+        _ = try await handler.handle(
+            method: "setResult",
+            params: ["result": ["success": true] as [String: Any]]
+        )
+        _ = try await handler.handle(
+            method: "setResult",
+            params: ["result": ["success": true] as [String: Any]]
+        )
+
+        XCTAssertEqual(resultCallCount, 1, "onResult should fire exactly once")
+    }
+
+    // MARK: - double dismiss
+
+    func testDoubleDismissOnlyFiresOnce() async throws {
+        var dismissCallCount = 0
+
+        let handler = LifecycleHandler(
+            viewController: nil,
+            onResult: nil,
+            onFailure: nil,
+            onDismiss: { dismissCallCount += 1 }
+        )
+
+        _ = try await handler.handle(method: "dismiss", params: nil)
+        _ = try await handler.handle(method: "dismiss", params: nil)
+
+        XCTAssertEqual(dismissCallCount, 1, "onDismiss should fire exactly once")
+    }
+}

--- a/packages/native-shell-ios/Tests/SelfNativeShellTests/LifecycleHandlerTests.swift
+++ b/packages/native-shell-ios/Tests/SelfNativeShellTests/LifecycleHandlerTests.swift
@@ -34,6 +34,7 @@ final class LifecycleHandlerTests: XCTestCase {
         let handler = LifecycleHandler(
             viewController: viewController,
             onResult: { receivedResult = $0 },
+            onFailure: nil,
             onDismiss: { dismissCallCount += 1 }
         )
 
@@ -58,6 +59,7 @@ final class LifecycleHandlerTests: XCTestCase {
         let handler = LifecycleHandler(
             viewController: viewController,
             onResult: nil,
+            onFailure: nil,
             onDismiss: { dismissCallCount += 1 }
         )
 
@@ -76,6 +78,7 @@ final class LifecycleHandlerTests: XCTestCase {
         let handler = LifecycleHandler(
             viewController: nil,
             onResult: nil,
+            onFailure: nil,
             onDismiss: { dismissCallCount += 1 }
         )
 

--- a/packages/native-shell-ios/Tests/SelfNativeShellTests/LifecycleHandlerTests.swift
+++ b/packages/native-shell-ios/Tests/SelfNativeShellTests/LifecycleHandlerTests.swift
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import UIKit
+import XCTest
+@testable import SelfNativeShell
+
+private final class MockViewController: UIViewController {
+    var dismissCallCount = 0
+    private var pendingCompletions: [() -> Void] = []
+
+    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        dismissCallCount += 1
+        if let completion {
+            pendingCompletions.append(completion)
+        }
+    }
+
+    func simulateDismissCompletion() {
+        let completions = pendingCompletions
+        pendingCompletions = []
+        for completion in completions {
+            completion()
+        }
+    }
+}
+
+final class LifecycleHandlerTests: XCTestCase {
+
+    func testSetResultEmitsResultAndSuppressesDismissCallback() async throws {
+        let viewController = MockViewController()
+        var receivedResult: Any?
+        var dismissCallCount = 0
+
+        let handler = LifecycleHandler(
+            viewController: viewController,
+            onResult: { receivedResult = $0 },
+            onDismiss: { dismissCallCount += 1 }
+        )
+
+        _ = try await handler.handle(
+            method: "setResult",
+            params: ["success": true, "verificationId": "ver_123"]
+        )
+
+        XCTAssertEqual(viewController.dismissCallCount, 1)
+        let result = receivedResult as? [String: Any]
+        XCTAssertEqual(result?["success"] as? Bool, true)
+        XCTAssertEqual(result?["verificationId"] as? String, "ver_123")
+
+        viewController.simulateDismissCompletion()
+        XCTAssertEqual(dismissCallCount, 0)
+    }
+
+    func testDismissWithViewControllerWaitsForCompletionBeforeCallingOnDismiss() async throws {
+        let viewController = MockViewController()
+        var dismissCallCount = 0
+
+        let handler = LifecycleHandler(
+            viewController: viewController,
+            onResult: nil,
+            onDismiss: { dismissCallCount += 1 }
+        )
+
+        _ = try await handler.handle(method: "dismiss", params: nil)
+
+        XCTAssertEqual(viewController.dismissCallCount, 1)
+        XCTAssertEqual(dismissCallCount, 0)
+
+        viewController.simulateDismissCompletion()
+        XCTAssertEqual(dismissCallCount, 1)
+    }
+
+    func testDismissWithoutViewControllerCallsOnDismissImmediatelyOnce() async throws {
+        var dismissCallCount = 0
+
+        let handler = LifecycleHandler(
+            viewController: nil,
+            onResult: nil,
+            onDismiss: { dismissCallCount += 1 }
+        )
+
+        _ = try await handler.handle(method: "dismiss", params: nil)
+        _ = try await handler.handle(method: "dismiss", params: nil)
+
+        XCTAssertEqual(dismissCallCount, 1)
+    }
+}

--- a/packages/native-shell-ios/Tests/SelfNativeShellTests/LifecycleResultEnvelopeTests.swift
+++ b/packages/native-shell-ios/Tests/SelfNativeShellTests/LifecycleResultEnvelopeTests.swift
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import XCTest
+@testable import SelfNativeShell
+
+final class LifecycleResultEnvelopeTests: XCTestCase {
+
+    // MARK: - extractPayload
+
+    func testExtractPayloadUnwrapsNestedResult() {
+        let inner: [String: Any] = ["success": true, "data": "value"]
+        let params: [String: Any] = ["result": inner, "extra": "ignored"]
+
+        let payload = SelfLifecycleResultEnvelope.extractPayload(from: params)
+
+        XCTAssertNotNil(payload)
+        let dict = payload as? [String: Any]
+        XCTAssertEqual(dict?["success"] as? Bool, true)
+        XCTAssertEqual(dict?["data"] as? String, "value")
+    }
+
+    func testExtractPayloadFallsBackToParamsWhenResultMissing() {
+        let params: [String: Any] = ["success": false, "error": "oops"]
+
+        let payload = SelfLifecycleResultEnvelope.extractPayload(from: params)
+
+        let dict = payload as? [String: Any]
+        XCTAssertEqual(dict?["success"] as? Bool, false)
+        XCTAssertEqual(dict?["error"] as? String, "oops")
+    }
+
+    func testExtractPayloadReturnsNilForNilParams() {
+        let payload = SelfLifecycleResultEnvelope.extractPayload(from: nil)
+
+        XCTAssertNil(payload)
+    }
+
+    // MARK: - extractSuccess
+
+    func testExtractSuccessReturnsTrueWhenSuccessIsTrue() {
+        let payload: [String: Any] = ["success": true]
+
+        let result = SelfLifecycleResultEnvelope.extractSuccess(from: payload)
+
+        XCTAssertEqual(result, true)
+    }
+
+    func testExtractSuccessReturnsFalseWhenSuccessIsFalse() {
+        let payload: [String: Any] = ["success": false]
+
+        let result = SelfLifecycleResultEnvelope.extractSuccess(from: payload)
+
+        XCTAssertEqual(result, false)
+    }
+
+    func testExtractSuccessReturnsNilWhenSuccessMissing() {
+        let payload: [String: Any] = ["data": "value"]
+
+        let result = SelfLifecycleResultEnvelope.extractSuccess(from: payload)
+
+        XCTAssertNil(result)
+    }
+
+    func testExtractSuccessReturnsNilWhenSuccessIsNotBool() {
+        let payload: [String: Any] = ["success": "yes"]
+
+        let result = SelfLifecycleResultEnvelope.extractSuccess(from: payload)
+
+        XCTAssertNil(result)
+    }
+
+    func testExtractSuccessReturnsNilForNonDictPayload() {
+        let result = SelfLifecycleResultEnvelope.extractSuccess(from: "not-a-dict")
+
+        XCTAssertNil(result)
+    }
+
+    func testExtractSuccessReturnsNilForNilPayload() {
+        let result = SelfLifecycleResultEnvelope.extractSuccess(from: nil)
+
+        XCTAssertNil(result)
+    }
+
+    // MARK: - SelfLifecycleResultError
+
+    func testResultErrorExtractsNestedErrorMessage() {
+        let payload: [String: Any] = [
+            "success": false,
+            "error": ["code": "TIMEOUT", "message": "Request timed out"],
+        ]
+        let error = SelfLifecycleResultError(payload: payload)
+
+        XCTAssertEqual(error.localizedDescription, "Request timed out")
+    }
+
+    func testResultErrorFallsBackToDefaultMessage() {
+        let error = SelfLifecycleResultError(payload: nil)
+
+        XCTAssertEqual(error.localizedDescription, "Verification failed")
+    }
+
+    func testResultErrorFallsBackWhenPayloadHasNoErrorKey() {
+        let payload: [String: Any] = ["success": false]
+        let error = SelfLifecycleResultError(payload: payload)
+
+        XCTAssertEqual(error.localizedDescription, "Verification failed")
+    }
+}

--- a/packages/native-shell-ios/Tests/SelfNativeShellTests/MessageRouterTests.swift
+++ b/packages/native-shell-ios/Tests/SelfNativeShellTests/MessageRouterTests.swift
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import XCTest
+@testable import SelfNativeShell
+
+final class MessageRouterTests: XCTestCase {
+
+    private func makeRequestJSON(
+        domain: String = "secureStorage",
+        method: String = "get",
+        params: [String: Any]? = nil,
+        version: Int = 1,
+        id: String = "req-1"
+    ) -> String {
+        var dict: [String: Any] = [
+            "type": "request",
+            "version": version,
+            "id": id,
+            "domain": domain,
+            "method": method,
+            "timestamp": 1000.0
+        ]
+        if let params = params {
+            dict["params"] = params
+        }
+        let data = try! JSONSerialization.data(withJSONObject: dict)
+        return String(data: data, encoding: .utf8)!
+    }
+
+    // MARK: - Version validation
+
+    func testUnsupportedVersionSendsErrorResponse() {
+        let expectation = expectation(description: "response sent")
+        var sentJS: String?
+
+        let router = MessageRouter { js in
+            sentJS = js
+            expectation.fulfill()
+        }
+
+        router.onMessageReceived(rawJson: makeRequestJSON(version: 999))
+
+        waitForExpectations(timeout: 2)
+
+        XCTAssertNotNil(sentJS)
+        XCTAssertTrue(sentJS!.contains("UNSUPPORTED_VERSION"))
+    }
+
+    // MARK: - Domain lookup
+
+    func testUnknownDomainSendsErrorResponse() {
+        let expectation = expectation(description: "response sent")
+        var sentJS: String?
+
+        let router = MessageRouter { js in
+            sentJS = js
+            expectation.fulfill()
+        }
+
+        router.onMessageReceived(rawJson: makeRequestJSON(domain: "secureStorage"))
+
+        waitForExpectations(timeout: 2)
+
+        XCTAssertNotNil(sentJS)
+        XCTAssertTrue(sentJS!.contains("UNKNOWN_DOMAIN"))
+    }
+
+    // MARK: - Handler dispatch
+
+    func testSuccessfulHandlerCallSendsSuccessResponse() {
+        let expectation = expectation(description: "response sent")
+        var sentJS: String?
+
+        let router = MessageRouter { js in
+            sentJS = js
+            expectation.fulfill()
+        }
+        router.register(handler: StubHandler(domain: .secureStorage, result: ["value": "abc"]))
+
+        router.onMessageReceived(rawJson: makeRequestJSON())
+
+        waitForExpectations(timeout: 2)
+
+        XCTAssertNotNil(sentJS)
+        XCTAssertTrue(sentJS!.contains("_handleResponse"))
+        XCTAssertTrue(sentJS!.contains("\"success\":true") || sentJS!.contains("\"success\" : true"))
+    }
+
+    func testHandlerErrorSendsFailureResponse() {
+        let expectation = expectation(description: "response sent")
+        var sentJS: String?
+
+        let router = MessageRouter { js in
+            sentJS = js
+            expectation.fulfill()
+        }
+        router.register(handler: StubHandler(
+            domain: .secureStorage,
+            error: BridgeHandlerError.missingParam("key")
+        ))
+
+        router.onMessageReceived(rawJson: makeRequestJSON())
+
+        waitForExpectations(timeout: 2)
+
+        XCTAssertNotNil(sentJS)
+        XCTAssertTrue(sentJS!.contains("MISSING_PARAM"))
+    }
+
+    func testGenericErrorSendsHandlerErrorResponse() {
+        let expectation = expectation(description: "response sent")
+        var sentJS: String?
+
+        let router = MessageRouter { js in
+            sentJS = js
+            expectation.fulfill()
+        }
+        router.register(handler: StubHandler(
+            domain: .secureStorage,
+            error: NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "disk full"])
+        ))
+
+        router.onMessageReceived(rawJson: makeRequestJSON())
+
+        waitForExpectations(timeout: 2)
+
+        XCTAssertNotNil(sentJS)
+        XCTAssertTrue(sentJS!.contains("HANDLER_ERROR"))
+    }
+
+    // MARK: - Malformed input
+
+    func testMalformedJSONIsDropped() {
+        var sentCount = 0
+
+        let router = MessageRouter { _ in
+            sentCount += 1
+        }
+
+        router.onMessageReceived(rawJson: "{not valid json")
+
+        // Give async code a chance to run
+        let expectation = expectation(description: "wait")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 2)
+
+        XCTAssertEqual(sentCount, 0)
+    }
+
+    // MARK: - Registration
+
+    func testRegisterReplacesExistingHandler() {
+        let expectation = expectation(description: "response sent")
+        var sentJS: String?
+
+        let router = MessageRouter { js in
+            sentJS = js
+            expectation.fulfill()
+        }
+        router.register(handler: StubHandler(domain: .secureStorage, result: ["value": "first"]))
+        router.register(handler: StubHandler(domain: .secureStorage, result: ["value": "second"]))
+
+        router.onMessageReceived(rawJson: makeRequestJSON())
+
+        waitForExpectations(timeout: 2)
+
+        XCTAssertNotNil(sentJS)
+        XCTAssertTrue(sentJS!.contains("second"))
+        XCTAssertFalse(sentJS!.contains("first"))
+    }
+}
+
+// MARK: - Test doubles
+
+private final class StubHandler: BridgeHandler {
+    let domain: BridgeDomain
+    private let result: Any?
+    private let error: Error?
+
+    init(domain: BridgeDomain, result: Any? = nil, error: Error? = nil) {
+        self.domain = domain
+        self.result = result
+        self.error = error
+    }
+
+    func handle(method: String, params: [String: Any]?) async throws -> Any? {
+        if let error = error { throw error }
+        return result
+    }
+}

--- a/packages/native-shell-ios/Tests/SelfNativeShellTests/SecureStorageHandlerTests.swift
+++ b/packages/native-shell-ios/Tests/SelfNativeShellTests/SecureStorageHandlerTests.swift
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import Foundation
+import XCTest
+@testable import SelfNativeShell
+
+private final class MockSecureStorageProvider: SecureStorageProvider {
+    var values: [String: String] = [:]
+
+    func get(key: String) throws -> String? {
+        values[key]
+    }
+
+    func set(key: String, value: String) throws {
+        values[key] = value
+    }
+
+    func remove(key: String) throws {
+        values.removeValue(forKey: key)
+    }
+}
+
+final class SecureStorageHandlerTests: XCTestCase {
+
+    func testGetReturnsStoredValue() async throws {
+        let provider = MockSecureStorageProvider()
+        provider.values["token"] = "abc123"
+        let handler = SecureStorageHandler(provider: provider)
+
+        let result = try await handler.handle(method: "get", params: ["key": "token"]) as? [String: Any]
+
+        XCTAssertEqual(result?["value"] as? String, "abc123")
+    }
+
+    func testGetReturnsNullForMissingKey() async throws {
+        let handler = SecureStorageHandler(provider: MockSecureStorageProvider())
+
+        let result = try await handler.handle(method: "get", params: ["key": "missing"]) as? [String: Any]
+
+        XCTAssertTrue(result?["value"] is NSNull)
+    }
+
+    func testSetPersistsValue() async throws {
+        let provider = MockSecureStorageProvider()
+        let handler = SecureStorageHandler(provider: provider)
+
+        let result = try await handler.handle(
+            method: "set",
+            params: ["key": "token", "value": "abc123"]
+        )
+
+        XCTAssertNil(result)
+        XCTAssertEqual(provider.values["token"], "abc123")
+    }
+
+    func testRemoveDeletesValue() async throws {
+        let provider = MockSecureStorageProvider()
+        provider.values["token"] = "abc123"
+        let handler = SecureStorageHandler(provider: provider)
+
+        let result = try await handler.handle(method: "remove", params: ["key": "token"])
+
+        XCTAssertNil(result)
+        XCTAssertNil(provider.values["token"])
+    }
+
+    func testMissingValueThrowsBridgeHandlerError() async {
+        let handler = SecureStorageHandler(provider: MockSecureStorageProvider())
+
+        do {
+            _ = try await handler.handle(method: "set", params: ["key": "token"])
+            XCTFail("Expected missingParam error")
+        } catch let error as BridgeHandlerError {
+            XCTAssertEqual(error.code, "MISSING_PARAM")
+            XCTAssertEqual(error.errorDescription, "Missing parameter: value")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+}

--- a/packages/native-shell-ios/Tests/SelfNativeShellTests/SelfSdkConfigTests.swift
+++ b/packages/native-shell-ios/Tests/SelfNativeShellTests/SelfSdkConfigTests.swift
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import XCTest
+@testable import SelfNativeShell
+
+private final class MockSecureStorageProvider: SecureStorageProvider {
+    func get(key: String) throws -> String? { nil }
+    func set(key: String, value: String) throws {}
+    func remove(key: String) throws {}
+}
+
+final class SelfSdkConfigTests: XCTestCase {
+
+    func testToQueryParamsIncludesRequiredFields() {
+        let config = SelfSdkConfig(
+            verificationId: "ver-123",
+            userId: "user-456",
+            secureStorageProvider: MockSecureStorageProvider()
+        )
+
+        let query = config.toQueryParams()
+
+        XCTAssertTrue(query.contains("verificationId=ver-123"))
+        XCTAssertTrue(query.contains("userId=user-456"))
+        XCTAssertTrue(query.contains("environment=prod"))
+        XCTAssertTrue(query.contains("version=1"))
+    }
+
+    func testToQueryParamsIncludesOptionalFields() {
+        let config = SelfSdkConfig(
+            verificationId: "ver-1",
+            userId: "user-1",
+            scope: "identity",
+            disclosures: ["name", "dob"],
+            appName: "TestApp",
+            appEndpoint: "https://example.com",
+            resultType: "json",
+            excludedCountries: ["US", "GB"],
+            endpointType: "staging",
+            userIdType: "email",
+            chainID: 137,
+            userDefinedData: "custom",
+            selfDefinedData: "internal",
+            secureStorageProvider: MockSecureStorageProvider()
+        )
+
+        let query = config.toQueryParams()
+
+        XCTAssertTrue(query.contains("scope=identity"))
+        XCTAssertTrue(query.contains("disclosures=name,dob"))
+        XCTAssertTrue(query.contains("appName=TestApp"))
+        XCTAssertTrue(query.contains("resultType=json"))
+        XCTAssertTrue(query.contains("excludedCountries=US,GB"))
+        XCTAssertTrue(query.contains("endpointType=staging"))
+        XCTAssertTrue(query.contains("userIdType=email"))
+        XCTAssertTrue(query.contains("chainID=137"))
+        XCTAssertTrue(query.contains("userDefinedData=custom"))
+        XCTAssertTrue(query.contains("selfDefinedData=internal"))
+    }
+
+    func testToQueryParamsOmitsNilOptionals() {
+        let config = SelfSdkConfig(
+            verificationId: "ver-1",
+            userId: "user-1",
+            secureStorageProvider: MockSecureStorageProvider()
+        )
+
+        let query = config.toQueryParams()
+
+        XCTAssertFalse(query.contains("scope="))
+        XCTAssertFalse(query.contains("disclosures="))
+        XCTAssertFalse(query.contains("appName="))
+        XCTAssertFalse(query.contains("chainID="))
+    }
+
+    func testToQueryParamsEncodesSpecialCharacters() {
+        let config = SelfSdkConfig(
+            verificationId: "ver 123",
+            userId: "user+456",
+            secureStorageProvider: MockSecureStorageProvider()
+        )
+
+        let query = config.toQueryParams()
+
+        XCTAssertFalse(query.contains(" "))
+        XCTAssertTrue(query.contains("ver%20123") || query.contains("ver+123"))
+    }
+}


### PR DESCRIPTION
## Summary

- Add dedicated GitHub Actions workflow (`native-shells-ci.yml`) that runs Android unit tests and iOS package tests on PR/push, with path filters so it only triggers when native shell packages change.
- Add comprehensive unit test suites for both platforms covering bridge models, message routing, secure storage, lifecycle handling, and crypto handler param validation — 39 Android tests (all passing locally), ~34 iOS tests (blocked locally by Xcode plugin issue, validated via CI).
- Harden Android `LifecycleHandler` with `LifecycleResultGate` (at-most-once result delivery) and `LifecycleResultEnvelope` (nested `result` payload unwrapping). Corresponding iOS `LifecycleHandler` hardened with `SelfLifecycleResultEnvelope` and `SelfLifecycleResultError`, plus `onFailure` callback.
- Fix `build.gradle.kts` to include missing test dependencies (junit, coroutines-test, robolectric) and enable `unitTests.isReturnDefaultValues` + `isIncludeAndroidResources` for proper JVM test execution.

## Changes

### CI / Config

- New `.github/workflows/native-shells-ci.yml` — Android (`./gradlew testDebugUnitTest`) and iOS (`xcodebuild test`) jobs with path-based filtering and artifact upload
- `packages/native-shell-android/build.gradle.kts` — add test deps (junit, kotlin-test, coroutines-test, robolectric), enable `testOptions`
- `packages/native-shell-ios/Package.swift` — add `SelfNativeShellTests` test target

### Native Shells — Lifecycle Hardening

- `LifecycleHandler.kt` — introduce `LifecycleResultGate` for at-most-once result delivery, `LifecycleResultEnvelope` for nested payload extraction
- `LifecycleHandler.swift` — add `onFailure` callback, `SelfLifecycleResultEnvelope` for payload extraction, `SelfLifecycleResultError` for error wrapping, guard against double-emit
- `SelfSdk.swift` — wire `onFailure` callback, use strong callback reference

### Android Tests (new)

- `BridgeModelsTest.kt` — serialization roundtrips, domain enum values (7 tests)
- `MessageRouterTest.kt` — version validation, domain lookup, handler dispatch, error propagation, malformed JSON (8 tests)
- `MessageRouterEscapeTest.kt` — JS string escaping (2 tests)
- `SecureStorageHandlerTest.kt` — get/set/remove, missing param errors (6 tests)
- `LifecycleHandlerTest.kt` — Robolectric: dismiss, setResult success/failure (3 tests)
- `LifecycleResultGateTest.kt` — at-most-once claim semantics (6 tests)
- `LifecycleResultEnvelopeTest.kt` — payload extraction, success flag parsing (8 tests)
- `CryptoHandlerTest.kt` — domain constant (1 test, AndroidKeyStore unavailable in JVM)

### iOS Tests (new)

- `BridgeModelsTests.swift` — decoding, response factories, AnyCodable, error codes (14 tests)
- `MessageRouterTests.swift` — version, domain, dispatch, error propagation (6 tests)
- `CryptoHandlerTests.swift` — param validation, unknown method (5 tests)
- `SelfSdkConfigTests.swift` — query param encoding (4 tests)
- `LifecycleHandlerTests.swift` — setResult, dismiss, idempotency (3 tests)
- `LifecycleHandlerRaceTests.swift` — race condition scenarios
- `LifecycleResultEnvelopeTests.swift` — payload extraction
- `SecureStorageHandlerTests.swift` — get/set/remove, missing params (5 tests)

## Test Plan

- [x] `./gradlew testDebugUnitTest` passes (39 tests)
- [ ] iOS `xcodebuild test` passes in CI (blocked locally by Xcode plugin issue)
- [ ] `git diff --check` passes

### Native Consolidation Checklist

- [ ] CONTRACTS.md reviewed - no unintended contract changes
- [ ] Layer 1 bridge contract tests pass (`cd app && yarn jest:run` / `yarn workspace @selfxyz/rn-sdk-test-app test`)
- [ ] Layer 3 builds pass (app iOS, RN test app iOS, RN test app Android)
- [ ] Layer 4 manual smoke test signed off (if consolidation PR)
- [ ] No new native business logic added (logic belongs in TypeScript)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lifecycle result gating to ensure only the first result/dismissal is delivered.
  * Fixed iOS callback routing to reliably surface success, failure, and cancellation.

* **Tests**
  * Added extensive unit and integration tests for Android and iOS bridge, handlers, lifecycle, and serialization logic.

* **Chores**
  * Added CI workflow to run platform-specific native tests automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->