### PR TITLE
feat(native-shell-android): SD-04 — add Maven publishing

### DIFF
--- a/.github/workflows/publish-android-sdk.yml
+++ b/.github/workflows/publish-android-sdk.yml
@@ -1,0 +1,43 @@
+name: Publish Android SDK
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 0.1.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Publish to GitHub Packages
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/native-shell-android
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - uses: ./.github/actions/cache-gradle
+
+      - name: Set version
+        run: |
+          sed -i "s/version = \".*\"/version = \"${{ inputs.version }}\"/" build.gradle.kts
+
+      - name: Build
+        run: ./gradlew build
+
+      - name: Publish
+        run: ./gradlew publishReleasePublicationToGitHubPackagesRepository
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-android-sdk.yml
+++ b/.github/workflows/publish-android-sdk.yml
@@ -1,8 +1,6 @@
 name: Publish Android SDK
 
 on:
-  push:
-    branches: [self-2473/sd-04-android-maven]
   workflow_dispatch:
     inputs:
       version:
@@ -38,18 +36,17 @@ jobs:
 
       - name: Set version
         run: |
-          VERSION="${{ inputs.version || '0.1.0-test' }}"
-          sed -i "s/version = \".*\"/version = \"$VERSION\"/" build.gradle.kts
+          sed -i "s/version = \".*\"/version = \"${{ inputs.version }}\"/" build.gradle.kts
 
       - name: Build
         run: ./gradlew build
 
       - name: Publish to Maven Local (dry run)
-        if: inputs.dry-run != 'false'
+        if: inputs.dry-run
         run: ./gradlew publishToMavenLocal
 
       - name: Publish to GitHub Packages
-        if: inputs.dry-run == 'false'
+        if: ${{ !inputs.dry-run }}
         run: ./gradlew publishReleasePublicationToGitHubPackagesRepository
         env:
           GITHUB_ACTOR: ${{ github.actor }}

--- a/.github/workflows/publish-android-sdk.yml
+++ b/.github/workflows/publish-android-sdk.yml
@@ -1,6 +1,8 @@
 name: Publish Android SDK
 
 on:
+  push:
+    branches: [self-2473/sd-04-android-maven]
   workflow_dispatch:
     inputs:
       version:
@@ -36,17 +38,18 @@ jobs:
 
       - name: Set version
         run: |
-          sed -i "s/version = \".*\"/version = \"${{ inputs.version }}\"/" build.gradle.kts
+          VERSION="${{ inputs.version || '0.1.0-test' }}"
+          sed -i "s/version = \".*\"/version = \"$VERSION\"/" build.gradle.kts
 
       - name: Build
         run: ./gradlew build
 
       - name: Publish to Maven Local (dry run)
-        if: inputs.dry-run
+        if: inputs.dry-run != 'false'
         run: ./gradlew publishToMavenLocal
 
       - name: Publish to GitHub Packages
-        if: ${{ !inputs.dry-run }}
+        if: inputs.dry-run == 'false'
         run: ./gradlew publishReleasePublicationToGitHubPackagesRepository
         env:
           GITHUB_ACTOR: ${{ github.actor }}

--- a/.github/workflows/publish-android-sdk.yml
+++ b/.github/workflows/publish-android-sdk.yml
@@ -7,6 +7,11 @@ on:
         description: 'Version to publish (e.g., 0.1.0)'
         required: true
         type: string
+      dry-run:
+        description: 'Dry run — build and validate without publishing'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -36,7 +41,12 @@ jobs:
       - name: Build
         run: ./gradlew build
 
-      - name: Publish
+      - name: Publish to Maven Local (dry run)
+        if: inputs.dry-run
+        run: ./gradlew publishToMavenLocal
+
+      - name: Publish to GitHub Packages
+        if: ${{ !inputs.dry-run }}
         run: ./gradlew publishReleasePublicationToGitHubPackagesRepository
         env:
           GITHUB_ACTOR: ${{ github.actor }}

--- a/packages/native-shell-android/build.gradle.kts
+++ b/packages/native-shell-android/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("org.jetbrains.kotlin.android") version "1.9.22"
     id("org.jetbrains.kotlin.plugin.serialization") version "1.9.22"
     id("org.jlleitschuh.gradle.ktlint") version "12.1.2"
+    `maven-publish`
 }
 
 ktlint {
@@ -73,6 +74,19 @@ tasks.register("validateWebViewBundle") {
 tasks.named("preBuild") {
     if (webViewBundleDir.exists()) {
         dependsOn("validateWebViewBundle")
+    }
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            create<MavenPublication>("release") {
+                from(components["release"])
+                groupId = "xyz.self.sdk"
+                artifactId = "native-shell-android"
+                version = "0.1.0"
+            }
+        }
     }
 }
 

--- a/packages/native-shell-android/build.gradle.kts
+++ b/packages/native-shell-android/build.gradle.kts
@@ -87,6 +87,16 @@ afterEvaluate {
                 version = "0.1.0"
             }
         }
+        repositories {
+            maven {
+                name = "GitHubPackages"
+                url = uri("https://maven.pkg.github.com/selfxyz/self")
+                credentials {
+                    username = System.getenv("GITHUB_ACTOR") ?: project.findProperty("gpr.user") as String? ?: ""
+                    password = System.getenv("GITHUB_TOKEN") ?: project.findProperty("gpr.token") as String? ?: ""
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Implements **SD-04** from <a href="https://linear.app/selfprotocol/issue/SELF-2473">SELF-2473</a> — add Maven publishing so integrators can add the native shell as a Gradle dependency.

- **`build.gradle.kts`** — Added `maven-publish` plugin and `publishing` block with `groupId=xyz.self.sdk`, `artifactId=native-shell-android`, `version=0.1.0`; added GitHub Packages repository with credentials resolved from `GITHUB_ACTOR`/`GITHUB_TOKEN` env vars or `gpr.user`/`gpr.token` project properties
- **`.github/workflows/publish-android-sdk.yml`** — New manual-dispatch workflow (`workflow_dispatch`) with a `version` string input and a `dry-run` boolean (default `true`); dry-run publishes to Maven Local for validation, non-dry-run publishes the release AAR to GitHub Packages

## Test plan

- `./gradlew publishToMavenLocal` ✅ BUILD SUCCESSFUL
- GitHub Actions dry-run publish workflow ✅ completed successfully
- POM includes correct runtime dependencies (appcompat, webkit, kotlinx-serialization-json, kotlinx-coroutines-android) ✅

## Usage

```kotlin
// settings.gradle.kts
dependencyResolutionManagement {
    repositories {
        maven {
            url = uri("https://maven.pkg.github.com/selfxyz/self")
            credentials {
                username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("GITHUB_ACTOR")
                password = providers.gradleProperty("gpr.token").orNull ?: System.getenv("GITHUB_TOKEN")
            }
        }
    }
}

// build.gradle.kts
dependencies {
    implementation("xyz.self.sdk:native-shell-android:0.1.0")
}
```

---

### Native Consolidation Checklist

- [ ] CONTRACTS.md reviewed - no unintended contract changes
- [ ] Layer 1 bridge contract tests pass (`cd app && yarn jest:run` / `yarn workspace @selfxyz/rn-sdk-test-app test`)
- [ ] Layer 3 builds pass (app iOS, RN test app iOS, RN test app Android)
- [ ] Layer 4 manual smoke test signed off (if consolidation PR)
- [ ] No new native business logic added (logic belongs in TypeScript)