### PR TITLE
feat(native-shell-ios): SD-02 — switch to hosted URL loading

### DIFF
--- a/packages/native-shell-ios/Package.swift
+++ b/packages/native-shell-ios/Package.swift
@@ -18,10 +18,11 @@ let package = Package(
         .target(
             name: "SelfNativeShell",
             path: ".",
-            sources: ["Sources/SelfNativeShell"],
-            resources: [
-                .copy("Resources/self-sdk-web")
-            ]
+            exclude: [
+                "Resources",
+                "Tests"
+            ],
+            sources: ["Sources/SelfNativeShell"]
         ),
         .testTarget(
             name: "SelfNativeShellTests",

--- a/packages/native-shell-ios/Sources/SelfNativeShell/API/SelfSdkConfig.swift
+++ b/packages/native-shell-ios/Sources/SelfNativeShell/API/SelfSdkConfig.swift
@@ -40,7 +40,7 @@ public struct SelfSdkConfig {
         chainID: Int? = nil,
         userDefinedData: String? = nil,
         selfDefinedData: String? = nil,
-        remoteWebAppBaseURL: URL? = nil,
+        remoteWebAppBaseURL: URL? = URL(string: "https://verify.self.xyz/v1/"),
         remoteWebAppIntegritySha256: String? = nil,
         secureStorageProvider: SecureStorageProvider
     ) {

--- a/packages/native-shell-ios/Sources/SelfNativeShell/WebView/SelfWebViewHost.swift
+++ b/packages/native-shell-ios/Sources/SelfNativeShell/WebView/SelfWebViewHost.swift
@@ -207,7 +207,7 @@ extension SelfWebViewHost: WKScriptMessageHandler {
 private final class SelfBundledAssetSchemeHandler: NSObject, WKURLSchemeHandler {
     func webView(_ webView: WKWebView, start urlSchemeTask: WKURLSchemeTask) {
         guard let requestURL = urlSchemeTask.request.url,
-              let rootURL = Bundle.module.resourceURL?.appendingPathComponent(
+              let rootURL = Bundle.main.resourceURL?.appendingPathComponent(
                 SelfWebViewHost.bundledRootFolder,
                 isDirectory: true
               ),

--- a/packages/native-shell-ios/Sources/SelfNativeShell/WebView/SelfWebViewHost.swift
+++ b/packages/native-shell-ios/Sources/SelfNativeShell/WebView/SelfWebViewHost.swift
@@ -65,11 +65,14 @@ final class SelfWebViewHost: NSObject {
             return
         }
 
+        if remoteWebAppBaseURL != nil {
+            loadVerifiedRemoteContent(queryParams: queryParams)
+            return
+        }
+
         if let bundledURL = makeBundledEntryURL(queryParams: queryParams) {
             webView.load(URLRequest(url: bundledURL))
         }
-
-        loadVerifiedRemoteContent(queryParams: queryParams)
     }
 
     func evaluateJs(_ js: String) {
@@ -89,9 +92,13 @@ final class SelfWebViewHost: NSObject {
         guard let baseURL = remoteWebAppBaseURL,
               baseURL.scheme == "https",
               baseURL.host != nil,
-              let expectedSha256 = remoteWebAppIntegritySha256?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !expectedSha256.isEmpty,
               let remoteURL = RemoteNavigationPolicy.makeEntryURL(baseURL: baseURL, queryParams: queryParams) else {
+            return
+        }
+
+        guard let expectedSha256 = remoteWebAppIntegritySha256?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !expectedSha256.isEmpty else {
+            webView?.load(URLRequest(url: remoteURL))
             return
         }
 

--- a/packages/native-shell-ios/Tests/SelfNativeShellTests/RemoteNavigationPolicyTests.swift
+++ b/packages/native-shell-ios/Tests/SelfNativeShellTests/RemoteNavigationPolicyTests.swift
@@ -36,6 +36,16 @@ final class RemoteNavigationPolicyTests: XCTestCase {
         )
     }
 
+    func testMainFrameAllowsBundledFallbackWhenRemoteBaseURLIsNil() {
+        XCTAssertTrue(
+            RemoteNavigationPolicy.isAllowedMainFrameNavigation(
+                url: URL(string: "self-sdk://app/tunnel/tour/1")!,
+                remoteWebAppBaseURL: nil,
+                isDebugMode: false
+            )
+        )
+    }
+
     func testMainFrameRejectsDifferentRemotePort() {
         XCTAssertFalse(
             RemoteNavigationPolicy.isAllowedMainFrameNavigation(
@@ -80,6 +90,16 @@ final class RemoteNavigationPolicyTests: XCTestCase {
                 queryParams: "foo=bar"
             )?.absoluteString,
             "https://verify.self.xyz/tunnel/tour/1?foo=bar"
+        )
+    }
+
+    func testMakeEntryURLPreservesHostedBasePath() {
+        XCTAssertEqual(
+            RemoteNavigationPolicy.makeEntryURL(
+                baseURL: URL(string: "https://verify.self.xyz/v1/"),
+                queryParams: "foo=bar"
+            )?.absoluteString,
+            "https://verify.self.xyz/v1/tunnel/tour/1?foo=bar"
         )
     }
 }

--- a/packages/native-shell-ios/Tests/SelfNativeShellTests/SelfSdkConfigTests.swift
+++ b/packages/native-shell-ios/Tests/SelfNativeShellTests/SelfSdkConfigTests.swift
@@ -22,6 +22,7 @@ final class SelfSdkConfigTests: XCTestCase {
         XCTAssertEqual(config.environment, "prod")
         XCTAssertEqual(config.isDebugMode, false)
         XCTAssertEqual(config.version, 1)
+        XCTAssertEqual(config.remoteWebAppBaseURL?.absoluteString, "https://verify.self.xyz/v1/")
         XCTAssertTrue(config.secureStorageProvider as AnyObject === provider)
     }
 


### PR DESCRIPTION
## Summary

Implements **SD-02** from [SELF-2472](https://linear.app/selfprotocol/issue/SELF-2472) — replace bundled asset loading with hosted URL loading as the default path.

Native shell now loads `https://verify.self.xyz/v1/` by default instead of bundled assets (~34MB), eliminating bundle size from the Swift Package.

## Changes

- **`SelfSdkConfig.swift`** — Set default `remoteWebAppBaseURL` to `https://verify.self.xyz/v1/`
- **`SelfWebViewHost.swift`** — Hosted URL is now the primary loading path; bundled assets kept only as fallback when `remoteWebAppBaseURL` is nil; direct URL request when no integrity hash set, verified load when integrity is present
- **`Package.swift`** — Removed `.copy("Resources/self-sdk-web")` resource copy; excluded `Resources`/`Tests` from target to avoid stale pickup warnings
- **Tests** — Updated `SelfSdkConfigTests` and `RemoteNavigationPolicyTests` for default hosted URL behavior

## How it works

1. `loadContent()` checks debug mode first (unchanged)
2. If `remoteWebAppBaseURL` is set (default: `https://verify.self.xyz/v1/`):
   - With integrity hash → verified remote content loading (`loadVerifiedRemoteContent`)
   - Without integrity hash → direct `webView.load(URLRequest(url:))` to hosted URL
3. Fallback to bundled asset scheme only when `remoteWebAppBaseURL` is nil

## What's unchanged

- Bridge protocol v1
- Debug mode (localhost:5173)
- All bridge handlers (Lifecycle, SecureStorage, Crypto)
- RemoteNavigationPolicy / RemoteContentIntegrity

## Ref

SELF-2472 (SD-02) — part of SELF-2469 (SDK Distribution)