### PR TITLE
feat(native-shell-android): SD-01 — switch to hosted URL loading

### DIFF
--- a/packages/native-shell-android/build.gradle.kts
+++ b/packages/native-shell-android/build.gradle.kts
@@ -53,11 +53,15 @@ android {
     }
 }
 
+val webViewBundleDir = file("src/main/assets/self-wallet")
+val webViewBundleIndex = file("src/main/assets/self-wallet/index.html")
+
 tasks.register("validateWebViewBundle") {
+    onlyIf {
+        webViewBundleDir.exists()
+    }
     doLast {
-        val bundleDir = file("src/main/assets/self-wallet")
-        val indexFile = file("src/main/assets/self-wallet/index.html")
-        if (!bundleDir.exists() || !indexFile.exists()) {
+        if (!webViewBundleIndex.exists()) {
             throw GradleException(
                 "WebView bundle not found at src/main/assets/self-wallet/index.html. " +
                     "Run ./scripts/build-webview-bundle.sh from the repo root first.",
@@ -67,7 +71,9 @@ tasks.register("validateWebViewBundle") {
 }
 
 tasks.named("preBuild") {
-    dependsOn("validateWebViewBundle")
+    if (webViewBundleDir.exists()) {
+        dependsOn("validateWebViewBundle")
+    }
 }
 
 dependencies {

--- a/packages/native-shell-android/src/main/kotlin/xyz/self/sdk/api/SelfSdkConfig.kt
+++ b/packages/native-shell-android/src/main/kotlin/xyz/self/sdk/api/SelfSdkConfig.kt
@@ -19,7 +19,7 @@ data class SelfSdkConfig(
     val chainID: Int? = null,
     val userDefinedData: String? = null,
     val selfDefinedData: String? = null,
-    val remoteWebAppBaseUrl: String? = null,
+    val remoteWebAppBaseUrl: String? = DEFAULT_REMOTE_WEB_APP_BASE_URL,
     val remoteWebAppIntegritySha256: String? = null,
 )
 
@@ -34,3 +34,5 @@ interface SelfSdkCallback {
 
     fun onCancelled()
 }
+
+const val DEFAULT_REMOTE_WEB_APP_BASE_URL = "https://verify.self.xyz/v1/"

--- a/packages/native-shell-android/src/main/kotlin/xyz/self/sdk/webview/AndroidWebViewHost.kt
+++ b/packages/native-shell-android/src/main/kotlin/xyz/self/sdk/webview/AndroidWebViewHost.kt
@@ -22,6 +22,7 @@ import android.webkit.WebViewClient
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.webkit.WebViewAssetLoader
+import xyz.self.sdk.api.DEFAULT_REMOTE_WEB_APP_BASE_URL
 import xyz.self.sdk.bridge.MessageRouter
 import java.net.HttpURLConnection
 import java.net.URI
@@ -31,10 +32,11 @@ class AndroidWebViewHost(
     private val context: Context,
     private val router: MessageRouter,
     private val isDebugMode: Boolean = false,
-    private val remoteWebAppBaseUrl: String? = null,
+    private val remoteWebAppBaseUrl: String? = DEFAULT_REMOTE_WEB_APP_BASE_URL,
     private val remoteWebAppIntegritySha256: String? = null,
 ) {
     private lateinit var webView: WebView
+    private val bundledAssetsAvailable by lazy { hasBundledAssets() }
 
     @Volatile
     private var isDestroyed = false
@@ -112,10 +114,7 @@ class AndroidWebViewHost(
                             request: WebResourceRequest?,
                         ): Boolean {
                             val url = request?.url ?: return true
-                            if (isBundledOrigin(url)) return false
-                            if (isDebugMode && isDebugOrigin(url)) return false
-                            if (isAllowedRemoteOrigin(url.toString())) return false
-                            return true
+                            return !shouldAllowNavigation(url.toString())
                         }
 
                         override fun onReceivedSslError(
@@ -138,7 +137,8 @@ class AndroidWebViewHost(
                                 isBundledOrigin(originUri) ||
                                     (isDebugMode && isDebugOrigin(originUri)) ||
                                     isMatchingOrigin(originUri, "https", "verify.didit.me", 443) ||
-                                    isAllowedRemoteOrigin(originStr)
+                                    isAllowedRemoteOrigin(originStr) ||
+                                    isDefaultHostedOrigin(originStr)
                             if (!isTrusted) {
                                 request.deny()
                                 return
@@ -205,8 +205,7 @@ class AndroidWebViewHost(
                 if (isDebugMode) {
                     loadUrl(buildDebugUrl(queryParams))
                 } else {
-                    loadUrl(buildBundledUrl(queryParams))
-                    maybeLoadVerifiedRemoteContent(queryParams)
+                    loadContent(queryParams)
                 }
             }
         return webView
@@ -232,6 +231,27 @@ class AndroidWebViewHost(
 
     private fun buildRemoteUrl(queryParams: String): String? = RemoteNavigationPolicy.buildRemoteEntryUrl(remoteWebAppBaseUrl, queryParams)
 
+    internal fun resolveInitialContentUrl(
+        queryParams: String,
+        bundledFallbackAvailable: Boolean = bundledAssetsAvailable,
+    ): String? {
+        val remoteUrl = buildRemoteUrl(queryParams)
+        if (remoteUrl != null) return remoteUrl
+        if (bundledFallbackAvailable && remoteWebAppBaseUrl.isNullOrBlank()) {
+            return buildBundledUrl(queryParams)
+        }
+        return null
+    }
+
+    internal fun shouldAllowNavigation(url: String): Boolean {
+        val uri = Uri.parse(url)
+        if (isBundledOrigin(uri)) return true
+        if (isDebugMode && isDebugOrigin(uri)) return true
+        if (isAllowedRemoteOrigin(url)) return true
+        if (isDefaultHostedOrigin(url)) return true
+        return false
+    }
+
     private fun buildEntryUrl(
         baseUrl: String,
         queryParams: String,
@@ -240,9 +260,19 @@ class AndroidWebViewHost(
         return "$baseUrl/tunnel/tour/1$separator"
     }
 
-    private fun maybeLoadVerifiedRemoteContent(queryParams: String) {
-        val remoteUrl = buildRemoteUrl(queryParams) ?: return
-        val expectedSha256 = remoteWebAppIntegritySha256?.takeIf { it.isNotBlank() } ?: return
+    private fun loadContent(queryParams: String) {
+        val initialUrl = resolveInitialContentUrl(queryParams) ?: return
+        if (initialUrl.startsWith(BUNDLED_ORIGIN)) {
+            webView.loadUrl(initialUrl)
+            return
+        }
+        if (!maybeLoadVerifiedRemoteContent(initialUrl)) {
+            webView.loadUrl(initialUrl)
+        }
+    }
+
+    private fun maybeLoadVerifiedRemoteContent(remoteUrl: String): Boolean {
+        val expectedSha256 = remoteWebAppIntegritySha256?.takeIf { it.isNotBlank() } ?: return false
 
         Thread {
             val verifiedHtml = fetchAndVerifyRemoteEntry(remoteUrl, expectedSha256)
@@ -262,6 +292,7 @@ class AndroidWebViewHost(
                 }
             }
         }.start()
+        return true
     }
 
     private fun fetchAndVerifyRemoteEntry(
@@ -311,6 +342,16 @@ class AndroidWebViewHost(
         }
 
     private fun isAllowedRemoteOrigin(url: String): Boolean = RemoteNavigationPolicy.isAllowedRemoteOrigin(url, remoteWebAppBaseUrl)
+
+    private fun isDefaultHostedOrigin(url: String): Boolean =
+        RemoteNavigationPolicy.isAllowedRemoteOrigin(url, DEFAULT_REMOTE_WEB_APP_BASE_URL)
+
+    private fun hasBundledAssets(): Boolean =
+        try {
+            context.assets.open("self-wallet/index.html").use { true }
+        } catch (_: Exception) {
+            false
+        }
 
     private fun resolvePort(uri: Uri): Int = RemoteNavigationPolicy.resolvePort(URI(uri.toString()))
 

--- a/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/api/SelfSdkConfigTest.kt
+++ b/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/api/SelfSdkConfigTest.kt
@@ -19,6 +19,7 @@ class SelfSdkConfigTest {
         assertEquals("prod", config.environment)
         assertFalse(config.isDebugMode)
         assertEquals(1, config.version)
+        assertEquals("https://verify.self.xyz/v1/", config.remoteWebAppBaseUrl)
     }
 
     @Test

--- a/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/api/SelfSdkLaunchTest.kt
+++ b/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/api/SelfSdkLaunchTest.kt
@@ -122,6 +122,26 @@ class SelfSdkLaunchTest {
     }
 
     @Test
+    fun `launch forwards default hosted web app url`() {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val launchConfig =
+            SelfSdkLaunchConfig(
+                config = minimalConfig(),
+                secureStorageProvider = FakeStorageProvider(),
+            )
+
+        SelfSdk.launch(activity, launchConfig)
+
+        val shadow = shadowOf(activity)
+        val intent = shadow.nextStartedActivityForResult.intent
+
+        assertEquals(
+            "https://verify.self.xyz/v1/",
+            intent.getStringExtra(SelfVerificationActivity.EXTRA_REMOTE_WEB_APP_BASE_URL),
+        )
+    }
+
+    @Test
     fun `launch uses default request code`() {
         val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
         val launchConfig =

--- a/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/webview/AndroidWebViewHostTest.kt
+++ b/packages/native-shell-android/src/test/kotlin/xyz/self/sdk/webview/AndroidWebViewHostTest.kt
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+package xyz.self.sdk.webview
+
+import android.app.Activity
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import xyz.self.sdk.bridge.MessageRouter
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@RunWith(RobolectricTestRunner::class)
+class AndroidWebViewHostTest {
+    private val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+
+    @Test
+    fun `resolveInitialContentUrl prefers hosted url when configured`() {
+        val host =
+            AndroidWebViewHost(
+                context = activity,
+                router = MessageRouter(sendToWebView = {}),
+            )
+
+        assertEquals(
+            "https://verify.self.xyz/v1/tunnel/tour/1?foo=bar",
+            host.resolveInitialContentUrl(queryParams = "foo=bar", bundledFallbackAvailable = true),
+        )
+    }
+
+    @Test
+    fun `resolveInitialContentUrl falls back to bundled assets only when remote base url is blank`() {
+        val host =
+            AndroidWebViewHost(
+                context = activity,
+                router = MessageRouter(sendToWebView = {}),
+                remoteWebAppBaseUrl = "   ",
+            )
+
+        assertEquals(
+            "https://appassets.androidplatform.net/tunnel/tour/1?foo=bar",
+            host.resolveInitialContentUrl(queryParams = "foo=bar", bundledFallbackAvailable = true),
+        )
+        assertNull(host.resolveInitialContentUrl(queryParams = "foo=bar", bundledFallbackAvailable = false))
+    }
+
+    @Test
+    fun `shouldAllowNavigation permits default hosted origin`() {
+        val host =
+            AndroidWebViewHost(
+                context = activity,
+                router = MessageRouter(sendToWebView = {}),
+                remoteWebAppBaseUrl = "   ",
+            )
+
+        assertTrue(host.shouldAllowNavigation("https://verify.self.xyz/v1/tunnel/tour/1"))
+    }
+}


### PR DESCRIPTION
## Summary

Implements **SD-01** from [SELF-2471](https://linear.app/selfprotocol/issue/SELF-2471) — replace `WebViewAssetLoader` with hosted URL loading as the default path.

Native shell now loads `https://verify.self.xyz/v1/` by default instead of bundled assets (~34MB), eliminating bundle size from the SDK.

## Changes

- **`SelfSdkConfig.kt`** — Set default `remoteWebAppBaseUrl` to `https://verify.self.xyz/v1/`
- **`AndroidWebViewHost.kt`** — Hosted URL is now the primary loading path; bundled assets kept only as fallback when remote URL is blank/null; `verify.self.xyz` explicitly allowed in navigation policy
- **`build.gradle.kts`** — `validateWebViewBundle` task made conditional (only runs if assets directory exists)
- **Tests** — Added/updated tests for default URL config and hosted loading behavior

## How it works

1. `loadContent()` resolves the initial URL from `remoteWebAppBaseUrl` (default: hosted)
2. If integrity hash is set → verified remote content loading (existing `RemoteContentIntegrity`)
3. If no integrity hash → direct `webView.loadUrl()` to hosted URL
4. Fallback to bundled assets only when remote URL is blank/null and assets exist

## What's unchanged

- Bridge protocol v1
- Debug mode (localhost:5173)
- All bridge handlers (SecureStorage, Crypto, Lifecycle)
- RemoteNavigationPolicy / RemoteContentIntegrity

## Ref

SELF-2471 (SD-01) — part of SELF-2469 (SDK Distribution)