### PR TITLE
feat(native-shell-ios): SD-05 — add CocoaPods support and verify SPM

### DIFF
--- a/packages/native-shell-android/README.md
+++ b/packages/native-shell-android/README.md
@@ -1,0 +1,42 @@
+# SelfSDK — Android Native Shell
+
+## Installation
+
+Add the GitHub Packages repository and dependency to your project:
+
+```kotlin
+// settings.gradle.kts
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+        maven {
+            url = uri("https://maven.pkg.github.com/selfxyz/self")
+            credentials {
+                username = project.findProperty("gpr.user") as String?
+                password = project.findProperty("gpr.token") as String?
+            }
+        }
+    }
+}
+
+// app/build.gradle.kts
+dependencies {
+    implementation("xyz.self.sdk:native-shell-android:0.1.0")
+}
+```
+
+Add your GitHub credentials to `~/.gradle/gradle.properties`:
+
+```properties
+gpr.user=YOUR_GITHUB_USERNAME
+gpr.token=YOUR_GITHUB_TOKEN
+```
+
+The token needs `read:packages` scope. Generate one at https://github.com/settings/tokens.
+
+## Requirements
+
+- Android API 24+ (minSdk)
+- Java 17
+- Kotlin 1.9+

--- a/packages/native-shell-ios/.gitignore
+++ b/packages/native-shell-ios/.gitignore
@@ -1,0 +1,6 @@
+.build/
+.swiftpm/
+Pods/
+*.xcodeproj/
+*.xcworkspace/
+DerivedData/

--- a/packages/native-shell-ios/README.md
+++ b/packages/native-shell-ios/README.md
@@ -1,0 +1,41 @@
+# SelfSDK — iOS Native Shell
+
+## Installation
+
+### Swift Package Manager
+
+In Xcode: **File → Add Package Dependencies**, enter:
+
+```
+https://github.com/selfxyz/self.git
+```
+
+Set the version rule (e.g. "Up to Next Major" from `0.1.0`).
+
+Or add to your `Package.swift`:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/selfxyz/self.git", from: "0.1.0")
+]
+```
+
+### CocoaPods
+
+Add to your `Podfile`:
+
+```ruby
+pod 'SelfSDK', :git => 'https://github.com/selfxyz/self.git', :tag => '0.1.0'
+```
+
+Then run:
+
+```bash
+pod install
+```
+
+## Requirements
+
+- iOS 15.0+
+- Swift 5.9+
+- Xcode 15+

--- a/packages/native-shell-ios/SelfSDK.podspec
+++ b/packages/native-shell-ios/SelfSDK.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name = 'SelfSDK'
+  s.version = '0.1.0'
+  s.summary = 'iOS native shell for hosting the Self SDK web experience.'
+  s.homepage = 'https://github.com/selfxyz/self'
+  s.license = { :type => 'BUSL-1.1', :file => 'LICENSE' }
+  s.author = { 'Self' => 'support@self.xyz' }
+  s.source = { :git => 'https://github.com/selfxyz/self.git', :tag => s.version.to_s }
+
+  s.ios.deployment_target = '15.0'
+  s.swift_version = '5.9'
+
+  s.source_files = 'Sources/SelfNativeShell/**/*.swift'
+  s.frameworks = 'UIKit', 'WebKit', 'CryptoKit'
+end


### PR DESCRIPTION
## Summary

Implements **SD-05** from [SELF-2474](https://linear.app/selfprotocol/issue/SELF-2474) — verify SPM distribution is clean after SD-02 and add CocoaPods support.

## Changes

- **`SelfSDK.podspec`** (new) — CocoaPods spec with `s.name='SelfSDK'`, iOS 15.0+, Swift 5.9, source files pointing to `Sources/SelfNativeShell/**/*.swift`, frameworks: UIKit, WebKit, CryptoKit. No resource bundles (web assets are hosted).
- **`.gitignore`** (new) — Excludes `.build/`, `.swiftpm/`, `Pods/`, `*.xcodeproj/`, `*.xcworkspace/`, `DerivedData/`
- **`Package.swift`** — Verified clean: no resource copy rules, no stale paths (unchanged from SD-02)

## Verified locally

- `xcodebuild build -scheme SelfNativeShell -destination 'generic/platform=iOS Simulator'` ✅ BUILD SUCCEEDED
- `pod lib lint` — skipped (`pod` not installed locally, CI will verify)

## Usage

**SPM:**
```swift
.package(url: "https://github.com/selfxyz/self.git", from: "0.1.0")
```

**CocoaPods:**
```ruby
pod 'SelfSDK', '~> 0.1.0'
```

## Ref

SELF-2474 (SD-05) — part of SELF-2469 (SDK Distribution)