### PR TITLE
SELF-2643: use expo-camera for qrcode scanning

### DIFF
--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -49,7 +49,6 @@ allprojects {
             substitute(platform(module('com.gemalto.jp2:jp2-android'))) using module('com.github.Tgo1014:JP2ForAndroid:1.0.4')
             substitute module('io.fotoapparat:fotoapparat') using module('com.github.fotoapparat:fotoapparat:2.7.0')
         }
-        resolutionStrategy.force 'com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava'
     }
     configurations.all {
         resolutionStrategy {

--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -2624,10 +2624,10 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   AppAuth: 1c1a8afa7e12f2ec3a294d9882dfa5ab7d3cb063
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
-  boost: 1dca942403ed9342f98334bf4c3621f011aa7946
+  boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   BVLinearGradient: cb006ba232a1f3e4f341bb62c42d1098c284da70
   DiditSDK: 3113b1aa1e5f67e84e84bd8449273257e5d9eff0
-  DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
+  DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   EXApplication: 4c72f6017a14a65e338c5e74fca418f35141e819
   EXConstants: fcfc75800824ac2d5c592b5bc74130bad17b146b
   Expo: 4bb70893882e6382b41d1e910d7226c6a1b85f0a
@@ -2651,8 +2651,8 @@ SPEC CHECKSUMS:
   FirebaseRemoteConfig: ca2e03fdd86e31d79ded53e24fa4ac719494dc35
   FirebaseRemoteConfigInterop: 1c6135e8a094cc6368949f5faeeca7ee8948b8aa
   FirebaseSharedSwift: e17c654ef1f1a616b0b33054e663ad1035c8fd40
-  fmt: 01b82d4ca6470831d1cc0852a1af644be019e8f6
-  glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
+  fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
+  glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   GoogleAppMeasurement: 8a82b93a6400c8e6551c0bcd66a9177f2e067aed
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleSignIn: fcee2257188d5eda57a5e2b6a715550ffff9206d

--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -27,6 +27,10 @@ PODS:
     - React-Core
   - ExpoAsset (11.0.5):
     - ExpoModulesCore
+  - ExpoCamera (16.0.18):
+    - ExpoModulesCore
+    - ZXingObjC/OneD
+    - ZXingObjC/PDF417
   - ExpoFileSystem (18.0.12):
     - ExpoModulesCore
   - ExpoFont (13.0.4):
@@ -2218,6 +2222,11 @@ PODS:
   - SwiftyTesseract (3.1.3)
   - Yoga (0.0.0)
   - YttriumWrapper (0.10.50)
+  - ZXingObjC/Core (3.6.9)
+  - ZXingObjC/OneD (3.6.9):
+    - ZXingObjC/Core
+  - ZXingObjC/PDF417 (3.6.9):
+    - ZXingObjC/Core
 
 DEPENDENCIES:
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
@@ -2229,6 +2238,7 @@ DEPENDENCIES:
   - Expo (from `../node_modules/expo`)
   - "ExpoAdapterGoogleSignIn (from `../node_modules/@react-native-google-signin/google-signin/expo/ios`)"
   - ExpoAsset (from `../node_modules/expo-asset/ios`)
+  - ExpoCamera (from `../node_modules/expo-camera/ios`)
   - ExpoFileSystem (from `../node_modules/expo-file-system/ios`)
   - ExpoFont (from `../node_modules/expo-font/ios`)
   - ExpoKeepAwake (from `../node_modules/expo-keep-awake/ios`)
@@ -2371,6 +2381,7 @@ SPEC REPOS:
     - SocketRocket
     - SwiftyTesseract
     - YttriumWrapper
+    - ZXingObjC
 
 EXTERNAL SOURCES:
   boost:
@@ -2391,6 +2402,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-google-signin/google-signin/expo/ios"
   ExpoAsset:
     :path: "../node_modules/expo-asset/ios"
+  ExpoCamera:
+    :path: "../node_modules/expo-camera/ios"
   ExpoFileSystem:
     :path: "../node_modules/expo-file-system/ios"
   ExpoFont:
@@ -2611,15 +2624,16 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   AppAuth: 1c1a8afa7e12f2ec3a294d9882dfa5ab7d3cb063
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
-  boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
+  boost: 1dca942403ed9342f98334bf4c3621f011aa7946
   BVLinearGradient: cb006ba232a1f3e4f341bb62c42d1098c284da70
   DiditSDK: 3113b1aa1e5f67e84e84bd8449273257e5d9eff0
-  DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
+  DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
   EXApplication: 4c72f6017a14a65e338c5e74fca418f35141e819
   EXConstants: fcfc75800824ac2d5c592b5bc74130bad17b146b
   Expo: 4bb70893882e6382b41d1e910d7226c6a1b85f0a
   ExpoAdapterGoogleSignIn: ab4d9fc38cb91077a4138d178395525ec65d0c2e
   ExpoAsset: 48386d40d53a8c1738929b3ed509bcad595b5516
+  ExpoCamera: 0a3e78de7b1ca8c438ee6784fa6f22c5b1b36966
   ExpoFileSystem: 42d363d3b96f9afab980dcef60d5657a4443c655
   ExpoFont: f354e926f8feae5e831ec8087f36652b44a0b188
   ExpoKeepAwake: b0171a73665bfcefcfcc311742a72a956e6aa680
@@ -2637,8 +2651,8 @@ SPEC CHECKSUMS:
   FirebaseRemoteConfig: ca2e03fdd86e31d79ded53e24fa4ac719494dc35
   FirebaseRemoteConfigInterop: 1c6135e8a094cc6368949f5faeeca7ee8948b8aa
   FirebaseSharedSwift: e17c654ef1f1a616b0b33054e663ad1035c8fd40
-  fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
-  glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
+  fmt: 01b82d4ca6470831d1cc0852a1af644be019e8f6
+  glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   GoogleAppMeasurement: 8a82b93a6400c8e6551c0bcd66a9177f2e067aed
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleSignIn: fcee2257188d5eda57a5e2b6a715550ffff9206d
@@ -2751,6 +2765,7 @@ SPEC CHECKSUMS:
   SwiftyTesseract: 1f3d96668ae92dc2208d9842c8a59bea9fad2cbb
   Yoga: c34725819ab0a5962e85455b9e56679b306910ee
   YttriumWrapper: d7f63336830536f1da41b745ed8bacedb04228c4
+  ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: 83f631d1b6308502a035e656b2f9dfab30431ae3
 

--- a/app/jest.config.cjs
+++ b/app/jest.config.cjs
@@ -36,6 +36,7 @@ module.exports = {
     '^@$': '<rootDir>/src',
     '^@tests/(.*)$': '<rootDir>/tests/src/$1',
     '^@tests$': '<rootDir>/tests/src',
+    '^expo-camera$': '<rootDir>/tests/__setup__/expoCameraMock.js',
     // Map react-native-svg to app's node_modules for all packages
     '^react-native-svg$': '<rootDir>/node_modules/react-native-svg',
     '^@selfxyz/mobile-sdk-alpha$':

--- a/app/package.json
+++ b/app/package.json
@@ -127,6 +127,7 @@
     "ethers": "^6.16.0",
     "expo": "~52.0.40",
     "expo-application": "~6.0.2",
+    "expo-camera": "~16.0.18",
     "hash.js": "^1.1.7",
     "js-sha1": "^0.7.0",
     "js-sha256": "^0.11.1",

--- a/app/src/components/native/QRCodeScanner.tsx
+++ b/app/src/components/native/QRCodeScanner.tsx
@@ -2,36 +2,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
-import React, { useCallback } from 'react';
-import type { NativeSyntheticEvent, StyleProp, ViewStyle } from 'react-native';
-import { PixelRatio, Platform, requireNativeComponent } from 'react-native';
-
-import { RCTFragment } from '@/components/native/RCTFragment';
-
-interface NativeQRCodeScannerViewProps {
-  onQRData: (event: NativeSyntheticEvent<{ data: string }>) => void;
-  onError: (
-    event: NativeSyntheticEvent<{
-      error: string;
-      errorMessage: string;
-      stackTrace: string;
-    }>,
-  ) => void;
-  style?: StyleProp<ViewStyle>;
-}
-
-const QRCodeNativeComponent = Platform.select({
-  ios: requireNativeComponent<NativeQRCodeScannerViewProps>(
-    'QRCodeScannerView',
-  ),
-  android: requireNativeComponent<NativeQRCodeScannerViewProps>(
-    'QRCodeScannerViewManager',
-  ),
-});
-
-if (!QRCodeNativeComponent) {
-  throw new Error('QRCodeScannerView not registered for this platform');
-}
+import React, { useCallback, useEffect, useRef } from 'react';
+import { StyleSheet, View } from 'react-native';
+import {
+  CameraView,
+  useCameraPermissions,
+  type BarcodeScanningResult,
+} from 'expo-camera';
 
 export interface QRCodeScannerViewProps {
   isMounted: boolean;
@@ -42,70 +19,54 @@ export const QRCodeScannerView: React.FC<QRCodeScannerViewProps> = ({
   onQRData,
   isMounted,
 }) => {
-  const _onError = useCallback(
-    (
-      event: NativeSyntheticEvent<{
-        error: string;
-        errorMessage: string;
-        stackTrace: string;
-      }>,
-    ) => {
+  const [permission, requestPermission] = useCameraPermissions();
+  const hasRequestedPermission = useRef(false);
+
+  useEffect(() => {
+    if (!hasRequestedPermission.current && !permission?.granted) {
+      hasRequestedPermission.current = true;
+      requestPermission();
+    }
+  }, [permission, requestPermission]);
+
+  useEffect(() => {
+    if (permission && !permission.granted && !permission.canAskAgain) {
+      onQRData(new Error('Camera permission denied'));
+    }
+  }, [permission, onQRData]);
+
+  const handleBarcodeScanned = useCallback(
+    (result: BarcodeScanningResult) => {
       if (!isMounted) {
         return;
       }
-      const {
-        error: nativeError,
-        errorMessage,
-        stackTrace,
-      } = event.nativeEvent;
-      const e = new Error(errorMessage);
-      e.name = nativeError;
-      e.stack = stackTrace;
-      onQRData(e);
+      onQRData(null, result.data);
     },
     [onQRData, isMounted],
   );
 
-  const _onQRData = useCallback(
-    (event: NativeSyntheticEvent<{ data: string }>) => {
-      if (!isMounted) {
-        return;
-      }
-      onQRData(null, event.nativeEvent.data);
-    },
-    [onQRData, isMounted],
-  );
-
-  if (Platform.OS === 'ios') {
-    return (
-      <QRCodeNativeComponent
-        onQRData={_onQRData}
-        onError={_onError}
-        style={{
-          width: '110%',
-          height: '110%',
-        }}
-      />
-    );
-  } else {
-    // For Android, wrap the native component inside your RCTFragment to preserve existing functionality.
-    const Fragment = RCTFragment as React.FC<
-      React.ComponentProps<typeof RCTFragment> & NativeQRCodeScannerViewProps
-    >;
-    return (
-      <Fragment
-        RCTFragmentViewManager={
-          QRCodeNativeComponent as ReturnType<typeof requireNativeComponent>
-        }
-        fragmentComponentName="QRCodeScannerViewManager"
-        isMounted={isMounted}
-        style={{
-          height: PixelRatio.getPixelSizeForLayoutSize(800),
-          width: PixelRatio.getPixelSizeForLayoutSize(400),
-        }}
-        onError={_onError}
-        onQRData={_onQRData}
-      />
-    );
+  if (!permission?.granted) {
+    return null;
   }
+
+  return (
+    <View style={styles.container}>
+      <CameraView
+        style={styles.camera}
+        facing="back"
+        barcodeScannerSettings={{ barcodeTypes: ['qr'] }}
+        onBarcodeScanned={handleBarcodeScanned}
+      />
+    </View>
+  );
 };
+
+const styles = StyleSheet.create({
+  container: {
+    width: '110%',
+    height: '110%',
+  },
+  camera: {
+    flex: 1,
+  },
+});

--- a/app/src/components/native/QRCodeScanner.tsx
+++ b/app/src/components/native/QRCodeScanner.tsx
@@ -44,10 +44,6 @@ export const QRCodeScannerView: React.FC<QRCodeScannerViewProps> = ({
     [onQRData, isMounted],
   );
 
-  if (!permission?.granted) {
-    return null;
-  }
-
   const handleMountError = useCallback(
     (event: { message: string }) => {
       if (!isMounted) return;
@@ -55,6 +51,10 @@ export const QRCodeScannerView: React.FC<QRCodeScannerViewProps> = ({
     },
     [isMounted, onQRData],
   );
+
+  if (!permission?.granted) {
+    return null;
+  }
 
   return (
     <View style={styles.container}>

--- a/app/src/components/native/QRCodeScanner.tsx
+++ b/app/src/components/native/QRCodeScanner.tsx
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
-import React, { useCallback, useEffect, useRef } from 'react';
-import { StyleSheet, View } from 'react-native';
 import {
+  type BarcodeScanningResult,
   CameraView,
   useCameraPermissions,
-  type BarcodeScanningResult,
 } from 'expo-camera';
+import React, { useCallback, useEffect, useRef } from 'react';
+import { StyleSheet, View } from 'react-native';
 
 export interface QRCodeScannerViewProps {
   isMounted: boolean;
@@ -35,11 +35,14 @@ export const QRCodeScannerView: React.FC<QRCodeScannerViewProps> = ({
     }
   }, [permission, onQRData]);
 
+  const hasScanned = useRef(false);
+
   const handleBarcodeScanned = useCallback(
     (result: BarcodeScanningResult) => {
-      if (!isMounted) {
+      if (!isMounted || hasScanned.current) {
         return;
       }
+      hasScanned.current = true;
       onQRData(null, result.data);
     },
     [onQRData, isMounted],

--- a/app/src/components/native/QRCodeScanner.tsx
+++ b/app/src/components/native/QRCodeScanner.tsx
@@ -20,20 +20,16 @@ export const QRCodeScannerView: React.FC<QRCodeScannerViewProps> = ({
   isMounted,
 }) => {
   const [permission, requestPermission] = useCameraPermissions();
-  const hasRequestedPermission = useRef(false);
 
   useEffect(() => {
-    if (!hasRequestedPermission.current && !permission?.granted) {
-      hasRequestedPermission.current = true;
-      requestPermission();
+    if (permission && !permission.granted) {
+      if (permission.canAskAgain) {
+        requestPermission();
+      } else {
+        onQRData(new Error('Camera permission denied'));
+      }
     }
-  }, [permission, requestPermission]);
-
-  useEffect(() => {
-    if (permission && !permission.granted && !permission.canAskAgain) {
-      onQRData(new Error('Camera permission denied'));
-    }
-  }, [permission, onQRData]);
+  }, [permission, requestPermission, onQRData]);
 
   const hasScanned = useRef(false);
 
@@ -52,6 +48,14 @@ export const QRCodeScannerView: React.FC<QRCodeScannerViewProps> = ({
     return null;
   }
 
+  const handleMountError = useCallback(
+    (event: { message: string }) => {
+      if (!isMounted) return;
+      onQRData(new Error(event.message));
+    },
+    [isMounted, onQRData],
+  );
+
   return (
     <View style={styles.container}>
       <CameraView
@@ -59,6 +63,7 @@ export const QRCodeScannerView: React.FC<QRCodeScannerViewProps> = ({
         facing="back"
         barcodeScannerSettings={{ barcodeTypes: ['qr'] }}
         onBarcodeScanned={handleBarcodeScanned}
+        onMountError={handleMountError}
       />
     </View>
   );

--- a/app/tests/__setup__/expoCameraMock.js
+++ b/app/tests/__setup__/expoCameraMock.js
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+const React = require('react');
+
+module.exports = {
+  CameraView: 'CameraView',
+  useCameraPermissions: () => [
+    { granted: true, canAskAgain: true },
+    jest.fn(),
+  ],
+};

--- a/app/tests/__setup__/expoCameraMock.js
+++ b/app/tests/__setup__/expoCameraMock.js
@@ -4,8 +4,5 @@
 
 module.exports = {
   CameraView: 'CameraView',
-  useCameraPermissions: () => [
-    { granted: true, canAskAgain: true },
-    jest.fn(),
-  ],
+  useCameraPermissions: () => [{ granted: true, canAskAgain: true }, jest.fn()],
 };

--- a/app/tests/__setup__/expoCameraMock.js
+++ b/app/tests/__setup__/expoCameraMock.js
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
-const React = require('react');
-
 module.exports = {
   CameraView: 'CameraView',
   useCameraPermissions: () => [

--- a/yarn.lock
+++ b/yarn.lock
@@ -11255,6 +11255,7 @@ __metadata:
     ethers: "npm:^6.16.0"
     expo: "npm:~52.0.40"
     expo-application: "npm:~6.0.2"
+    expo-camera: "npm:~16.0.18"
     hash.js: "npm:^1.1.7"
     hermes-eslint: "npm:^0.33.3"
     jest: "npm:^30.3.0"
@@ -24695,6 +24696,23 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 10c0/e768aa5e3115e4604352b69e4d02e229ecf63f4162353f1505d76c52901810b7bafa378be9924f71b0a82d4ea75448e3b60b65aa528cca536b4781d227141421
+  languageName: node
+  linkType: hard
+
+"expo-camera@npm:~16.0.18":
+  version: 16.0.18
+  resolution: "expo-camera@npm:16.0.18"
+  dependencies:
+    invariant: "npm:^2.2.4"
+  peerDependencies:
+    expo: "*"
+    react: "*"
+    react-native: "*"
+    react-native-web: "*"
+  peerDependenciesMeta:
+    react-native-web:
+      optional: true
+  checksum: 10c0/19d6f27af22d6e148b0bd7dc1dc37778b155ce0454515045a07e7dcc2b0474aa3d0d0986684fcbfe16837cffa41b33128d23376454d975b09b592c3dd92fe803
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

<!-- Brief description of changes -->

## Test plan

<!-- How was this tested? -->

---

### Native Consolidation Checklist

<!-- Check items that apply to this PR. Delete section if not touching native code. -->

- [ ] CONTRACTS.md reviewed - no unintended contract changes
- [ ] Layer 1 bridge contract tests pass (`cd app && yarn jest:run` / `yarn workspace @selfxyz/rn-sdk-test-app test`)
- [ ] Layer 3 builds pass (app iOS, RN test app iOS, RN test app Android)
- [ ] Layer 4 manual smoke test signed off (if consolidation PR)
- [ ] No new native business logic added (logic belongs in TypeScript)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced native QR scanner with an Expo Camera-based implementation; added expo-camera dependency and updated camera permission flow (prompts when allowed, reports error when denied).

* **Tests**
  * Added a Jest mock for the camera module to support reliable camera-related tests.

* **Chores**
  * Removed a global Gradle force rule; other dependency resolution rules remain active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->