### PR TITLE
Rename KYC references to be platform agnostic

### DIFF
--- a/.claude/skills/spec-from-audit/SKILL.md
+++ b/.claude/skills/spec-from-audit/SKILL.md
@@ -101,7 +101,7 @@ Follow these strictly:
 
 1. **Decisions, not options** — "Use local wrappers" not "Consider adding to Euclid or using local wrappers." Every ambiguous implementation choice must be resolved in the spec. If you genuinely can't decide, flag it as a blocker and ask the user — don't embed it as an option.
 2. **Second person** — "You are fixing...", "You will modify..."
-3. **Exact file paths with line numbers** — `src/utils/sumsubProvider.ts:118`, not "the provider file"
+3. **Exact file paths with line numbers** — `src/utils/kycProvider.ts:118`, not "the provider file"
 4. **Current code, not stale references** — you read the files in Step 2, use what you actually saw
 5. **Explicit constraints** — "You will NOT modify..." sections prevent scope creep
 6. **Required vs optional** — mark every item. Don't let agents infer priority.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Specs are agent-executable prompts. A new Claude Code session with no prior cont
 - **Make decisions, not options.** "Use local wrappers" not "Consider adding to Euclid or using local wrappers." Agents can't choose between approaches — tell them which one.
 - **Use second person.** "You are fixing X" not "X should be fixed."
 - **Be explicit about constraints.** "You will NOT modify..." not just "Focus on..."
-- **Provide exact file paths with line numbers.** `src/utils/sumsubProvider.ts:118` not "the provider file."
+- **Provide exact file paths with line numbers.** `src/utils/kycProvider.ts:118` not "the provider file."
 - **State the validation command.** Agents will run it. If it's not there, they'll skip validation.
 - **One spec = one PR.** Target the PR size from Key Rules (1k–3k LOC). If a spec would exceed that, split it.
 - **Mark items as required vs optional.** Don't let agents infer priority.

--- a/app/android/app/src/debug/AndroidManifest.xml
+++ b/app/android/app/src/debug/AndroidManifest.xml
@@ -14,7 +14,7 @@
         tools:ignore="GoogleAppIndexingWarning"
         tools:replace="android:usesCleartextTraffic">
         
-        <!-- Override conflicting ML Kit dependencies from passportreader (ocr) and Sumsub SDK (face) -->
+        <!-- Override conflicting ML Kit dependencies from passportreader (ocr) and the KYC SDK (face) -->
         <meta-data
             android:name="com.google.mlkit.vision.DEPENDENCIES"
             android:value="ocr,face"

--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
-    <!-- Remove FOREGROUND_SERVICE_MICROPHONE merged in by Sumsub SDK (VideoIdent is disabled) -->
+    <!-- Remove FOREGROUND_SERVICE_MICROPHONE merged in by the KYC SDK (VideoIdent is disabled) -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" tools:node="remove" />
 
     <application
@@ -112,7 +112,7 @@
         <meta-data android:name="photopicker_activity:0:required" android:value="" />
       </service>
 
-      <!-- Override conflicting ML Kit dependencies from passportreader (ocr) and Sumsub SDK (face) -->
+      <!-- Override conflicting ML Kit dependencies from passportreader (ocr) and the KYC SDK (face) -->
       <meta-data
           android:name="com.google.mlkit.vision.DEPENDENCIES"
           android:value="ocr,face"

--- a/app/src/hooks/useKycLauncher.ts
+++ b/app/src/hooks/useKycLauncher.ts
@@ -8,28 +8,31 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import { sanitizeErrorMessage } from '@selfxyz/mobile-sdk-alpha';
 
-import { createSession, launchDidit } from '@/integrations/didit';
-import type { DiditVerificationResult } from '@/integrations/didit/types';
+import {
+  createKycSession,
+  launchKycVerification as startKycVerification,
+} from '@/integrations/kyc';
+import type { KycVerificationResult } from '@/integrations/kyc/types';
 import type { RootStackParamList } from '@/navigation';
 
 export type FallbackErrorSource = 'mrz_scan_failed' | 'nfc_scan_failed';
 
