### PR TITLE
Fix Android AD_ID permission blocking Play Store upload

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -21,6 +21,8 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <!-- Remove FOREGROUND_SERVICE_MICROPHONE merged in by the KYC SDK (VideoIdent is disabled) -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" tools:node="remove" />
+    <!-- Remove AD_ID merged in by Google Play Services/Firebase — app does not use advertising ID -->
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove" />
 
     <application
       android:name=".MainApplication"


### PR DESCRIPTION
## Summary

- Remove the `com.google.android.gms.permission.AD_ID` permission that Google Play Services/Firebase merges into the Android manifest transitively
- The Play Store rejected uploads because the app declares it doesn't use advertising ID, but the merged manifest included the permission

## Changes

### React Native app

- Added `tools:node="remove"` for `com.google.android.gms.permission.AD_ID` in `AndroidManifest.xml`, matching the existing pattern used for `FOREGROUND_SERVICE_MICROPHONE`

## Test Plan

- [ ] `yarn lint && yarn types` passes
- [ ] Android build completes successfully (`cd app && npx react-native build-android --mode=release` or Fastlane)
- [ ] Play Store upload no longer rejected for AD_ID permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed advertising ID permission declaration to reflect that the app does not utilize advertising identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->