### PR TITLE
[SELF-2633] bugfix: add revealed data view for KYC ID cards

### DIFF
--- a/app/src/components/homescreen/KycIdCard.tsx
+++ b/app/src/components/homescreen/KycIdCard.tsx
@@ -4,22 +4,34 @@
 
 import type { FC } from 'react';
 import React from 'react';
-import { Image } from 'react-native';
-import { YStack } from 'tamagui';
+import { Dimensions, Image } from 'react-native';
+import { Separator, Text, XStack, YStack } from 'tamagui';
 
 import { deserializeApplicantInfo } from '@selfxyz/common';
 import { commonNames } from '@selfxyz/common/constants/countries';
 import type { KycData } from '@selfxyz/common/utils/types';
 import { RoundFlag } from '@selfxyz/mobile-sdk-alpha/components';
-import { black, white } from '@selfxyz/mobile-sdk-alpha/constants/colors';
+import {
+  black,
+  separatorColor,
+  slate100,
+  slate400,
+  white,
+} from '@selfxyz/mobile-sdk-alpha/constants/colors';
+import { dinot } from '@selfxyz/mobile-sdk-alpha/constants/fonts';
 
 import CardBackgroundId1 from '@/assets/images/card_background_id1.png';
+import LogoGray from '@/assets/images/logo_gray.svg';
 import SelfLogoPending from '@/assets/images/self_logo_pending.svg';
 import CardBottomContent from '@/components/homescreen/CardBottomContent';
 import CardHeader from '@/components/homescreen/CardHeader';
 import { cardStyles } from '@/components/homescreen/cardStyles';
+import IdAttribute from '@/components/homescreen/IdAttribute';
 import { useCardDimensions } from '@/hooks/useCardDimensions';