-export interface UseDiditLauncherOptions {
+export interface UseKycLauncherOptions {
   /**
    * Country code for the user's document
    */
   countryCode: string;
   /**
-   * Error source to track where the Didit launch was initiated from
+   * Error source to track where the KYC launch was initiated from
    */
   errorSource: FallbackErrorSource;
   /**
    * Optional callback to handle successful verification.
-   * Receives the Didit result and the sessionId from the session.
+   * Receives the KYC result and the sessionId from the session.
    * If not provided, defaults to navigating to KycSuccess with the sessionId.
    */
   onSuccess?: (
-    result: DiditVerificationResult,
+    result: KycVerificationResult,
     sessionId: string,
   ) => void | Promise<void>;
   /**
@@ -41,42 +44,42 @@ export interface UseDiditLauncherOptions {
    */
   onError?: (
     error: unknown,
-    result?: DiditVerificationResult,
+    result?: KycVerificationResult,
   ) => void | Promise<void>;
 }
 
 /**
- * Custom hook for launching Didit verification with consistent error handling.
+ * Custom hook for launching KYC verification with consistent error handling.
  *
  * Abstracts the common pattern of:
  * 1. Creating a session
- * 2. Launching Didit SDK
+ * 2. Launching the provider SDK
  * 3. Handling errors by navigating to fallback screen
  * 4. Managing loading state
  *
  * @example
  * ```tsx
- * const { launchDiditVerification, isLoading } = useDiditLauncher({
+ * const { launchKycVerification, isLoading } = useKycLauncher({
  *   countryCode: 'US',
  *   errorSource: 'nfc_scan_failed',
  * });
  *
- * <Button onPress={launchDiditVerification} disabled={isLoading}>
+ * <Button onPress={launchKycVerification} disabled={isLoading}>
  *   {isLoading ? 'Loading...' : 'Try Alternative Verification'}
  * </Button>
  * ```
  */
-export const useDiditLauncher = (options: UseDiditLauncherOptions) => {
+export const useKycLauncher = (options: UseKycLauncherOptions) => {
   const { countryCode, errorSource, onSuccess, onCancel, onError } = options;
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const [isLoading, setIsLoading] = useState(false);
 
-  const launchDiditVerification = useCallback(async () => {
+  const launchKycVerification = useCallback(async () => {
     setIsLoading(true);
     try {
-      const session = await createSession();
-      const result = await launchDidit(session.sessionToken);
+      const session = await createKycSession();
+      const result = await startKycVerification(session.sessionToken);
 
       // Handle user cancellation
       if (result.type === 'cancelled') {
@@ -89,7 +92,7 @@ export const useDiditLauncher = (options: UseDiditLauncherOptions) => {
         const error =
           result.error?.message || result.error?.type || 'Unknown error';
         const safeError = sanitizeErrorMessage(error);
-        console.error('Didit verification failed:', safeError);
+        console.error('KYC verification failed:', safeError);
 
         // Call custom error handler if provided, otherwise navigate to fallback screen
         if (onError) {
@@ -134,7 +137,7 @@ export const useDiditLauncher = (options: UseDiditLauncherOptions) => {
   }, [navigation, countryCode, errorSource, onSuccess, onCancel, onError]);
 
   return {
-    launchDiditVerification,
+    launchKycVerification,
     isLoading,
   };
 };

--- a/app/src/hooks/useKycWebSocket.ts
+++ b/app/src/hooks/useKycWebSocket.ts
@@ -9,12 +9,12 @@ import { DIDIT_TEE_URL } from '@env';
 import { deserializeApplicantInfo } from '@selfxyz/common';
 import type { DocumentType, KycData } from '@selfxyz/common/utils/types';
 
-import type { ApplicantInfoSerialized } from '@/integrations/didit/types';
+import type { ApplicantInfoSerialized } from '@/integrations/kyc/types';
 import { navigationRef } from '@/navigation';
 import { storeDocumentWithDeduplication } from '@/providers/passportDataProvider';
 import { usePendingKycStore } from '@/stores/pendingKycStore';
 
-interface UseDiditWebSocketOptions {
+interface UseKycWebSocketOptions {
   onSuccess?: () => void;
   onError?: (error: string) => void;
   onVerificationFailed?: (reason: string) => void;
@@ -22,11 +22,11 @@ interface UseDiditWebSocketOptions {
 }
 
 /**
- * Shared hook for Didit websocket subscription logic.
+ * Shared hook for KYC websocket subscription logic.
  * Handles connecting to the TEE service, subscribing to a sessionId,
  * and processing verification results.
  */
-export function useDiditWebSocket(options: UseDiditWebSocketOptions = {}) {
+export function useKycWebSocket(options: UseKycWebSocketOptions = {}) {
   const {
     onSuccess,
     onError,
@@ -51,7 +51,7 @@ export function useDiditWebSocket(options: UseDiditWebSocketOptions = {}) {
     (sessionId: string) => {
       if (subscribedSessionIdsRef.current.has(sessionId)) {
         console.log(
-          '[DiditWebSocket] Already subscribed to sessionId:',
+          '[KycWebSocket] Already subscribed to sessionId:',
           sessionId,
         );
         return;
@@ -63,7 +63,7 @@ export function useDiditWebSocket(options: UseDiditWebSocketOptions = {}) {
       // Don't retry 'processing' verifications as the proving machine is reading to be triggered.
       if (isProcessing) {
         console.log(
-          '[DiditWebSocket] Verification in processing state, skipping for sessionId:',
+          '[KycWebSocket] Verification in processing state, skipping for sessionId:',
           sessionId,
         );
         return;
@@ -71,14 +71,14 @@ export function useDiditWebSocket(options: UseDiditWebSocketOptions = {}) {
 
       if (!skipAddPending) {
         console.log(
-          '[DiditWebSocket] Adding pending verification for sessionId:',
+          '[KycWebSocket] Adding pending verification for sessionId:',
           sessionId,
         );
         addPendingVerification(sessionId);
       }
       subscribedSessionIdsRef.current.add(sessionId);
 
-      console.log('[DiditWebSocket] Connecting to WebSocket:', DIDIT_TEE_URL);
+      console.log('[KycWebSocket] Connecting to WebSocket:', DIDIT_TEE_URL);
       const socket = io(DIDIT_TEE_URL, {
         transports: ['websocket', 'polling'],
       });
@@ -87,7 +87,7 @@ export function useDiditWebSocket(options: UseDiditWebSocketOptions = {}) {
 
       socket.on('connect', () => {
         console.log(
-          '[DiditWebSocket] Connected, subscribing to user:',
+          '[KycWebSocket] Connected, subscribing to user:',
           sessionId,
         );
         socket.emit('subscribe', sessionId);
@@ -95,7 +95,7 @@ export function useDiditWebSocket(options: UseDiditWebSocketOptions = {}) {
 
       socket.on('success', async (data: ApplicantInfoSerialized) => {
         console.log(
-          '[DiditWebSocket] Received applicant info for sessionId:',
+          '[KycWebSocket] Received applicant info for sessionId:',
           sessionId,
         );
 
@@ -113,7 +113,7 @@ export function useDiditWebSocket(options: UseDiditWebSocketOptions = {}) {
           };
           const documentId = await storeDocumentWithDeduplication(kycData);
           console.log(
-            '[DiditWebSocket] KYC data stored successfully, documentId:',
+            '[KycWebSocket] KYC data stored successfully, documentId:',
             documentId,
           );
 
@@ -131,7 +131,7 @@ export function useDiditWebSocket(options: UseDiditWebSocketOptions = {}) {
           socket.emit('ack_success', sessionId);
           onSuccess?.();
         } catch (err) {
-          console.error('[DiditWebSocket] Failed to store KYC data:', err);
+          console.error('[KycWebSocket] Failed to store KYC data:', err);
           updateVerificationStatus(
             sessionId,
             'failed',
@@ -146,7 +146,7 @@ export function useDiditWebSocket(options: UseDiditWebSocketOptions = {}) {
       });
 
       socket.on('verification_failed', (reason: string) => {
-        console.log('[DiditWebSocket] Verification failed:', reason);
+        console.log('[KycWebSocket] Verification failed:', reason);
         updateVerificationStatus(sessionId, 'failed', reason);
         onVerificationFailed?.(reason);
 
@@ -156,7 +156,7 @@ export function useDiditWebSocket(options: UseDiditWebSocketOptions = {}) {
       });
 
       socket.on('error', (errorMessage: string) => {
-        console.error('[DiditWebSocket] Socket error:', errorMessage);
+        console.error('[KycWebSocket] Socket error:', errorMessage);
         updateVerificationStatus(sessionId, 'failed', errorMessage);
         onError?.(errorMessage);
 
@@ -166,7 +166,7 @@ export function useDiditWebSocket(options: UseDiditWebSocketOptions = {}) {
       });
 
       socket.on('disconnect', () => {
-        console.log('[DiditWebSocket] Disconnected for sessionId:', sessionId);
+        console.log('[KycWebSocket] Disconnected for sessionId:', sessionId);
       });
     },
     [

--- a/app/src/hooks/useKycWebSocket.ts
+++ b/app/src/hooks/useKycWebSocket.ts
@@ -14,6 +14,9 @@ import { navigationRef } from '@/navigation';
 import { storeDocumentWithDeduplication } from '@/providers/passportDataProvider';
 import { usePendingKycStore } from '@/stores/pendingKycStore';
 
+const redactSessionId = (id: string) =>
+  id.length > 8 ? `${id.slice(0, 4)}***${id.slice(-4)}` : '***';
+
 interface UseKycWebSocketOptions {
   onSuccess?: () => void;
   onError?: (error: string) => void;
@@ -52,7 +55,7 @@ export function useKycWebSocket(options: UseKycWebSocketOptions = {}) {
       if (subscribedSessionIdsRef.current.has(sessionId)) {
         console.log(
           '[KycWebSocket] Already subscribed to sessionId:',
-          sessionId,
+          redactSessionId(sessionId),
         );
         return;
       }
@@ -64,7 +67,7 @@ export function useKycWebSocket(options: UseKycWebSocketOptions = {}) {
       if (isProcessing) {
         console.log(
           '[KycWebSocket] Verification in processing state, skipping for sessionId:',
-          sessionId,
+          redactSessionId(sessionId),
         );
         return;
       }
@@ -72,7 +75,7 @@ export function useKycWebSocket(options: UseKycWebSocketOptions = {}) {
       if (!skipAddPending) {
         console.log(
           '[KycWebSocket] Adding pending verification for sessionId:',
-          sessionId,
+          redactSessionId(sessionId),
         );
         addPendingVerification(sessionId);
       }
@@ -88,7 +91,7 @@ export function useKycWebSocket(options: UseKycWebSocketOptions = {}) {
       socket.on('connect', () => {
         console.log(
           '[KycWebSocket] Connected, subscribing to user:',
-          sessionId,
+          redactSessionId(sessionId),
         );
         socket.emit('subscribe', sessionId);
       });
@@ -96,7 +99,7 @@ export function useKycWebSocket(options: UseKycWebSocketOptions = {}) {
       socket.on('success', async (data: ApplicantInfoSerialized) => {
         console.log(
           '[KycWebSocket] Received applicant info for sessionId:',
-          sessionId,
+          redactSessionId(sessionId),
         );
 
         try {
@@ -166,7 +169,10 @@ export function useKycWebSocket(options: UseKycWebSocketOptions = {}) {
       });
 
       socket.on('disconnect', () => {
-        console.log('[KycWebSocket] Disconnected for sessionId:', sessionId);
+        console.log(
+          '[KycWebSocket] Disconnected for sessionId:',
+          redactSessionId(sessionId),
+        );
       });
     },
     [

--- a/app/src/hooks/usePendingKycRecovery.ts
+++ b/app/src/hooks/usePendingKycRecovery.ts
@@ -4,7 +4,7 @@
 
 import { useCallback, useEffect, useRef } from 'react';
 
-import { useDiditWebSocket } from '@/hooks/useDiditWebSocket';
+import { useKycWebSocket } from '@/hooks/useKycWebSocket';
 import { navigationRef } from '@/navigation';
 import { usePendingKycStore } from '@/stores/pendingKycStore';
 
@@ -28,7 +28,7 @@ function getRecoveryIdentifier(verification: RecoveryVerification) {
  * 2. For each non-expired pending/processing verification, reconnects to websocket
  * 3. Subscribes to the sessionId to receive any cached results
  * 4. Updates verification status based on server response
- * 5. Initiates proving machine after document storage (handled in useDiditWebSocket)
+ * 5. Initiates proving machine after document storage (handled in useKycWebSocket)
  *
  * NOTE: This requires the TEE server to cache completed verification results
  * so they can be retrieved when the app reopens.
@@ -51,7 +51,7 @@ export function usePendingKycRecovery() {
     console.log('[PendingKycRecovery] Verification failed:', reason);
   }, []);
 
-  const { subscribe, unsubscribeAll } = useDiditWebSocket({
+  const { subscribe, unsubscribeAll } = useKycWebSocket({
     skipAddPending: true,
     onSuccess: handleSuccess,
     onError: handleError,

--- a/app/src/integrations/kyc/index.ts
+++ b/app/src/integrations/kyc/index.ts
@@ -4,11 +4,11 @@
 
 export type {
   ApplicantInfoSerialized,
-  DiditVerificationResult,
+  KycVerificationResult,
   SessionResponse,
-} from '@/integrations/didit/types';
+} from '@/integrations/kyc/types';
 export {
-  type DiditConfig,
-  createSession,
-  launchDidit,
-} from '@/integrations/didit/diditService';
+  type KycLaunchConfig,
+  createKycSession,
+  launchKycVerification,
+} from '@/integrations/kyc/kycService';

--- a/app/src/integrations/kyc/kycService.ts
+++ b/app/src/integrations/kyc/kycService.ts
@@ -36,9 +36,7 @@ export const createKycSession = async (): Promise<SessionResponse> => {
     clearTimeout(timeoutId);
 
     if (!response.ok) {
-      throw new Error(
-        `Failed to create Didit session (HTTP ${response.status})`,
-      );
+      throw new Error(`Failed to create KYC session (HTTP ${response.status})`);
     }
 
     const body = await response.json();
@@ -54,13 +52,13 @@ export const createKycSession = async (): Promise<SessionResponse> => {
     if (err instanceof Error) {
       if (err.name === 'AbortError') {
         throw new Error(
-          `Request to Didit TEE timed out after ${FETCH_TIMEOUT_MS / 1000}s`,
+          `Request to KYC TEE timed out after ${FETCH_TIMEOUT_MS / 1000}s`,
         );
       }
-      throw new Error(`Failed to create Didit session: ${err.message}`);
+      throw new Error(`Failed to create KYC session: ${err.message}`);
     }
 
-    throw new Error('Failed to create Didit session: Unknown error');
+    throw new Error('Failed to create KYC session: Unknown error');
   }
 };
 

--- a/app/src/integrations/kyc/kycService.ts
+++ b/app/src/integrations/kyc/kycService.ts
@@ -6,18 +6,18 @@ import { startVerification } from '@didit-protocol/sdk-react-native';
 import { DIDIT_TEE_URL } from '@env';
 
 import type {
-  DiditVerificationResult,
+  KycVerificationResult,
   SessionResponse,
-} from '@/integrations/didit/types';
+} from '@/integrations/kyc/types';
 
-export interface DiditConfig {
+export interface KycLaunchConfig {
   locale?: string;
   debug?: boolean;
 }
 
 const FETCH_TIMEOUT_MS = 30000;
 
-export const createSession = async (): Promise<SessionResponse> => {
+export const createKycSession = async (): Promise<SessionResponse> => {
   const apiUrl = DIDIT_TEE_URL;
   console.log('[Didit] createSession URL:', apiUrl);
   const controller = new AbortController();
@@ -64,14 +64,14 @@ export const createSession = async (): Promise<SessionResponse> => {
   }
 };
 
-export const launchDidit = async (
+export const launchKycVerification = async (
   sessionToken: string,
-  config?: DiditConfig,
-): Promise<DiditVerificationResult> => {
+  config?: KycLaunchConfig,
+): Promise<KycVerificationResult> => {
   const result = await startVerification(sessionToken, {
     languageCode: config?.locale ?? 'en',
     loggingEnabled: config?.debug ?? __DEV__,
   });
 
-  return result as DiditVerificationResult;
+  return result as KycVerificationResult;
 };

--- a/app/src/integrations/kyc/types.ts
+++ b/app/src/integrations/kyc/types.ts
@@ -8,7 +8,7 @@ export interface ApplicantInfoSerialized {
   pubkey: Array<string>;
 }
 
-export interface DiditVerificationResult {
+export interface KycVerificationResult {
   type: 'completed' | 'cancelled' | 'failed';
   session?: {
     status: string;

--- a/app/src/providers/selfClientProvider.tsx
+++ b/app/src/providers/selfClientProvider.tsx
@@ -316,7 +316,7 @@ export const SelfClientProvider = ({ children }: PropsWithChildren) => {
         documentTypes: string[];
       }) => {
         currentCountryCode = countryCode;
-        // Store country code early so it's available for Didit fallback flows
+        // Store country code early so it's available for KYC fallback flows
         useMRZStore.getState().update({ countryCode });
         navigateIfReady('IDPicker', { countryCode, documentTypes });
       },
@@ -346,12 +346,10 @@ export const SelfClientProvider = ({ children }: PropsWithChildren) => {
                   if (
                     useErrorInjectionStore
                       .getState()
-                      .shouldTrigger('didit_initialization')
+                      .shouldTrigger('kyc_initialization')
                   ) {
-                    console.log('[DEV] Injecting Didit initialization error');
-                    throw new Error(
-                      'Injected Didit initialization error for testing',
-                    );
+                    console.log('[DEV] Injecting KYC initialization error');
+                    throw new Error('Injected KYC initialization error for testing');
                   }
 
                   const session = await createKycSession();
@@ -359,12 +357,12 @@ export const SelfClientProvider = ({ children }: PropsWithChildren) => {
                     session.sessionToken,
                   );
 
-                  console.log('[Didit] Result:', JSON.stringify(result));
+                  console.log('[KYC] Result:', JSON.stringify(result));
 
                   // User cancelled/dismissed without completing verification
                   if (result.type === 'cancelled') {
                     console.log(
-                      '[Didit] User cancelled or closed without completing',
+                      '[KYC] User cancelled or closed without completing',
                     );
                     return;
                   }
@@ -372,7 +370,7 @@ export const SelfClientProvider = ({ children }: PropsWithChildren) => {
                   // Dev-only: Check for injected verification error
                   const shouldInjectVerificationError = useErrorInjectionStore
                     .getState()
-                    .shouldTrigger('didit_verification');
+                    .shouldTrigger('kyc_verification');
 
                   // Actual error from provider
                   if (
@@ -380,7 +378,7 @@ export const SelfClientProvider = ({ children }: PropsWithChildren) => {
                     shouldInjectVerificationError
                   ) {
                     if (shouldInjectVerificationError) {
-                      console.log('[DEV] Injecting Didit verification error');
+                      console.log('[DEV] Injecting KYC verification error');
                     } else {
                       const safeError = sanitizeErrorMessage(
                         result.error?.message ||
@@ -402,7 +400,7 @@ export const SelfClientProvider = ({ children }: PropsWithChildren) => {
                   // User completed verification
                   // Navigate to KYC success screen
                   console.log(
-                    '[Didit] Verification submitted, status:',
+                    '[KYC] Verification submitted, status:',
                     result.session?.status,
                   );
                   if (navigationRef.isReady()) {

--- a/app/src/providers/selfClientProvider.tsx
+++ b/app/src/providers/selfClientProvider.tsx
@@ -349,7 +349,9 @@ export const SelfClientProvider = ({ children }: PropsWithChildren) => {
                       .shouldTrigger('kyc_initialization')
                   ) {
                     console.log('[DEV] Injecting KYC initialization error');
-                    throw new Error('Injected KYC initialization error for testing');
+                    throw new Error(
+                      'Injected KYC initialization error for testing',
+                    );
                   }
 
                   const session = await createKycSession();

--- a/app/src/providers/selfClientProvider.tsx
+++ b/app/src/providers/selfClientProvider.tsx
@@ -23,7 +23,7 @@ import {
 } from '@selfxyz/mobile-sdk-alpha';
 
 import { logNFCEvent, logProofEvent } from '@/config/sentry';
-import { createSession, launchDidit } from '@/integrations/didit';
+import { createKycSession, launchKycVerification } from '@/integrations/kyc';
 import type { RootStackParamList } from '@/navigation';
 import { navigationRef } from '@/navigation';
 import {
@@ -354,8 +354,10 @@ export const SelfClientProvider = ({ children }: PropsWithChildren) => {
                     );
                   }
 
-                  const session = await createSession();
-                  const result = await launchDidit(session.sessionToken);
+                  const session = await createKycSession();
+                  const result = await launchKycVerification(
+                    session.sessionToken,
+                  );
 
                   console.log('[Didit] Result:', JSON.stringify(result));
 

--- a/app/src/providers/selfClientProvider.tsx
+++ b/app/src/providers/selfClientProvider.tsx
@@ -359,7 +359,7 @@ export const SelfClientProvider = ({ children }: PropsWithChildren) => {
                     session.sessionToken,
                   );
 
-                  console.log('[KYC] Result:', JSON.stringify(result));
+                  console.log('[KYC] Result type:', result.type);
 
                   // User cancelled/dismissed without completing verification
                   if (result.type === 'cancelled') {

--- a/app/src/screens/documents/aadhaar/AadhaarUploadErrorScreen.tsx
+++ b/app/src/screens/documents/aadhaar/AadhaarUploadErrorScreen.tsx
@@ -27,7 +27,7 @@ import { useSafeBottomPadding } from '@selfxyz/mobile-sdk-alpha/hooks';
 
 import WarningIcon from '@/assets/images/warning.svg';
 import { NavBar } from '@/components/navbar/BaseNavBar';
-import { useDiditLauncher } from '@/hooks/useDiditLauncher';
+import { useKycLauncher } from '@/hooks/useKycLauncher';
 import { buttonTap } from '@/integrations/haptics';
 import type { RootStackParamList } from '@/navigation';
 import { extraYPadding } from '@/utils/styleUtils';
@@ -70,7 +70,7 @@ const AadhaarUploadErrorScreen: React.FC = () => {
   const errorType = route.params?.errorType || 'general';
   const { title, description } = getErrorMessages(errorType);
 
-  const { launchDiditVerification, isLoading: isRetrying } = useDiditLauncher({
+  const { launchKycVerification, isLoading: isRetrying } = useKycLauncher({
     countryCode: 'IND',
     errorSource: 'mrz_scan_failed', // Use a compatible error source
     onCancel: () => {
@@ -93,8 +93,8 @@ const AadhaarUploadErrorScreen: React.FC = () => {
 
   const handleTryAlternative = useCallback(async () => {
     trackEvent(AadhaarEvents.HELP_BUTTON_PRESSED, { errorType });
-    await launchDiditVerification();
-  }, [errorType, launchDiditVerification, trackEvent]);
+    await launchKycVerification();
+  }, [errorType, launchKycVerification, trackEvent]);
 
   return (
     <YStack flex={1} backgroundColor={slate100}>

--- a/app/src/screens/documents/scanning/DocumentCameraTroubleScreen.tsx
+++ b/app/src/screens/documents/scanning/DocumentCameraTroubleScreen.tsx
@@ -16,8 +16,8 @@ import QrScan from '@/assets/icons/qr_scan.svg';
 import Star from '@/assets/icons/star.svg';
 import type { TipProps } from '@/components/Tips';
 import Tips from '@/components/Tips';
-import { useDiditLauncher } from '@/hooks/useDiditLauncher';
 import useHapticNavigation from '@/hooks/useHapticNavigation';
+import { useKycLauncher } from '@/hooks/useKycLauncher';
 import SimpleScrolledTitleLayout from '@/layouts/SimpleScrolledTitleLayout';
 import { flush as flushAnalytics } from '@/services/analytics';
 
@@ -54,7 +54,7 @@ const DocumentCameraTroubleScreen: React.FC = () => {
   const selfClient = useSelfClient();
   const { useMRZStore } = selfClient;
   const { countryCode } = useMRZStore();
-  const { launchDiditVerification, isLoading } = useDiditLauncher({
+  const { launchKycVerification, isLoading } = useKycLauncher({
     countryCode,
     errorSource: 'mrz_scan_failed',
   });
@@ -88,7 +88,7 @@ const DocumentCameraTroubleScreen: React.FC = () => {
           </Caption>
 
           <SecondaryButton
-            onPress={launchDiditVerification}
+            onPress={launchKycVerification}
             disabled={isLoading}
             textColor={slate700}
             style={{ marginBottom: 0 }}

--- a/app/src/screens/documents/scanning/DocumentNFCTroubleScreen.tsx
+++ b/app/src/screens/documents/scanning/DocumentNFCTroubleScreen.tsx
@@ -14,9 +14,9 @@ import { slate500, slate700 } from '@selfxyz/mobile-sdk-alpha/constants/colors';
 
 import type { TipProps } from '@/components/Tips';
 import Tips from '@/components/Tips';
-import { useDiditLauncher } from '@/hooks/useDiditLauncher';
 import { useFeedbackAutoHide } from '@/hooks/useFeedbackAutoHide';
 import useHapticNavigation from '@/hooks/useHapticNavigation';
+import { useKycLauncher } from '@/hooks/useKycLauncher';
 import { selectionChange } from '@/integrations/haptics';
 import SimpleScrolledTitleLayout from '@/layouts/SimpleScrolledTitleLayout';
 import { flushAllAnalytics } from '@/services/analytics';
@@ -61,7 +61,7 @@ const DocumentNFCTroubleScreen: React.FC = () => {
   const selfClient = useSelfClient();
   const { useMRZStore } = selfClient;
   const { countryCode } = useMRZStore();
-  const { launchDiditVerification, isLoading } = useDiditLauncher({
+  const { launchKycVerification, isLoading } = useKycLauncher({
     countryCode,
     errorSource: 'nfc_scan_failed',
   });
@@ -96,7 +96,7 @@ const DocumentNFCTroubleScreen: React.FC = () => {
           </SecondaryButton>
 
           <SecondaryButton
-            onPress={launchDiditVerification}
+            onPress={launchKycVerification}
             disabled={isLoading}
             textColor={slate700}
             style={{ marginBottom: 0 }}

--- a/app/src/screens/documents/scanning/RegistrationFallbackMRZScreen.tsx
+++ b/app/src/screens/documents/scanning/RegistrationFallbackMRZScreen.tsx
@@ -25,7 +25,7 @@ import { useSafeBottomPadding } from '@selfxyz/mobile-sdk-alpha/hooks';
 
 import WarningIcon from '@/assets/images/warning.svg';
 import { NavBar } from '@/components/navbar/BaseNavBar';
-import { useDiditLauncher } from '@/hooks/useDiditLauncher';
+import { useKycLauncher } from '@/hooks/useKycLauncher';
 import { buttonTap } from '@/integrations/haptics';
 import type { RootStackParamList } from '@/navigation';
 import { extraYPadding } from '@/utils/styleUtils';
@@ -66,7 +66,7 @@ const RegistrationFallbackMRZScreen: React.FC = () => {
 
   const headerTitle = getHeaderTitle(documentType);
 
-  const { launchDiditVerification, isLoading: isRetrying } = useDiditLauncher({
+  const { launchKycVerification, isLoading: isRetrying } = useKycLauncher({
     countryCode,
     errorSource: 'mrz_scan_failed',
     onCancel: () => {
@@ -87,8 +87,8 @@ const RegistrationFallbackMRZScreen: React.FC = () => {
     trackEvent('REGISTRATION_FALLBACK_TRY_ALTERNATIVE', {
       errorSource: 'mrz_scan_failed',
     });
-    await launchDiditVerification();
-  }, [launchDiditVerification, trackEvent]);
+    await launchKycVerification();
+  }, [launchKycVerification, trackEvent]);
 
   const handleRetryOriginal = useCallback(() => {
     trackEvent('REGISTRATION_FALLBACK_RETRY_ORIGINAL', {

--- a/app/src/screens/documents/scanning/RegistrationFallbackNFCScreen.tsx
+++ b/app/src/screens/documents/scanning/RegistrationFallbackNFCScreen.tsx
@@ -26,7 +26,7 @@ import { useSafeBottomPadding } from '@selfxyz/mobile-sdk-alpha/hooks';
 
 import WarningIcon from '@/assets/images/warning.svg';
 import { NavBar } from '@/components/navbar/BaseNavBar';
-import { useDiditLauncher } from '@/hooks/useDiditLauncher';
+import { useKycLauncher } from '@/hooks/useKycLauncher';
 import { buttonTap } from '@/integrations/haptics';
 import type { RootStackParamList } from '@/navigation';
 import { extraYPadding } from '@/utils/styleUtils';
@@ -67,7 +67,7 @@ const RegistrationFallbackNFCScreen: React.FC = () => {
 
   const headerTitle = getHeaderTitle(documentType);
 
-  const { launchDiditVerification, isLoading: isRetrying } = useDiditLauncher({
+  const { launchKycVerification, isLoading: isRetrying } = useKycLauncher({
     countryCode,
     errorSource: 'nfc_scan_failed',
     onCancel: () => {
@@ -93,8 +93,8 @@ const RegistrationFallbackNFCScreen: React.FC = () => {
     trackEvent('REGISTRATION_FALLBACK_TRY_ALTERNATIVE', {
       errorSource: 'nfc_scan_failed',
     });
-    await launchDiditVerification();
-  }, [launchDiditVerification, trackEvent]);
+    await launchKycVerification();
+  }, [launchKycVerification, trackEvent]);
 
   const handleRetryOriginal = useCallback(() => {
     trackEvent('REGISTRATION_FALLBACK_RETRY_ORIGINAL', {

--- a/app/src/screens/documents/selection/LogoConfirmationScreen.tsx
+++ b/app/src/screens/documents/selection/LogoConfirmationScreen.tsx
@@ -25,8 +25,8 @@ import { advercase, dinot } from '@selfxyz/mobile-sdk-alpha/constants/fonts';
 import EPassportLogo from '@/assets/icons/epassport_logo.svg';
 import { DocumentFlowNavBar } from '@/components/navbar/DocumentFlowNavBar';
 import useHapticNavigation from '@/hooks/useHapticNavigation';
-import { createSession, launchDidit } from '@/integrations/didit';
 import { buttonTap } from '@/integrations/haptics';
+import { createKycSession, launchKycVerification } from '@/integrations/kyc';
 import { ExpandableBottomLayout } from '@/layouts/ExpandableBottomLayout';
 import type { RootStackParamList } from '@/navigation';
 import { useFeedback } from '@/providers/feedbackProvider';
@@ -58,8 +58,8 @@ const LogoConfirmationScreen: React.FC = () => {
       buttonText: 'Proceed with an external verifier',
       onButtonPress: async () => {
         try {
-          const session = await createSession();
-          const result = await launchDidit(session.sessionToken);
+          const session = await createKycSession();
+          const result = await launchKycVerification(session.sessionToken);
 
           // User cancelled/dismissed without completing verification
           if (result.type === 'cancelled') {
@@ -69,7 +69,7 @@ const LogoConfirmationScreen: React.FC = () => {
           // Verification failed (provider error/rejection)
           if (result.type === 'failed') {
             console.error(
-              'Didit verification failed:',
+              'KYC verification failed:',
               result.error?.type ?? 'unknown',
             );
             navigation.navigate('KycFailure', {
@@ -82,7 +82,7 @@ const LogoConfirmationScreen: React.FC = () => {
           // Verification succeeded - navigate to KycSuccessScreen
           navigation.navigate('KycSuccess', { sessionId: session.sessionId });
         } catch {
-          console.error('Error launching Didit verification');
+          console.error('Error launching KYC verification');
           showModal({
             titleText: 'Error',
             bodyText: 'Unable to start verification. Please try again.',

--- a/app/src/screens/kyc/KycSuccessScreen.tsx
+++ b/app/src/screens/kyc/KycSuccessScreen.tsx
@@ -21,7 +21,7 @@ import {
 import { ProofEvents } from '@selfxyz/mobile-sdk-alpha/constants/analytics';
 import { black, white } from '@selfxyz/mobile-sdk-alpha/constants/colors';
 
-import { useDiditWebSocket } from '@/hooks/useDiditWebSocket';
+import { useKycWebSocket } from '@/hooks/useKycWebSocket';
 import { buttonTap } from '@/integrations/haptics';
 import type { RootStackParamList } from '@/navigation';
 import {
@@ -66,7 +66,7 @@ const KycSuccessScreen: React.FC<KycSuccessRouteParams> = ({
     console.log('[KycSuccessScreen] Verification failed:', reason);
   }, []);
 
-  const { subscribe, unsubscribeAll } = useDiditWebSocket({
+  const { subscribe, unsubscribeAll } = useKycWebSocket({
     onSuccess: handleWebSocketSuccess,
     onError: handleWebSocketError,
     onVerificationFailed: handleVerificationFailed,

--- a/app/src/stores/errorInjectionStore.ts
+++ b/app/src/stores/errorInjectionStore.ts
@@ -16,8 +16,8 @@ export type InjectedErrorType =
   | 'nfc_parse_failure'
   | 'api_network_error'
   | 'api_timeout'
-  | 'didit_initialization'
-  | 'didit_verification';
+  | 'kyc_initialization'
+  | 'kyc_verification';
 
 export const ERROR_GROUPS = {
   MRZ: ['mrz_invalid_format', 'mrz_unknown_error'] as InjectedErrorType[],
@@ -27,7 +27,7 @@ export const ERROR_GROUPS = {
     'nfc_parse_failure',
   ] as InjectedErrorType[],
   API: ['api_network_error', 'api_timeout'] as InjectedErrorType[],
-  Didit: ['didit_initialization', 'didit_verification'] as InjectedErrorType[],
+  KYC: ['kyc_initialization', 'kyc_verification'] as InjectedErrorType[],
 };
 
 export const ERROR_LABELS: Record<InjectedErrorType, string> = {
@@ -38,8 +38,8 @@ export const ERROR_LABELS: Record<InjectedErrorType, string> = {
   nfc_parse_failure: 'NFC: Parse failure',
   api_network_error: 'API: Network error',
   api_timeout: 'API: Timeout',
-  didit_initialization: 'Didit: Initialization',
-  didit_verification: 'Didit: Verification',
+  kyc_initialization: 'KYC: Initialization',
+  kyc_verification: 'KYC: Verification',
 };
 
 interface ErrorInjectionState {

--- a/app/tests/src/hooks/usePendingKycRecovery.test.ts
+++ b/app/tests/src/hooks/usePendingKycRecovery.test.ts
@@ -8,8 +8,8 @@ import { usePendingKycRecovery } from '@/hooks/usePendingKycRecovery';
 import { navigationRef } from '@/navigation';
 
 // Mock dependencies
-jest.mock('@/hooks/useDiditWebSocket', () => ({
-  useDiditWebSocket: jest.fn(() => ({
+jest.mock('@/hooks/useKycWebSocket', () => ({
+  useKycWebSocket: jest.fn(() => ({
     subscribe: jest.fn(),
     unsubscribeAll: jest.fn(),
   })),
@@ -39,8 +39,8 @@ describe('usePendingKycRecovery', () => {
     jest.useFakeTimers();
 
     // Setup default mocks
-    const { useDiditWebSocket } = jest.requireMock('@/hooks/useDiditWebSocket');
-    useDiditWebSocket.mockReturnValue({
+    const { useKycWebSocket } = jest.requireMock('@/hooks/useKycWebSocket');
+    useKycWebSocket.mockReturnValue({
       subscribe: mockSubscribe,
       unsubscribeAll: mockUnsubscribeAll,
     });

--- a/app/tests/src/navigation.test.tsx
+++ b/app/tests/src/navigation.test.tsx
@@ -24,7 +24,7 @@ jest.mock('@/services/analytics', () => ({
   flush: jest.fn(),
 }));
 
-// Mock Didit SDK to prevent ES module parsing errors in isolateModules
+// Mock KYC SDK to prevent ES module parsing errors in isolateModules
 jest.mock('@didit-protocol/sdk-react-native', () => ({
   __esModule: true,
   startVerification: jest.fn().mockResolvedValue({

--- a/app/tests/src/screens/kyc/KycSuccessScreen.test.tsx
+++ b/app/tests/src/screens/kyc/KycSuccessScreen.test.tsx
@@ -44,8 +44,8 @@ jest.mock('react-native-edge-to-edge', () => ({
   SystemBars: () => null,
 }));
 
-jest.mock('@/hooks/useDiditWebSocket', () => ({
-  useDiditWebSocket: jest.fn(() => ({
+jest.mock('@/hooks/useKycWebSocket', () => ({
+  useKycWebSocket: jest.fn(() => ({
     subscribe: jest.fn(),
     unsubscribe: jest.fn(),
     unsubscribeAll: jest.fn(),

--- a/common/src/utils/types.ts
+++ b/common/src/utils/types.ts
@@ -90,9 +90,9 @@ export interface PassportData extends BaseIDData {
   passportMetadata?: PassportMetadata;
 }
 
-// pending - pending didit verification
-// processing - didit verification completed and pending onchain confirmation
-// failed - didit verification failed
+// pending - pending KYC verification
+// processing - KYC verification completed and pending onchain confirmation
+// failed - KYC verification failed
 export type PendingKycStatus = 'pending' | 'processing' | 'failed';
 
 export interface PendingKycVerification {

--- a/contracts/contracts/constants/AttestationId.sol
+++ b/contracts/contracts/constants/AttestationId.sol
@@ -8,7 +8,7 @@ pragma solidity 0.8.28;
  *      - E_PASSPORT (1): Electronic passports with NFC chip
  *      - EU_ID_CARD (2): EU biometric ID cards with NFC chip
  *      - AADHAAR (3): Indian Aadhaar identity documents
- *      - KYC (4): African identity documents via SumSub
+ *      - KYC (4): KYC-backed identity documents
  */
 library AttestationId {
     /// @notice Identifier for an E-PASSPORT attestation (electronic passports with NFC chip).
@@ -20,6 +20,6 @@ library AttestationId {
     /// @notice Identifier for an AADHAAR attestation (Indian Aadhaar identity documents).
     bytes32 constant AADHAAR = bytes32(uint256(3));
 
-    /// @notice Identifier for a KYC attestation (African identity documents via SumSub).
+    /// @notice Identifier for a KYC attestation (KYC-backed identity documents).
     bytes32 constant KYC = bytes32(uint256(4));
 }

--- a/docs/maintenance/tech-debt-baseline.json
+++ b/docs/maintenance/tech-debt-baseline.json
@@ -40,7 +40,7 @@
         "@sentry/react": "^9.32.0",
         "@sentry/react-native": "7.0.0",
         "@stablelib/cbor": "^2.0.1",
-        "@sumsub/react-native-mobilesdk-module": "1.40.2",
+        "@didit-protocol/sdk-react-native": "^3.2.8",
         "@tamagui/animations-css": "1.126.14",
         "@tamagui/animations-react-native": "1.126.14",
         "@tamagui/config": "1.126.14",

--- a/packages/webview-app/src/screens/onboarding/ProviderLaunchScreen.tsx
+++ b/packages/webview-app/src/screens/onboarding/ProviderLaunchScreen.tsx
@@ -13,9 +13,9 @@ import { useSelfClient } from '../../providers/SelfClientProvider';
 import { useVerificationRequest } from '../../providers/VerificationRequestProvider';
 import type { KycProviderResult } from '../../types/kycProvider';
 import { buildKycDocument } from '../../utils/buildKycDocument';
+import { WEB_SAFE_AREA } from '../../utils/insets';
 import { waitForKycAttestation } from '../../utils/kycAttestation';
 import { createKycSession, launchKycWebSdk } from '../../utils/kycProvider';
-import { WEB_SAFE_AREA } from '../../utils/insets';
 
 const CONTAINER_ID = 'kyc-sdk-container';
 
@@ -57,9 +57,7 @@ export const ProviderLaunchScreen: React.FC = () => {
 
       if ((result.status === 'success' || result.status === 'partial') && sessionIdRef.current) {
         setPhase('waiting');
-        const attestationResult = await waitForKycAttestation(
-          sessionIdRef.current,
-        );
+        const attestationResult = await waitForKycAttestation(sessionIdRef.current);
 
         if (!mountedRef.current) return;
 

--- a/packages/webview-app/src/screens/onboarding/ProviderLaunchScreen.tsx
+++ b/packages/webview-app/src/screens/onboarding/ProviderLaunchScreen.tsx
@@ -13,8 +13,8 @@ import { useSelfClient } from '../../providers/SelfClientProvider';
 import { useVerificationRequest } from '../../providers/VerificationRequestProvider';
 import type { KycProviderResult } from '../../types/kycProvider';
 import { buildKycDocument } from '../../utils/buildKycDocument';
-import { waitForAttestation } from '../../utils/diditAttestation';
-import { createDiditSession, launchDiditWebSdk } from '../../utils/diditProvider';
+import { waitForKycAttestation } from '../../utils/kycAttestation';
+import { createKycSession, launchKycWebSdk } from '../../utils/kycProvider';
 import { WEB_SAFE_AREA } from '../../utils/insets';
 
 const CONTAINER_ID = 'didit-sdk-container';
@@ -57,7 +57,9 @@ export const ProviderLaunchScreen: React.FC = () => {
 
       if ((result.status === 'success' || result.status === 'partial') && sessionIdRef.current) {
         setPhase('waiting');
-        const attestationResult = await waitForAttestation(sessionIdRef.current);
+        const attestationResult = await waitForKycAttestation(
+          sessionIdRef.current,
+        );
 
         if (!mountedRef.current) return;
 
@@ -163,12 +165,12 @@ export const ProviderLaunchScreen: React.FC = () => {
 
     (async () => {
       try {
-        const session = await createDiditSession(controller.signal);
+        const session = await createKycSession(controller.signal);
         if (cancelled) return;
 
         sessionIdRef.current = session.sessionId;
 
-        const destroy = await launchDiditWebSdk({
+        const destroy = await launchKycWebSdk({
           url: session.url,
           containerId: CONTAINER_ID,
           verificationId,

--- a/packages/webview-app/src/screens/onboarding/ProviderLaunchScreen.tsx
+++ b/packages/webview-app/src/screens/onboarding/ProviderLaunchScreen.tsx
@@ -17,7 +17,7 @@ import { waitForKycAttestation } from '../../utils/kycAttestation';
 import { createKycSession, launchKycWebSdk } from '../../utils/kycProvider';
 import { WEB_SAFE_AREA } from '../../utils/insets';
 
-const CONTAINER_ID = 'didit-sdk-container';
+const CONTAINER_ID = 'kyc-sdk-container';
 
 type Phase = 'loading' | 'active' | 'waiting' | 'error';
 
@@ -38,7 +38,7 @@ export const ProviderLaunchScreen: React.FC = () => {
 
   const defaultNextPath = nextPath ?? '/onboarding/provider-result';
   const isTunnelFlow = defaultNextPath.startsWith('/tunnel/') || backPath?.startsWith('/tunnel/') === true;
-  const verificationId = ctxVerificationId ?? `didit-${Date.now()}`;
+  const verificationId = ctxVerificationId ?? `kyc-${Date.now()}`;
 
   const [phase, setPhase] = useState<Phase>('loading');
   const [errorMessage, setErrorMessage] = useState('');

--- a/packages/webview-app/src/utils/kycAttestation.ts
+++ b/packages/webview-app/src/utils/kycAttestation.ts
@@ -22,10 +22,7 @@ export interface AttestationResult {
  *
  * After receiving data, emits `ack_success` to trigger session deletion on the TEE.
  */
-export function waitForKycAttestation(
-  sessionId: string,
-  signal?: AbortSignal,
-): Promise<AttestationResult> {
+export function waitForKycAttestation(sessionId: string, signal?: AbortSignal): Promise<AttestationResult> {
   return new Promise(resolve => {
     const socket = io(DIDIT_TEE_URL, {
       transports: ['websocket', 'polling'],

--- a/packages/webview-app/src/utils/kycAttestation.ts
+++ b/packages/webview-app/src/utils/kycAttestation.ts
@@ -22,7 +22,10 @@ export interface AttestationResult {
  *
  * After receiving data, emits `ack_success` to trigger session deletion on the TEE.
  */
-export function waitForAttestation(sessionId: string, signal?: AbortSignal): Promise<AttestationResult> {
+export function waitForKycAttestation(
+  sessionId: string,
+  signal?: AbortSignal,
+): Promise<AttestationResult> {
   return new Promise(resolve => {
     const socket = io(DIDIT_TEE_URL, {
       transports: ['websocket', 'polling'],

--- a/packages/webview-app/src/utils/kycProvider.ts
+++ b/packages/webview-app/src/utils/kycProvider.ts
@@ -33,9 +33,7 @@ function buildProviderResult(verificationId: string, overrides: Partial<KycProvi
   };
 }
 
-export async function createKycSession(
-  signal?: AbortSignal,
-): Promise<KycSession> {
+export async function createKycSession(signal?: AbortSignal): Promise<KycSession> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
@@ -72,9 +70,7 @@ export async function createKycSession(
   }
 }
 
-export async function launchKycWebSdk(
-  config: KycLaunchConfig,
-): Promise<() => void> {
+export async function launchKycWebSdk(config: KycLaunchConfig): Promise<() => void> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { DiditSdk } = (await import('@didit-protocol/sdk-web')) as any;
 

--- a/packages/webview-app/src/utils/kycProvider.ts
+++ b/packages/webview-app/src/utils/kycProvider.ts
@@ -52,7 +52,7 @@ export async function createKycSession(
     clearTimeout(timeoutId);
 
     if (!response.ok) {
-      throw new Error(`Failed to create Didit session (HTTP ${response.status})`);
+      throw new Error(`Failed to create KYC session (HTTP ${response.status})`);
     }
 
     const body: unknown = await response.json();
@@ -63,12 +63,12 @@ export async function createKycSession(
   } catch (err) {
     clearTimeout(timeoutId);
     if (err instanceof Error && err.name === 'AbortError') {
-      throw new Error(`Didit session request timed out after ${FETCH_TIMEOUT_MS / 1000}s`);
+      throw new Error(`KYC session request timed out after ${FETCH_TIMEOUT_MS / 1000}s`);
     }
     if (err instanceof Error) {
-      throw new Error(`Failed to create Didit session: ${err.message}`);
+      throw new Error(`Failed to create KYC session: ${err.message}`);
     }
-    throw new Error('Failed to create Didit session: Unknown error');
+    throw new Error('Failed to create KYC session: Unknown error');
   }
 }
 

--- a/packages/webview-app/src/utils/kycProvider.ts
+++ b/packages/webview-app/src/utils/kycProvider.ts
@@ -8,7 +8,7 @@ const FETCH_TIMEOUT_MS = 30_000;
 
 const DIDIT_TEE_URL = import.meta.env.VITE_DIDIT_TEE_URL ?? 'https://kyc.self.xyz';
 
-export interface DiditLaunchConfig {
+export interface KycLaunchConfig {
   url: string;
   containerId: string;
   verificationId: string;
@@ -17,7 +17,7 @@ export interface DiditLaunchConfig {
   onEvent?: (event: string, payload: unknown) => void;
 }
 
-export interface DiditSession {
+export interface KycSession {
   sessionId: string;
   sessionToken: string;
   url: string;
@@ -33,7 +33,9 @@ function buildProviderResult(verificationId: string, overrides: Partial<KycProvi
   };
 }
 
-export async function createDiditSession(signal?: AbortSignal): Promise<DiditSession> {
+export async function createKycSession(
+  signal?: AbortSignal,
+): Promise<KycSession> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
@@ -55,9 +57,9 @@ export async function createDiditSession(signal?: AbortSignal): Promise<DiditSes
 
     const body: unknown = await response.json();
     if (typeof body === 'string') {
-      return JSON.parse(body) as DiditSession;
+      return JSON.parse(body) as KycSession;
     }
-    return body as DiditSession;
+    return body as KycSession;
   } catch (err) {
     clearTimeout(timeoutId);
     if (err instanceof Error && err.name === 'AbortError') {
@@ -70,7 +72,9 @@ export async function createDiditSession(signal?: AbortSignal): Promise<DiditSes
   }
 }
 
-export async function launchDiditWebSdk(config: DiditLaunchConfig): Promise<() => void> {
+export async function launchKycWebSdk(
+  config: KycLaunchConfig,
+): Promise<() => void> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { DiditSdk } = (await import('@didit-protocol/sdk-web')) as any;
 

--- a/purple/global/authentication.md
+++ b/purple/global/authentication.md
@@ -56,7 +56,7 @@ Platform adapters implement this — React Native uses keychain, web uses volati
 | Service        | Method       | Purpose              | Token Persistence |
 |----------------|-------------|----------------------|-------------------|
 | Google Drive   | OAuth 2.0   | Mnemonic backup      | Per-session       |
-| Sumsub KYC     | API token   | Identity verification | Per-session       |
+| Didit KYC      | API token   | Identity verification | Per-session       |
 | Turnkey        | Google OAuth | Wallet backup        | DISABLED          |
 
 ## Keychain Security Levels (Adaptive)

--- a/purple/global/external-services.md
+++ b/purple/global/external-services.md
@@ -8,7 +8,7 @@
 | Firebase Remote Config | `@react-native-firebase/remote-config` | Feature flags, remote config | `app/src/providers/remoteConfigProvider.tsx` |
 | Segment | `@segment/analytics-react-native` | Analytics / event tracking | `app/src/services/analytics.ts` |
 | Sentry | `@sentry/react-native` | Error tracking / crash reporting | `app/src/config/sentry.ts` |
-| Sumsub | `@sumsub/react-native-mobilesdk-module` | KYC identity verification | `app/src/integrations/sumsub/` |
+| Didit | `@didit-protocol/sdk-react-native` | KYC identity verification | `app/src/integrations/kyc/` |
 | Google Drive | `@robinbobin/react-native-google-drive-api-wrapper` | Cloud mnemonic backup | `app/src/services/cloud-backup/google.ts` |
 | Google OAuth | `react-native-app-auth` | OAuth 2.0 for Drive access | `app/src/services/cloud-backup/google.ts` |
 
@@ -29,7 +29,7 @@
 - Provides feature flags and runtime configuration
 - Fetched on app start, cached locally
 
-### KYC (Sumsub)
+### KYC (Didit)
 - Access token fetched per-session via TEE endpoint
 - 30-second timeout on token fetch
 - Token not persisted — fresh for each KYC session

--- a/purple/temp/codebase-analysis.md
+++ b/purple/temp/codebase-analysis.md
@@ -50,4 +50,4 @@ Identity verification wallet using NFC passport scanning + zero-knowledge proofs
 - No Express/Nest/etc server
 - Smart contracts serve as "backend"
 - SDK core package handles proving/verification
-- External services: Firebase, Segment, Sentry, Sumsub KYC
+- External services: Firebase, Segment, Sentry, Didit KYC

--- a/specs/projects/sdk/workstreams/kmp-revival/SPEC.md
+++ b/specs/projects/sdk/workstreams/kmp-revival/SPEC.md
@@ -127,10 +127,10 @@ Any other domain request returns a `DOMAIN_NOT_FOUND` error response.
 
 ## Related Specs
 
-| Spec                                                             | Relationship                                        |
-| ---------------------------------------------------------------- | --------------------------------------------------- |
-| [SDK Overview](../../OVERVIEW.md)                                | Parent architecture                                 |
-| [Native Shells Lite](../native-shells-lite/SPEC.md)              | Sibling — serves non-KMP consumers                  |
-| [Paused Native Shells (KMP)](../../paused/native-shells/SPEC.md) | Historical KMP work — validated foundation          |
-| [Build Pipeline](../build-pipeline/SPEC.md)                      | Downstream — bundles webview-app into native assets |
+| Spec                                                             | Relationship                                                   |
+| ---------------------------------------------------------------- | -------------------------------------------------------------- |
+| [SDK Overview](../../OVERVIEW.md)                                | Parent architecture                                            |
+| [Native Shells Lite](../native-shells-lite/SPEC.md)              | Sibling — serves non-KMP consumers                             |
+| [Paused Native Shells (KMP)](../../paused/native-shells/SPEC.md) | Historical KMP work — validated foundation                     |
+| [Build Pipeline](../build-pipeline/SPEC.md)                      | Downstream — bundles webview-app into native assets            |
 | [SDK Distribution — SD-06](../sdk-distribution/SPEC.md)          | Downstream — remote publishing after KR-03 validates artifacts |

--- a/specs/projects/sdk/workstreams/sdk-distribution/SPEC.md
+++ b/specs/projects/sdk/workstreams/sdk-distribution/SPEC.md
@@ -58,13 +58,13 @@
 
 ## Backlog
 
-| ID    | Title                            | Status | Priority | Depends On | Plan                                                                                 | PR  |
-| ----- | -------------------------------- | ------ | -------- | ---------- | ------------------------------------------------------------------------------------ | --- |
-| SD-01 | Android hosted URL loading       | Ready  | High     | NSL-01     | [plans/SD-01-android-hosted-url.md](./plans/SD-01-android-hosted-url.md)             | —   |
-| SD-02 | iOS hosted URL loading           | Ready  | High     | NSL-02     | [plans/SD-02-ios-hosted-url.md](./plans/SD-02-ios-hosted-url.md)                     | —   |
-| SD-03 | WebView app hosting setup        | Ready  | High     | —          | [plans/SD-03-hosting-setup.md](./plans/SD-03-hosting-setup.md)                       | —   |
-| SD-04 | Android Maven publishing         | Ready  | Medium   | SD-01      | [plans/SD-04-android-maven-publishing.md](./plans/SD-04-android-maven-publishing.md) | —   |
-| SD-05 | iOS publishing (SPM + CocoaPods) | Ready  | Medium   | SD-02      | [plans/SD-05-ios-spm-publishing.md](./plans/SD-05-ios-spm-publishing.md)             | —   |
+| ID    | Title                             | Status | Priority | Depends On | Plan                                                                                 | PR  |
+| ----- | --------------------------------- | ------ | -------- | ---------- | ------------------------------------------------------------------------------------ | --- |
+| SD-01 | Android hosted URL loading        | Ready  | High     | NSL-01     | [plans/SD-01-android-hosted-url.md](./plans/SD-01-android-hosted-url.md)             | —   |
+| SD-02 | iOS hosted URL loading            | Ready  | High     | NSL-02     | [plans/SD-02-ios-hosted-url.md](./plans/SD-02-ios-hosted-url.md)                     | —   |
+| SD-03 | WebView app hosting setup         | Ready  | High     | —          | [plans/SD-03-hosting-setup.md](./plans/SD-03-hosting-setup.md)                       | —   |
+| SD-04 | Android Maven publishing          | Ready  | Medium   | SD-01      | [plans/SD-04-android-maven-publishing.md](./plans/SD-04-android-maven-publishing.md) | —   |
+| SD-05 | iOS publishing (SPM + CocoaPods)  | Ready  | Medium   | SD-02      | [plans/SD-05-ios-spm-publishing.md](./plans/SD-05-ios-spm-publishing.md)             | —   |
 | SD-06 | KMP remote publishing (Maven+SPM) | Ready  | Medium   | KR-03      | [plans/SD-06-kmp-remote-publishing.md](./plans/SD-06-kmp-remote-publishing.md)       | —   |
 
 Allowed statuses: `Ready`, `In Progress`, `Blocked`, `Deferred`, `Done`
@@ -105,11 +105,11 @@ Allowed statuses: `Ready`, `In Progress`, `Blocked`, `Deferred`, `Done`
 
 ## Related Specs
 
-| Spec                                                | Relationship                                             |
-| --------------------------------------------------- | -------------------------------------------------------- |
-| [SDK Overview](../../OVERVIEW.md)                   | Parent architecture                                      |
-| [Native Shells Lite](../native-shells-lite/SPEC.md) | Upstream — shells must exist before distribution changes |
-| [Build Pipeline](../build-pipeline/SPEC.md)         | Sibling — bundle script retained for local dev only      |
-| [WebView Spec](../webview/SPEC.md)                  | Upstream — produces the web app being hosted             |
-| [SDK Core Spec](../sdk-core/SPEC.md)                | Sibling — engine consumed by hosted web app              |
+| Spec                                                | Relationship                                                |
+| --------------------------------------------------- | ----------------------------------------------------------- |
+| [SDK Overview](../../OVERVIEW.md)                   | Parent architecture                                         |
+| [Native Shells Lite](../native-shells-lite/SPEC.md) | Upstream — shells must exist before distribution changes    |
+| [Build Pipeline](../build-pipeline/SPEC.md)         | Sibling — bundle script retained for local dev only         |
+| [WebView Spec](../webview/SPEC.md)                  | Upstream — produces the web app being hosted                |
+| [SDK Core Spec](../sdk-core/SPEC.md)                | Sibling — engine consumed by hosted web app                 |
 | [KMP Revival](../kmp-revival/SPEC.md)               | Upstream — KR-03 validates artifacts before SD-06 publishes |


### PR DESCRIPTION
## Summary

- Renames provider-agnostic Didit surface areas (hooks, services, integrations, utils) to generic `kyc` naming across the RN app and WebView, keeping Didit naming only where it directly wraps the vendor SDK
- Removes residual Sumsub references from Android manifests, Solidity comments, docs, and CLAUDE.md
- Updates error injection store, console log prefixes, and error messages to use `kyc` instead of `didit`/`Sumsub`

## Changes

### React Native app

- Renamed `app/src/integrations/didit/` → `kyc/` (service, types, index)
- Renamed `useDiditLauncher` → `useKycLauncher`, `useDiditWebSocket` → `useKycWebSocket`
- Updated all call sites: fallback screens, LogoConfirmationScreen, KycSuccessScreen, selfClientProvider, usePendingKycRecovery
- Renamed error injection keys from `didit_*` to `kyc_*` with updated labels and log prefixes

### WebView app

- Renamed `diditProvider.ts` → `kycProvider.ts`, `diditAttestation.ts` → `kycAttestation.ts`
- Updated ProviderLaunchScreen imports and container/fallback IDs
- Made session error messages provider-agnostic ("KYC session" instead of "Didit session")

### Common/shared

- Updated `PendingKycStatus` comments in `common/src/utils/types.ts` from "didit" to "KYC"

### Contracts

- Updated AttestationId.sol comments to remove Sumsub reference

### Docs/config

- Updated Android manifests (debug + main) to say "KYC SDK" instead of "Sumsub SDK"
- Updated `CLAUDE.md` and `spec-from-audit/SKILL.md` example file paths
- Updated `purple/` docs and `tech-debt-baseline.json` to reflect Didit provider
- Updated navigation test comment

## Linear Issues

- Closes [SELF-2585](https://linear.app/selfprotocol/issue/SELF-2585/remove-all-sumsub-references-and-abstract-didit-to-generic-kyc-naming) — Remove all Sumsub references & abstract Didit to generic KYC naming

## Test Plan

- [x] `cd app && yarn types`
- [x] `cd packages/webview-app && yarn build`
- [x] `cd packages/mobile-sdk-alpha && yarn test`
- [x] Targeted tests pass: `usePendingKycRecovery.test.ts`, `KycSuccessScreen.test.tsx`
- [ ] Verify no remaining generic `didit` references outside vendor-specific code: `rg -i '\bdidit\b' --type-not lock -g '*.{ts,tsx}' | grep -v '@didit-protocol\|verify\.didit\.me\|DIDIT_HOST\|DIDIT_TEE_URL\|DiditSdk\|provider.*didit\|didit-tee'`

### Native Consolidation Checklist

- [ ] CONTRACTS.md reviewed - no unintended contract changes
- [ ] Layer 1 bridge contract tests pass (`cd app && yarn jest:run` / `yarn workspace @selfxyz/rn-sdk-test-app test`)
- [ ] Layer 3 builds pass (app iOS, RN test app iOS, RN test app Android)
- [ ] Layer 4 manual smoke test signed off (if consolidation PR)
- [ ] No new native business logic added (logic belongs in TypeScript)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated KYC provider references and authentication docs to reflect the new KYC provider naming.

* **Chores**
  * Switched verification integration and test/config wiring from the previous provider to the KYC integration.
  * Updated runtime labels and error injection options to reference KYC, and adjusted related test mocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->