### PR TITLE
Pin react-native-webview to 13.16.0 to address iOS e2e failure

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -78,12 +78,12 @@
   "resolutions": {
     "punycode": "npm:punycode.js@2.3.1",
     "react-native-blur-effect": "1.1.3",
-    "react-native-webview": "13.16.1"
+    "react-native-webview": "13.16.0"
   },
   "overrides": {
     "punycode": "npm:punycode.js@2.3.1",
     "react-native-blur-effect": "1.1.3",
-    "react-native-webview": "13.16.1"
+    "react-native-webview": "13.16.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.29.2",
@@ -169,7 +169,7 @@
     "react-native-svg-web": "1.0.9",
     "react-native-url-polyfill": "^3.0.0",
     "react-native-web": "^0.21.2",
-    "react-native-webview": "^13.16.1",
+    "react-native-webview": "13.16.0",
     "react-qr-barcode-scanner": "^2.1.25",
     "socket.io-client": "^4.8.3",
     "tamagui": "1.126.14",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-native-passkey": "^3.3.3",
-    "react-native-webview": "13.16.1"
+    "react-native-webview": "13.16.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.28.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11293,7 +11293,7 @@ __metadata:
     react-native-svg-web: "npm:1.0.9"
     react-native-url-polyfill: "npm:^3.0.0"
     react-native-web: "npm:^0.21.2"
-    react-native-webview: "npm:^13.16.1"
+    react-native-webview: "npm:13.16.0"
     react-qr-barcode-scanner: "npm:^2.1.25"
     react-test-renderer: "npm:^18.3.1"
     rollup-plugin-visualizer: "npm:^6.0.5"
@@ -34667,16 +34667,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-webview@npm:13.16.1":
-  version: 13.16.1
-  resolution: "react-native-webview@npm:13.16.1"
+"react-native-webview@npm:13.16.0":
+  version: 13.16.0
+  resolution: "react-native-webview@npm:13.16.0"
   dependencies:
     escape-string-regexp: "npm:^4.0.0"
     invariant: "npm:2.2.4"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10c0/8fdf14447bc430100d78030b8fdb60df223bd51cdb25c06d58757962fea8ad0cd9cdb13a7aa40ff795c671d2b04a561cbeb2b5795d95780d7f0d3734573ebeeb
+  checksum: 10c0/813c3cb176effd65f8d9b45eb00732ac87bfab2d0b1c4016f0d43e95f9a287e495913540ebe4f47da868c804f6fdcb2246a2156d6e31712bd426b43bcecc8e7f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Motivation
- The iOS E2E job failed after a dependency bump to `react-native-webview@13.16.1`, so a minimal rollback to the previously-known-good `13.16.0` is needed to restore CI stability.
- Keep the change small and focused to avoid introducing unrelated upgrade risk to the mobile workspace.

### Description
- Reverted `react-native-webview` to `13.16.0` in `app/package.json` and aligned the root `package.json` resolution to `13.16.0` so workspace resolution is consistent.
- Updated `resolutions` and `overrides` entries to `13.16.0` in the mobile app workspace to ensure Yarn picks the pinned version.
- Regenerated `yarn.lock` so the repository lockfile resolves `react-native-webview@13.16.0` consistently across the monorepo.
- Change is intentionally scoped to dependency pins only and does not modify source code or tests.

### Testing
- Ran `yarn install` successfully to refresh dependency resolution and produce the updated `yarn.lock`.
- Ran `yarn workspace @selfxyz/mobile-app types` and the type check completed without errors.
- Ran `yarn workspace @selfxyz/mobile-app lint` and linting completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d603a08b44832da352ec7a8427bd17)