### PR TITLE
Fix navigation in disclose result related screens

### DIFF
--- a/packages/webview-app/src/screens/tunnel/TunnelProofReceiptScreen.tsx
+++ b/packages/webview-app/src/screens/tunnel/TunnelProofReceiptScreen.tsx
@@ -21,14 +21,6 @@ export const TunnelProofReceiptScreen: React.FC = () => {
   const { backPath = '/tunnel/proof/result', backState } =
     (location.state as { backPath?: string; backState?: Record<string, unknown> } | null) ?? {};
 
-  const showConfirm = backPath !== '/tunnel/proof/result' || backState?.success === true;
-
-  const onConfirm = useCallback(() => {
-    haptic.trigger('selection');
-    analytics.trackEvent('tunnel_proof_receipt_confirmed');
-    navigate('/tunnel/proof/disclose');
-  }, [navigate, haptic, analytics]);
-
   const proofItems = useMemo(() => {
     if (displayLabels && displayLabels.length > 0) {
       return displayLabels.map(label => ({ label }));
@@ -49,7 +41,6 @@ export const TunnelProofReceiptScreen: React.FC = () => {
       {...WEB_SAFE_AREA}
       variant="default"
       onClose={onClose}
-      onConfirm={showConfirm ? onConfirm : undefined}
       appIcon={<SelfLogo size={40} />}
       appName={appName}
       appEndpoint={appEndpoint}

--- a/packages/webview-app/src/screens/tunnel/TunnelResultScreen.tsx
+++ b/packages/webview-app/src/screens/tunnel/TunnelResultScreen.tsx
@@ -78,8 +78,10 @@ export const TunnelResultScreen: React.FC = () => {
         success: false,
         userId: request.userId,
         verificationId,
-        errorCode: 'VERIFICATION_FAILED',
-        errorMessage: error ?? 'Verification failed',
+        error: {
+          code: 'VERIFICATION_FAILED',
+          message: error ?? 'Verification failed',
+        },
       };
       await lifecycle.setResult(result);
       analytics.trackEvent('tunnel_result_cancelled', { source });
@@ -88,6 +90,7 @@ export const TunnelResultScreen: React.FC = () => {
       analytics.trackEvent('tunnel_result_cancel_failed', {
         error: err instanceof Error ? err.message : 'Failed to send cancel result',
       });
+      lifecycle.dismiss();
     }
   }, [request.userId, verificationId, error, lifecycle, analytics, source]);
 

--- a/packages/webview-app/src/screens/tunnel/TunnelResultScreen.tsx
+++ b/packages/webview-app/src/screens/tunnel/TunnelResultScreen.tsx
@@ -31,18 +31,6 @@ const getTunnelBackPath = (source: TunnelResultState['source']): string => {
   }
 };
 
-const getTunnelClosePath = (source: TunnelResultState['source']): string => {
-  switch (source) {
-    case 'disclose':
-      return '/tunnel/proof/disclose';
-    case 'kyc':
-      return '/tunnel/kyc';
-    case 'proving':
-    default:
-      return '/tunnel/tour/4';
-  }
-};
-
 export const TunnelResultScreen: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
@@ -84,9 +72,24 @@ export const TunnelResultScreen: React.FC = () => {
     });
   }, [location.pathname, location.state, navigate]);
 
-  const onCancel = useCallback(() => {
-    navigate(getTunnelClosePath(source), { replace: true });
-  }, [navigate, source]);
+  const onCancel = useCallback(async () => {
+    try {
+      const result: VerificationResult = {
+        success: false,
+        userId: request.userId,
+        verificationId,
+        errorCode: 'VERIFICATION_FAILED',
+        errorMessage: error ?? 'Verification failed',
+      };
+      await lifecycle.setResult(result);
+      analytics.trackEvent('tunnel_result_cancelled', { source });
+      lifecycle.dismiss();
+    } catch (err) {
+      analytics.trackEvent('tunnel_result_cancel_failed', {
+        error: err instanceof Error ? err.message : 'Failed to send cancel result',
+      });
+    }
+  }, [request.userId, verificationId, error, lifecycle, analytics, source]);
 
   if (success) {
     return (


### PR DESCRIPTION
## Summary

<!-- Brief description of changes -->

## Test plan

<!-- How was this tested? -->

---

### Native Consolidation Checklist

<!-- Check items that apply to this PR. Delete section if not touching native code. -->

- [ ] CONTRACTS.md reviewed - no unintended contract changes
- [ ] Layer 1 bridge contract tests pass (`cd app && yarn jest:run` / `yarn workspace @selfxyz/rn-sdk-test-app test`)
- [ ] Layer 3 builds pass (app iOS, RN test app iOS, RN test app Android)
- [ ] Layer 4 manual smoke test signed off (if consolidation PR)
- [ ] No new native business logic added (logic belongs in TypeScript)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a redundant confirmation step from the proof receipt flow, simplifying user interactions.
  * Improved the cancellation flow for verification: cancellations now reliably report a failed result, provide clearer error messaging, and always close the workflow.
  * Enhanced analytics and error tracking around cancellation to aid troubleshooting without changing user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->