### PR TITLE
Fix: Navigating to account recovery

### DIFF
--- a/packages/webview-app/src/screens/tunnel/TunnelProvingScreen.tsx
+++ b/packages/webview-app/src/screens/tunnel/TunnelProvingScreen.tsx
@@ -104,19 +104,11 @@ export const TunnelProvingScreen: React.FC = () => {
         state: currentState,
       });
       navigateToError(reason ?? errorCode ?? currentState);
-    } else if (currentState === 'completed' && phase === 'dsc') {
-      setPhase('register');
-      analytics.trackEvent('tunnel_proving_registration_complete', { previousPhase: 'dsc' });
-      void Promise.resolve(init(client, 'register', true)).catch(err => {
-        const message = err instanceof Error ? err.message : 'Register init failed';
-        analytics.trackEvent('tunnel_proving_init_failed', { error: message, phase: 'register' });
-        navigateToError(message);
-      });
-    } else if (currentState === 'completed' && phase === 'register') {
-      analytics.trackEvent('tunnel_proving_registration_complete', { previousPhase: 'register' });
+    } else if (currentState === 'completed') {
+      analytics.trackEvent('tunnel_proving_registration_complete', { previousPhase: phase });
       navigate('/tunnel/proof/disclose', { replace: true });
     }
-  }, [currentState, initDone, phase, client, init, analytics, haptic, navigate, errorCode, reason, navigateToError]);
+  }, [currentState, initDone, phase, analytics, haptic, navigate, errorCode, reason, navigateToError]);
 
   return (
     <ProofGenerationScreen

--- a/packages/webview-app/src/screens/tunnel/TunnelProvingScreen.tsx
+++ b/packages/webview-app/src/screens/tunnel/TunnelProvingScreen.tsx
@@ -106,7 +106,9 @@ export const TunnelProvingScreen: React.FC = () => {
       navigateToError(reason ?? errorCode ?? currentState);
     } else if (currentState === 'completed') {
       analytics.trackEvent('tunnel_proving_registration_complete', { previousPhase: phase });
-      navigate('/tunnel/proof/disclose', { replace: true });
+      // Brief delay to allow tree reader to index the on-chain commitment
+      // before disclose fetches the identity tree.
+      setTimeout(() => navigate('/tunnel/proof/disclose', { replace: true }), 5000);
     }
   }, [currentState, initDone, phase, analytics, haptic, navigate, errorCode, reason, navigateToError]);
 


### PR DESCRIPTION
## Summary

<!-- Brief description of changes -->
Fixes - wrongly navigating to `Recovery required` screen in mock passport flow.
- Remove manual dsc to register chaining in mock document flow of the webview-app.
- Adds a delay before navigating to /disclose to allow the tree reader to index the onchain event.

## Test plan

<!-- How was this tested? -->

---

### Native Consolidation Checklist

<!-- Check items that apply to this PR. Delete section if not touching native code. -->

- [ ] CONTRACTS.md reviewed - no unintended contract changes
- [ ] Layer 1 bridge contract tests pass (`cd app && yarn jest:run` / `yarn workspace @selfxyz/rn-sdk-test-app test`)
- [ ] Layer 3 builds pass (app iOS, RN test app iOS, RN test app Android)
- [ ] Layer 4 manual smoke test signed off (if consolidation PR)
- [ ] No new native business logic added (logic belongs in TypeScript)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined tunnel registration completion flow by removing redundant intermediate steps.
  * Added 5-second delay before navigating to proof disclosure screen.
  * Enhanced analytics event tracking for registration completion milestones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->