### PR TITLE
hide ios google client id for now

### DIFF
--- a/app/ios/OpenPassport/Info.plist
+++ b/app/ios/OpenPassport/Info.plist
@@ -31,10 +31,8 @@
 			<array>
 				<string>proofofpassport</string>
 				<string>com.warroom.proofofpassport</string>
-				<!-- TODO: Replace with reversed iOS client ID from Google Cloud Console -->
-				<!-- Format: com.googleusercontent.apps.YOUR-IOS-CLIENT-ID -->
-				<!-- See: app/.env for instructions on creating the iOS client ID -->
-				<string>com.googleusercontent.apps.YOUR_CLIENT_ID</string>
+				<!-- TODO: Uncomment when social logins ship — replace with reversed iOS client ID -->
+				<!-- <string>com.googleusercontent.apps.YOUR_CLIENT_ID</string> -->
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
## Summary

<!-- Brief description of changes -->

## Test plan

<!-- How was this tested? -->

---

### Native Consolidation Checklist

<!-- Check items that apply to this PR. Delete section if not touching native code. -->

- [ ] CONTRACTS.md reviewed - no unintended contract changes
- [ ] Layer 1 bridge contract tests pass (`cd app && yarn jest:run` / `yarn workspace @selfxyz/rn-sdk-test-app test`)
- [ ] Layer 3 builds pass (app iOS, RN test app iOS, RN test app Android)
- [ ] Layer 4 manual smoke test signed off (if consolidation PR)
- [ ] No new native business logic added (logic belongs in TypeScript)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Temporarily disabled Google authentication configuration entry in the iOS app settings. The entry will be re-enabled when social login functionality is released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->