-import { getCountryAdjective } from '@/utils/countryDemonyms';
+import {
+  getCountryAdjective,
+  getCountryDemonym,
+} from '@/utils/countryDemonyms';
 
 interface KycIdCardProps {
   idDocument: KycData;
@@ -44,18 +56,23 @@ function getKycDocTitle(idType: string): string {
 }
 
 /**
- * KYC document card - matches IdCard design exactly but shows "STANDARD" badge.
- * Used for documents verified through KYC flow (drivers license, etc.).
+ * Format YYYYMMDD to DD/MM/YYYY for display.
  */
-const KycIdCard: FC<KycIdCardProps> = ({
-  idDocument,
-  selected,
-  hidden: _hidden,
-}) => {
+function formatKycDate(date: string): string {
+  if (date.length !== 8) return date;
+  return `${date.slice(6, 8)}/${date.slice(4, 6)}/${date.slice(0, 4)}`;
+}
+
+const KycIdCard: FC<KycIdCardProps> = ({ idDocument, selected, hidden }) => {
   // Extract KYC fields from serialized applicant info with error handling
   let country = '';
   let idType = '';
   let idNumber = '';
+  let fullName = '';
+  let dob = '';
+  let gender = '';
+  let expiryDate = '';
+  let issuanceDate = '';
 
   try {
     const applicantInfo = deserializeApplicantInfo(
@@ -64,12 +81,16 @@ const KycIdCard: FC<KycIdCardProps> = ({
     country = applicantInfo.country || '';
     idType = applicantInfo.idType || '';
     idNumber = applicantInfo.idNumber || '';
+    fullName = applicantInfo.fullName || '';
+    dob = applicantInfo.dob || '';
+    gender = applicantInfo.gender || '';
+    expiryDate = applicantInfo.expiryDate || '';
+    issuanceDate = applicantInfo.issuanceDate || '';
   } catch (error) {
     console.error(
       '[KycIdCard] Failed to deserialize applicant info, using fallback values:',
       error,
     );
-    // Fallback to safe defaults - component will render generic "ID CARD" display
   }
 
   const docTitle = getKycDocTitle(idType);
@@ -105,6 +126,164 @@ const KycIdCard: FC<KycIdCardProps> = ({
 
   // Bottom label (e.g., "US DRIVERS LICENSE")
   const bottomLabel = `${countryAdj} ${docTitle}`;
+
+  // Revealed data view
+  if (!hidden && selected) {
+    const { width: screenWidth } = Dimensions.get('window');
+    const revealedWidth = screenWidth * 0.95 - 16;
+    const revealedHeight = revealedWidth * 0.645;
+    const revealedBorderRadius = revealedWidth * 0.04;
+    const revealedPadding = revealedWidth * 0.035;
+    const revealedFontSize = {
+      large: revealedWidth * 0.045,
+      small: revealedWidth * 0.028,
+    };
+    const imageSize = {
+      width: revealedWidth * 0.2,
+      height: revealedWidth * 0.29,
+    };
+    const contentLeftOffset = imageSize.width + revealedPadding;
+    const countryName = getCountryDemonym(country);
+
+    return (
+      <YStack width="100%" alignItems="center" justifyContent="center">
+        <YStack
+          width={revealedWidth}
+          height={revealedHeight}
+          backgroundColor={white}
+          borderRadius={revealedBorderRadius}
+          borderWidth={0.75}
+          borderColor={separatorColor}
+          padding={revealedPadding}
+          shadowColor={black}
+          shadowOffset={{ width: 0, height: 2 }}
+          shadowOpacity={0.1}
+          shadowRadius={4}
+          elevation={4}
+          marginBottom={8}
+          justifyContent="center"
+        >
+          {/* Header */}
+          <XStack alignItems="center">
+            <RoundFlag
+              countryCode={country}
+              size={revealedFontSize.large * 2}
+            />
+            <YStack marginLeft={revealedPadding}>
+              <Text
+                fontWeight="bold"
+                fontFamily={dinot}
+                fontSize={revealedFontSize.large * 1.4}
+                color="black"
+              >
+                {docTitle}
+              </Text>
+              <Text
+                fontSize={revealedFontSize.small}
+                color={slate400}
+                fontFamily={dinot}
+              >
+                Verified {countryName} {docTitle}
+              </Text>
+            </YStack>
+          </XStack>
+
+          <Separator
+            backgroundColor={separatorColor}
+            height={1}
+            width={revealedWidth - 1}
+            marginLeft={-revealedPadding}
+            marginTop={revealedPadding}
+          />
+
+          {/* Attributes Grid */}
+          <XStack height="60%" paddingVertical={revealedPadding}>
+            <YStack
+              width={imageSize.width}
+              height={imageSize.height}
+              backgroundColor="#F5F5F5"
+              borderRadius={revealedBorderRadius * 0.5}
+              justifyContent="center"
+              alignItems="center"
+              marginRight={revealedPadding}
+            >
+              <LogoGray
+                width={imageSize.width * 0.5}
+                height={imageSize.height * 0.5}
+              />
+            </YStack>
+
+            <YStack
+              flex={1}
+              justifyContent="space-between"
+              height={imageSize.height}
+            >
+              <XStack flex={1} gap={revealedPadding * 0.3}>
+                <YStack flex={1}>
+                  <IdAttribute name="TYPE" value={docTitle} />
+                </YStack>
+                <YStack flex={1}>
+                  <IdAttribute name="CODE" value="SELF ID" />
+                </YStack>
+                <YStack flex={1}>
+                  <IdAttribute name="DOC NO." value={idNumber} />
+                </YStack>
+              </XStack>
+              <XStack flex={1} gap={revealedPadding * 0.3}>
+                <YStack flex={2}>
+                  <IdAttribute name="NAME" value={fullName} />
+                </YStack>
+                <YStack flex={1}>
+                  <IdAttribute name="SEX" value={gender} />
+                </YStack>
+              </XStack>
+              <XStack flex={1} gap={revealedPadding * 0.3}>
+                <YStack flex={1}>
+                  <IdAttribute name="NATIONALITY" value={countryName} />
+                </YStack>
+                <YStack flex={1}>
+                  <IdAttribute name="DOB" value={formatKycDate(dob)} />
+                </YStack>
+                <YStack flex={1}>
+                  <IdAttribute
+                    name="EXPIRY DATE"
+                    value={formatKycDate(expiryDate)}
+                  />
+                </YStack>
+              </XStack>
+              <XStack flex={1} gap={revealedPadding * 0.3}>
+                <YStack flex={1}>
+                  <IdAttribute
+                    name="ISSUE DATE"
+                    value={formatKycDate(issuanceDate)}
+                  />
+                </YStack>
+                <YStack flex={1} />
+                <YStack flex={1} />
+              </XStack>
+            </YStack>
+          </XStack>
+
+          {/* Footer */}
+          <XStack
+            alignItems="center"
+            backgroundColor={slate100}
+            borderRadius={revealedBorderRadius / 3}
+            paddingHorizontal={revealedPadding / 2}
+            paddingVertical={revealedPadding / 4}
+            minHeight={revealedFontSize.large * 1.5}
+          >
+            <XStack width={contentLeftOffset} alignItems="center">
+              <LogoGray
+                width={revealedFontSize.large}
+                height={revealedFontSize.large}
+              />
+            </XStack>
+          </XStack>
+        </YStack>
+      </YStack>
+    );
+  }
 
   return (
     <YStack width="100%" alignItems="center" justifyContent="center">


### PR DESCRIPTION
The "View ID Data" button was broken for didit KYC documents because KycIdCard ignored the hidden prop. This adds a revealed view showing name, DOB, nationality, document number, gender, and dates.

## Summary

<!-- Brief description of changes -->

## Test plan

<!-- How was this tested? -->

---

### Native Consolidation Checklist

<!-- Check items that apply to this PR. Delete section if not touching native code. -->

- [ ] CONTRACTS.md reviewed - no unintended contract changes
- [ ] Layer 1 bridge contract tests pass (`cd app && yarn jest:run` / `yarn workspace @selfxyz/rn-sdk-test-app test`)
- [ ] Layer 3 builds pass (app iOS, RN test app iOS, RN test app Android)
- [ ] Layer 4 manual smoke test signed off (if consolidation PR)
- [ ] No new native business logic added (logic belongs in TypeScript)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced KYC ID card now displays additional information including full name, date of birth, gender, and document dates.
  * Improved date formatting for better readability across the application.
  * Redesigned card layout presents KYC details in a clearer, organized format when revealed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->