### PR TITLE
Add tap-through demo mode for tunnel verification flow

### DIFF
--- a/packages/webview-app/src/App.tsx
+++ b/packages/webview-app/src/App.tsx
@@ -55,6 +55,7 @@ import { TunnelCountryPickerScreen } from './screens/tunnel/TunnelCountryPickerS
 import { TunnelDiscloseScreen } from './screens/tunnel/TunnelDiscloseScreen';
 import { TunnelIDTypeScreen } from './screens/tunnel/TunnelIDTypeScreen';
 import { TunnelKycFailureScreen } from './screens/tunnel/TunnelKycFailureScreen';
+import { TunnelKycPendingScreen } from './screens/tunnel/TunnelKycPendingScreen';
 import { TunnelKycSuccessScreen } from './screens/tunnel/TunnelKycSuccessScreen';
 import { TunnelKycWrapper } from './screens/tunnel/TunnelKycWrapper';
 import { TunnelProofReceiptScreen } from './screens/tunnel/TunnelProofReceiptScreen';
@@ -112,6 +113,7 @@ export const App: React.FC = () => (
             <Route path="/coming-soon" element={<ComingSoonScreen />} />
             <Route path="/tunnel/tour/:step" element={<TunnelTourScreen />} />
             <Route path="/tunnel/kyc" element={<TunnelKycWrapper />} />
+            <Route path="/tunnel/kyc-pending" element={<TunnelKycPendingScreen />} />
             <Route path="/tunnel/kyc-failure" element={<TunnelKycFailureScreen />} />
             <Route path="/tunnel/kyc-success" element={<TunnelKycSuccessScreen />} />
             <Route path="/tunnel/registration/country" element={<TunnelCountryPickerScreen />} />

--- a/packages/webview-app/src/App.tsx
+++ b/packages/webview-app/src/App.tsx
@@ -113,7 +113,7 @@ export const App: React.FC = () => (
             <Route path="/coming-soon" element={<ComingSoonScreen />} />
             <Route path="/tunnel/tour/:step" element={<TunnelTourScreen />} />
             <Route path="/tunnel/kyc" element={<TunnelKycWrapper />} />
-            <Route path="/tunnel/kyc-pending" element={<TunnelKycPendingScreen />} />
+            {import.meta.env.DEV && <Route path="/tunnel/kyc-pending" element={<TunnelKycPendingScreen />} />}
             <Route path="/tunnel/kyc-failure" element={<TunnelKycFailureScreen />} />
             <Route path="/tunnel/kyc-success" element={<TunnelKycSuccessScreen />} />
             <Route path="/tunnel/registration/country" element={<TunnelCountryPickerScreen />} />

--- a/packages/webview-app/src/screens/onboarding/ProviderLaunchScreen.tsx
+++ b/packages/webview-app/src/screens/onboarding/ProviderLaunchScreen.tsx
@@ -127,7 +127,7 @@ export const ProviderLaunchScreen: React.FC = () => {
     let cancelled = false;
     const controller = new AbortController();
 
-    if (environment !== 'prod') {
+    if (environment !== 'prod' && !defaultNextPath.includes('mock=demo')) {
       (async () => {
         try {
           setPhase('waiting');

--- a/packages/webview-app/src/screens/onboarding/ProviderLaunchScreen.tsx
+++ b/packages/webview-app/src/screens/onboarding/ProviderLaunchScreen.tsx
@@ -306,12 +306,12 @@ export const ProviderLaunchScreen: React.FC = () => {
       {phase === 'waiting' && (
         <div
           style={{
-            position: 'absolute',
-            inset: 0,
-            zIndex: 1,
-            overflow: 'hidden',
+            width: '100vw',
+            height: '100vh',
             display: 'flex',
             flexDirection: 'column',
+            position: 'relative',
+            overflow: 'hidden',
           }}
         >
           <KycPendingScreen

--- a/packages/webview-app/src/screens/onboarding/ProviderResultScreen.tsx
+++ b/packages/webview-app/src/screens/onboarding/ProviderResultScreen.tsx
@@ -22,9 +22,15 @@ export const ProviderResultScreen: React.FC = () => {
   const state =
     (location.state as ({ providerResult?: KycProviderResult } & MockOnboardingNavigationState) | null) ?? null;
 
-  const providerResult = state?.providerResult ?? createMockProviderResult({ outcome: mockOutcome });
+  const providerResult =
+    state?.providerResult ?? (import.meta.env.DEV ? createMockProviderResult({ outcome: mockOutcome }) : undefined);
 
   useEffect(() => {
+    if (!providerResult) {
+      navigate('/', { replace: true });
+      return;
+    }
+
     haptic.trigger('selection');
     analytics.trackEvent('provider_result_received', {
       status: providerResult.status,
@@ -79,8 +85,8 @@ export const ProviderResultScreen: React.FC = () => {
     lifecycle,
     mockOutcome,
     navigate,
-    providerResult.error?.retryable,
-    providerResult.status,
+    providerResult?.error?.retryable,
+    providerResult?.status,
     state?.countryCode,
     state?.documentType,
   ]);

--- a/packages/webview-app/src/screens/tunnel/TunnelDiscloseScreen.tsx
+++ b/packages/webview-app/src/screens/tunnel/TunnelDiscloseScreen.tsx
@@ -4,7 +4,7 @@
 
 import type React from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import type { ProofGenerationStep } from '@selfxyz/euclid';
 import { ProofProgressScreen, SelfLogo } from '@selfxyz/euclid';
@@ -14,7 +14,53 @@ import { useProvingStore } from '@selfxyz/mobile-sdk-alpha/browser';
 import { useSelfClient } from '../../providers/SelfClientProvider';
 import { useVerificationRequest } from '../../providers/VerificationRequestProvider';
 import { WEB_SAFE_AREA } from '../../utils/insets';
+import { isDemoMode } from '../../utils/mockOnboardingFlow';
 import { initSelfAppFromRequest } from '../../utils/selfAppContext';
+
+const DEMO_DISCLOSE_STEPS: ProofGenerationStep[] = [
+  'readingRegistry',
+  'generatingProof',
+  'awaitingVerification',
+  'finishingUp',
+];
+
+const DemoTunnelDiscloseScreen: React.FC<{ search: string }> = ({ search }) => {
+  const navigate = useNavigate();
+  const { appName, appEndpoint, timestamp } = useVerificationRequest();
+  const [stepIndex, setStepIndex] = useState(0);
+
+  const advance = useCallback(() => {
+    if (stepIndex < DEMO_DISCLOSE_STEPS.length - 1) {
+      setStepIndex(i => i + 1);
+    } else {
+      navigate(`/tunnel/proof/result${search}`, { replace: true, state: { success: true } });
+    }
+  }, [stepIndex, navigate, search]);
+
+  return (
+    <div
+      style={{
+        width: '100vw',
+        height: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        position: 'relative',
+        overflow: 'hidden',
+      }}
+    >
+      <ProofProgressScreen
+        {...WEB_SAFE_AREA}
+        appIcon={<SelfLogo size={40} />}
+        appName={appName}
+        appEndpoint={appEndpoint}
+        documentType="passport"
+        timestamp={timestamp}
+        step={DEMO_DISCLOSE_STEPS[stepIndex]}
+      />
+      <div onClick={advance} style={{ position: 'absolute', inset: 0, zIndex: 1, cursor: 'pointer' }} />
+    </div>
+  );
+};
 
 const MAX_DISCLOSE_RETRIES = 3;
 const DISCLOSE_RETRY_DELAY_MS = 3000;
@@ -43,7 +89,12 @@ function mapDiscloseStateToStep(state: ProvingStateType | null): ProofGeneration
 }
 
 export const TunnelDiscloseScreen: React.FC = () => {
+  const location = useLocation();
   const navigate = useNavigate();
+
+  if (isDemoMode(location.search)) {
+    return <DemoTunnelDiscloseScreen search={location.search} />;
+  }
   const { client, analytics, haptic } = useSelfClient();
   const verificationCtx = useVerificationRequest();
   const { appName, appEndpoint, timestamp } = verificationCtx;

--- a/packages/webview-app/src/screens/tunnel/TunnelDiscloseScreen.tsx
+++ b/packages/webview-app/src/screens/tunnel/TunnelDiscloseScreen.tsx
@@ -88,13 +88,8 @@ function mapDiscloseStateToStep(state: ProvingStateType | null): ProofGeneration
   }
 }
 
-export const TunnelDiscloseScreen: React.FC = () => {
-  const location = useLocation();
+const StandardTunnelDiscloseScreen: React.FC = () => {
   const navigate = useNavigate();
-
-  if (isDemoMode(location.search)) {
-    return <DemoTunnelDiscloseScreen search={location.search} />;
-  }
   const { client, analytics, haptic } = useSelfClient();
   const verificationCtx = useVerificationRequest();
   const { appName, appEndpoint, timestamp } = verificationCtx;
@@ -201,4 +196,14 @@ export const TunnelDiscloseScreen: React.FC = () => {
       step={mapDiscloseStateToStep(currentState)}
     />
   );
+};
+
+export const TunnelDiscloseScreen: React.FC = () => {
+  const location = useLocation();
+
+  if (isDemoMode(location.search)) {
+    return <DemoTunnelDiscloseScreen search={location.search} />;
+  }
+
+  return <StandardTunnelDiscloseScreen />;
 };

--- a/packages/webview-app/src/screens/tunnel/TunnelKycPendingScreen.tsx
+++ b/packages/webview-app/src/screens/tunnel/TunnelKycPendingScreen.tsx
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import type React from 'react';
+import { useCallback } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+import { KycPendingScreen } from '@selfxyz/euclid';
+
+import { WEB_SAFE_AREA } from '../../utils/insets';
+import { createMockProviderResult } from '../../utils/mockOnboardingFlow';
+
+export const TunnelKycPendingScreen: React.FC = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const handleTap = useCallback(() => {
+    navigate(`/tunnel/kyc-success${location.search}`, {
+      state: { providerResult: createMockProviderResult({ outcome: 'demo' }) },
+    });
+  }, [navigate, location.search]);
+
+  return (
+    <div
+      style={{
+        width: '100vw',
+        height: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        position: 'relative',
+        overflow: 'hidden',
+      }}
+    >
+      <KycPendingScreen insets={WEB_SAFE_AREA.insets} onCheckBackLater={() => {}} onReceiveLiveUpdates={() => {}} />
+      <div onClick={handleTap} style={{ position: 'absolute', inset: 0, zIndex: 1, cursor: 'pointer' }} />
+    </div>
+  );
+};

--- a/packages/webview-app/src/screens/tunnel/TunnelKycSuccessScreen.tsx
+++ b/packages/webview-app/src/screens/tunnel/TunnelKycSuccessScreen.tsx
@@ -11,6 +11,7 @@ import { KycVerificationSuccessScreen } from '@selfxyz/euclid';
 import { useSelfClient } from '../../providers/SelfClientProvider';
 import type { KycProviderResult } from '../../types/kycProvider';
 import { WEB_SAFE_AREA } from '../../utils/insets';
+import { isDemoMode } from '../../utils/mockOnboardingFlow';
 
 export const TunnelKycSuccessScreen: React.FC = () => {
   const navigate = useNavigate();
@@ -20,8 +21,10 @@ export const TunnelKycSuccessScreen: React.FC = () => {
   const state = location.state as { providerResult?: KycProviderResult } | null;
   const providerResult = state?.providerResult;
 
+  const demo = isDemoMode(location.search);
+
   useEffect(() => {
-    if (!providerResult) return;
+    if (demo || !providerResult) return;
 
     if (providerResult.status === 'cancel') {
       navigate('/tunnel/tour/4', { replace: true });
@@ -36,13 +39,13 @@ export const TunnelKycSuccessScreen: React.FC = () => {
       }
       return;
     }
-  }, [providerResult, navigate]);
+  }, [demo, providerResult, navigate]);
 
   const onGenerateProof = useCallback(() => {
     haptic.trigger('success');
     analytics.trackEvent('tunnel_kyc_success_generate_proof');
-    navigate('/tunnel/proof/generating');
-  }, [navigate, haptic, analytics]);
+    navigate(`/tunnel/proof/generating${location.search}`);
+  }, [navigate, location.search, haptic, analytics]);
 
   return <KycVerificationSuccessScreen insets={WEB_SAFE_AREA.insets} onGenerateProof={onGenerateProof} />;
 };

--- a/packages/webview-app/src/screens/tunnel/TunnelKycWrapper.tsx
+++ b/packages/webview-app/src/screens/tunnel/TunnelKycWrapper.tsx
@@ -5,7 +5,7 @@
 import type React from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 
-import { createMockProviderResult, getMockOutcomeFromSearch } from '../../utils/mockOnboardingFlow';
+import { createMockProviderResult, getMockOutcomeFromSearch, isDemoMode } from '../../utils/mockOnboardingFlow';
 
 /**
  * Redirects `/tunnel/kyc` to `ProviderLaunchScreen` at `/onboarding/provider`
@@ -18,6 +18,21 @@ export const TunnelKycWrapper: React.FC = () => {
   const location = useLocation();
   const incomingState = (location.state as Record<string, unknown>) ?? {};
   const mockOutcome = getMockOutcomeFromSearch(location.search);
+
+  if (isDemoMode(location.search)) {
+    const pendingPath = `/tunnel/kyc-pending${location.search}`;
+    return (
+      <Navigate
+        to="/onboarding/provider"
+        replace
+        state={{
+          ...incomingState,
+          backPath: pendingPath,
+          nextPath: pendingPath,
+        }}
+      />
+    );
+  }
 
   if (import.meta.env.DEV && location.search.includes('mock=')) {
     return (

--- a/packages/webview-app/src/screens/tunnel/TunnelProofReceiptScreen.tsx
+++ b/packages/webview-app/src/screens/tunnel/TunnelProofReceiptScreen.tsx
@@ -21,14 +21,6 @@ export const TunnelProofReceiptScreen: React.FC = () => {
   const { backPath = '/tunnel/proof/result', backState } =
     (location.state as { backPath?: string; backState?: Record<string, unknown> } | null) ?? {};
 
-  const showConfirm = backPath !== '/tunnel/proof/result' || backState?.success === true;
-
-  const onConfirm = useCallback(() => {
-    haptic.trigger('selection');
-    analytics.trackEvent('tunnel_proof_receipt_confirmed');
-    navigate('/tunnel/proof/disclose');
-  }, [navigate, haptic, analytics]);
-
   const proofItems = useMemo(() => {
     if (displayLabels && displayLabels.length > 0) {
       return displayLabels.map(label => ({ label }));
@@ -49,7 +41,6 @@ export const TunnelProofReceiptScreen: React.FC = () => {
       {...WEB_SAFE_AREA}
       variant="default"
       onClose={onClose}
-      onConfirm={showConfirm ? onConfirm : undefined}
       appIcon={<SelfLogo size={40} />}
       appName={appName}
       appEndpoint={appEndpoint}

--- a/packages/webview-app/src/screens/tunnel/TunnelProvingScreen.tsx
+++ b/packages/webview-app/src/screens/tunnel/TunnelProvingScreen.tsx
@@ -74,13 +74,8 @@ function mapProvingStateToStep(state: ProvingStateType | null, phase: Phase): Pr
   }
 }
 
-export const TunnelProvingScreen: React.FC = () => {
-  const location = useLocation();
+const StandardTunnelProvingScreen: React.FC = () => {
   const navigate = useNavigate();
-
-  if (isDemoMode(location.search)) {
-    return <DemoTunnelProvingScreen search={location.search} />;
-  }
   const { client, analytics, haptic } = useSelfClient();
   const verificationCtx = useVerificationRequest();
   const currentState = useProvingStore(s => s.currentState);
@@ -156,4 +151,14 @@ export const TunnelProvingScreen: React.FC = () => {
       idCardProps={getIdCardProps(passportData?.documentCategory)}
     />
   );
+};
+
+export const TunnelProvingScreen: React.FC = () => {
+  const location = useLocation();
+
+  if (isDemoMode(location.search)) {
+    return <DemoTunnelProvingScreen search={location.search} />;
+  }
+
+  return <StandardTunnelProvingScreen />;
 };

--- a/packages/webview-app/src/screens/tunnel/TunnelProvingScreen.tsx
+++ b/packages/webview-app/src/screens/tunnel/TunnelProvingScreen.tsx
@@ -4,7 +4,7 @@
 
 import type React from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import type { ProofGenerationStep } from '@selfxyz/euclid';
 import { ProofGenerationScreen } from '@selfxyz/euclid';
@@ -14,8 +14,40 @@ import { loadSelectedDocument, useProvingStore } from '@selfxyz/mobile-sdk-alpha
 import { useSelfClient } from '../../providers/SelfClientProvider';
 import { useVerificationRequest } from '../../providers/VerificationRequestProvider';
 import { WEB_SAFE_AREA } from '../../utils/insets';
+import { isDemoMode } from '../../utils/mockOnboardingFlow';
 import { getIdCardProps } from '../../utils/provingUtils';
 import { initSelfAppFromRequest } from '../../utils/selfAppContext';
+
+const DEMO_PROVING_STEPS: ProofGenerationStep[] = ['readingRegistry', 'generatingProof'];
+
+const DemoTunnelProvingScreen: React.FC<{ search: string }> = ({ search }) => {
+  const navigate = useNavigate();
+  const [stepIndex, setStepIndex] = useState(0);
+
+  const advance = useCallback(() => {
+    if (stepIndex < DEMO_PROVING_STEPS.length - 1) {
+      setStepIndex(i => i + 1);
+    } else {
+      navigate(`/tunnel/proof/disclose${search}`, { replace: true });
+    }
+  }, [stepIndex, navigate, search]);
+
+  return (
+    <div
+      style={{
+        width: '100vw',
+        height: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        position: 'relative',
+        overflow: 'hidden',
+      }}
+    >
+      <ProofGenerationScreen {...WEB_SAFE_AREA} step={DEMO_PROVING_STEPS[stepIndex]} />
+      <div onClick={advance} style={{ position: 'absolute', inset: 0, zIndex: 1, cursor: 'pointer' }} />
+    </div>
+  );
+};
 
 type Phase = 'dsc' | 'register';
 
@@ -43,7 +75,12 @@ function mapProvingStateToStep(state: ProvingStateType | null, phase: Phase): Pr
 }
 
 export const TunnelProvingScreen: React.FC = () => {
+  const location = useLocation();
   const navigate = useNavigate();
+
+  if (isDemoMode(location.search)) {
+    return <DemoTunnelProvingScreen search={location.search} />;
+  }
   const { client, analytics, haptic } = useSelfClient();
   const verificationCtx = useVerificationRequest();
   const currentState = useProvingStore(s => s.currentState);

--- a/packages/webview-app/src/screens/tunnel/TunnelResultScreen.tsx
+++ b/packages/webview-app/src/screens/tunnel/TunnelResultScreen.tsx
@@ -78,8 +78,10 @@ export const TunnelResultScreen: React.FC = () => {
         success: false,
         userId: request.userId,
         verificationId,
-        errorCode: 'VERIFICATION_FAILED',
-        errorMessage: error ?? 'Verification failed',
+        error: {
+          code: 'VERIFICATION_FAILED',
+          message: error ?? 'Verification failed',
+        },
       };
       await lifecycle.setResult(result);
       analytics.trackEvent('tunnel_result_cancelled', { source });
@@ -88,6 +90,7 @@ export const TunnelResultScreen: React.FC = () => {
       analytics.trackEvent('tunnel_result_cancel_failed', {
         error: err instanceof Error ? err.message : 'Failed to send cancel result',
       });
+      lifecycle.dismiss();
     }
   }, [request.userId, verificationId, error, lifecycle, analytics, source]);
 

--- a/packages/webview-app/src/screens/tunnel/TunnelResultScreen.tsx
+++ b/packages/webview-app/src/screens/tunnel/TunnelResultScreen.tsx
@@ -31,18 +31,6 @@ const getTunnelBackPath = (source: TunnelResultState['source']): string => {
   }
 };
 
-const getTunnelClosePath = (source: TunnelResultState['source']): string => {
-  switch (source) {
-    case 'disclose':
-      return '/tunnel/proof/disclose';
-    case 'kyc':
-      return '/tunnel/kyc';
-    case 'proving':
-    default:
-      return '/tunnel/tour/4';
-  }
-};
-
 export const TunnelResultScreen: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
@@ -84,9 +72,24 @@ export const TunnelResultScreen: React.FC = () => {
     });
   }, [location.pathname, location.state, navigate]);
 
-  const onCancel = useCallback(() => {
-    navigate(getTunnelClosePath(source), { replace: true });
-  }, [navigate, source]);
+  const onCancel = useCallback(async () => {
+    try {
+      const result: VerificationResult = {
+        success: false,
+        userId: request.userId,
+        verificationId,
+        errorCode: 'VERIFICATION_FAILED',
+        errorMessage: error ?? 'Verification failed',
+      };
+      await lifecycle.setResult(result);
+      analytics.trackEvent('tunnel_result_cancelled', { source });
+      lifecycle.dismiss();
+    } catch (err) {
+      analytics.trackEvent('tunnel_result_cancel_failed', {
+        error: err instanceof Error ? err.message : 'Failed to send cancel result',
+      });
+    }
+  }, [request.userId, verificationId, error, lifecycle, analytics, source]);
 
   if (success) {
     return (

--- a/packages/webview-app/src/screens/tunnel/TunnelResultScreen.tsx
+++ b/packages/webview-app/src/screens/tunnel/TunnelResultScreen.tsx
@@ -12,6 +12,7 @@ import type { VerificationResult } from '@selfxyz/webview-bridge';
 import { useSelfClient } from '../../providers/SelfClientProvider';
 import { useVerificationRequest } from '../../providers/VerificationRequestProvider';
 import { WEB_SAFE_AREA } from '../../utils/insets';
+import { isDemoMode } from '../../utils/mockOnboardingFlow';
 
 interface TunnelResultState {
   success?: boolean;
@@ -44,7 +45,22 @@ export const TunnelResultScreen: React.FC = () => {
     analytics.trackEvent('tunnel_result_failure', { error });
   }, [success, error, analytics]);
 
+  const demo = isDemoMode(location.search);
+
   const onContinue = useCallback(async () => {
+    if (demo) {
+      const demoResult: VerificationResult = {
+        success: true,
+        userId: request.userId,
+        verificationId,
+        claims: { resultType: 'proofRequested' },
+      };
+      await lifecycle.setResult(demoResult);
+      analytics.trackEvent('tunnel_result_success');
+      lifecycle.dismiss();
+      return;
+    }
+
     try {
       const result: VerificationResult = {
         success: true,
@@ -60,7 +76,7 @@ export const TunnelResultScreen: React.FC = () => {
         error: err instanceof Error ? err.message : 'Failed to send result',
       });
     }
-  }, [request.userId, verificationId, lifecycle, analytics]);
+  }, [demo, request.userId, verificationId, lifecycle, analytics]);
 
   const onRetry = useCallback(() => {
     navigate(getTunnelBackPath(source), { replace: true });

--- a/packages/webview-app/src/utils/mockOnboardingFlow.ts
+++ b/packages/webview-app/src/utils/mockOnboardingFlow.ts
@@ -11,7 +11,7 @@ export interface MockOnboardingNavigationState {
   nextPath?: string;
 }
 
-export type MockRegistrationOutcome = 'success' | 'kyc-failure' | 'registration-failure' | 'cancel';
+export type MockRegistrationOutcome = 'success' | 'kyc-failure' | 'registration-failure' | 'cancel' | 'demo';
 export type PromptMockState = 'default' | 'existing-account';
 
 const DEFAULT_OUTCOME: MockRegistrationOutcome = 'success';
@@ -71,6 +71,13 @@ export const createMockProviderResult = ({
           retryable: true,
         },
       };
+    case 'demo':
+      return {
+        status: 'success',
+        verificationId: resolvedVerificationId,
+        provider: 'mock-provider',
+        completedAt: new Date().toISOString(),
+      };
   }
 };
 
@@ -86,6 +93,7 @@ export const getMockOutcomeFromSearch = (search: string): MockRegistrationOutcom
     case 'kyc-failure':
     case 'registration-failure':
     case 'cancel':
+    case 'demo':
       return value;
     default:
       return DEFAULT_OUTCOME;
@@ -116,3 +124,6 @@ export const getPromptMockSearch = (mock: PromptMockState = DEFAULT_PROMPT_MOCK)
 
 export const getProviderPath = (outcome: MockRegistrationOutcome): string =>
   `/onboarding/provider${getMockOutcomeSearch(outcome)}`;
+
+export const isDemoMode = (search: string): boolean =>
+  MOCKS_ENABLED && new URLSearchParams(search).get('mock') === 'demo';

--- a/packages/webview-app/src/utils/mockOnboardingFlow.ts
+++ b/packages/webview-app/src/utils/mockOnboardingFlow.ts
@@ -25,6 +25,10 @@ export const createMockProviderResult = ({
   outcome: MockRegistrationOutcome;
   verificationId?: string;
 }): KycProviderResult => {
+  if (!MOCKS_ENABLED) {
+    return { status: 'success', verificationId: '', provider: '', completedAt: new Date().toISOString() };
+  }
+
   const resolvedVerificationId = verificationId ?? 'mock-verification';
 
   switch (outcome) {

--- a/packages/webview-app/src/utils/mockOnboardingFlow.ts
+++ b/packages/webview-app/src/utils/mockOnboardingFlow.ts
@@ -26,7 +26,7 @@ export const createMockProviderResult = ({
   verificationId?: string;
 }): KycProviderResult => {
   if (!MOCKS_ENABLED) {
-    return { status: 'success', verificationId: '', provider: '', completedAt: new Date().toISOString() };
+    throw new Error('createMockProviderResult must not be called outside dev mode');
   }
 
   const resolvedVerificationId = verificationId ?? 'mock-verification';


### PR DESCRIPTION
## Summary

- Add a `mock=demo` query parameter that enables a tap-to-advance demo mode through the full tunnel verification flow (KYC pending → success → proving → disclose → result)
- Demo screens simulate each step with click-to-advance overlays, letting stakeholders walk through the flow without real NFC/KYC
- Fix `onCancel` in TunnelResultScreen to properly send a failure result and dismiss instead of navigating to an internal route
- Guard ProviderResultScreen against missing provider result in production by redirecting to home

## Changes

### WebView App

- New `TunnelKycPendingScreen` with tap-to-advance demo behavior
- New `DemoTunnelProvingScreen` and `DemoTunnelDiscloseScreen` inline components for demo mode
- `TunnelKycWrapper` routes demo mode through the pending screen
- `TunnelKycSuccessScreen` preserves query string and skips redirect logic in demo mode
- `TunnelResultScreen` sends proper `VerificationResult` on cancel (dismiss instead of internal nav)
- `TunnelProofReceiptScreen` removes unused `onConfirm` prop wiring
- `ProviderResultScreen` guards against undefined `providerResult` in production
- `ProviderLaunchScreen` skips auto-mock when demo mode is active; fixes overlay layout

### Utils

- `mockOnboardingFlow.ts` adds `demo` outcome, `isDemoMode()` helper, and dev-only guard on `createMockProviderResult`

## Test Plan

- [ ] `cd packages/webview-app && yarn build` passes
- [ ] `yarn lint && yarn types` passes
- [ ] Navigate to tunnel flow with `?mock=demo` — tap through KYC pending → success → proving → disclose → result
- [ ] Cancel on result screen dismisses the SDK (sends failure result)
- [ ] Normal (non-demo) tunnel flow still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a KYC pending screen and demo-mode flows for proving, disclose, and success with click-to-advance interactions.

* **Improvements**
  * Demo-mode detection and routing applied consistently across tunnel and onboarding flows; query strings and demo state are preserved during navigation.
  * Provider result handling now avoids proceeding when results are absent.

* **Bug Fixes**
  * Mock flow generation respects environment and query flags; fixed overlay positioning and adjusted cancel/confirm behaviors to avoid unintended side effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->