### PR TITLE
feat(ci): Android PR preview builds via Internal App Sharing

### DIFF
--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -97,6 +97,11 @@ on:
         required: false
         type: boolean
         default: false
+      pr_number:
+        description: "PR number for per-PR preview build. When set (Android only), uploads to Play Store Internal App Sharing and posts a Slack message with the install URL. Skips the version-bump PR."
+        required: false
+        type: string
+        default: ""
 
   pull_request:
     types: [closed]
@@ -131,10 +136,11 @@ on:
         default: false
 
 concurrency:
-  # Group by deployment track or ref name to allow different tracks to run in parallel
-  # cancel-in-progress: false ensures we don't cancel ongoing deployments
-  # Branch-locking in create-version-bump-pr prevents duplicate PRs for same version
-  group: mobile-deploy-${{ inputs.deployment_track || github.ref_name }}
+  # Group by PR number (when set) so multiple PR preview builds run in parallel,
+  # otherwise by deployment track or ref name to allow different tracks to run in parallel.
+  # cancel-in-progress: false ensures we don't cancel ongoing deployments.
+  # Branch-locking in create-version-bump-pr prevents duplicate PRs for same version.
+  group: mobile-deploy-${{ inputs.pr_number != '' && format('pr-{0}', inputs.pr_number) || inputs.deployment_track || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -263,7 +269,9 @@ jobs:
     permissions:
       contents: read
       actions: write
+    # PR preview builds are Android-only for now — always skip iOS when pr_number is set.
     if: |
+      inputs.pr_number == '' &&
       (github.event_name != 'pull_request' ||
         (github.event.action == 'closed' && github.event.pull_request.merged == true)) &&
       (
@@ -1236,8 +1244,20 @@ jobs:
         if: inputs.platform != 'ios'
         uses: ./.github/actions/cleanup-gradle-artifacts
 
-      - name: Upload to Google Play Store using WIF
-        if: inputs.platform != 'ios' && inputs.test_mode != true
+      - name: Upload to Play Store Internal App Sharing (PR preview)
+        id: ias-upload
+        if: inputs.platform != 'ios' && inputs.test_mode != true && inputs.pr_number != ''
+        timeout-minutes: 10
+        run: |
+          cd ${{ env.APP_PATH }}
+          echo "🧪 PR preview build for #${{ inputs.pr_number }} — uploading to Internal App Sharing..."
+          python scripts/upload_to_play_store.py \
+            --aab "android/app/build/outputs/bundle/release/app-release.aab" \
+            --package-name "${{ secrets.ANDROID_PACKAGE_NAME }}" \
+            --mode ias
+
+      - name: Upload to Google Play Store track using WIF
+        if: inputs.platform != 'ios' && inputs.test_mode != true && inputs.pr_number == ''
         timeout-minutes: 10
         run: |
           cd ${{ env.APP_PATH }}
@@ -1250,6 +1270,96 @@ jobs:
             --aab "android/app/build/outputs/bundle/release/app-release.aab" \
             --package-name "${{ secrets.ANDROID_PACKAGE_NAME }}" \
             --track "$DEPLOYMENT_TRACK"
+
+      - name: Post PR preview build link to Slack
+        if: inputs.platform != 'ios' && inputs.test_mode != true && inputs.pr_number != '' && steps.ias-upload.outputs.download_url != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_QA_BUILDS }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          DOWNLOAD_URL: ${{ steps.ias-upload.outputs.download_url }}
+          APP_VERSION: ${{ needs.bump-version.outputs.version }}
+          BUILD_NUMBER: ${{ needs.bump-version.outputs.android_build }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "⚠️  SLACK_WEBHOOK_QA_BUILDS not configured — skipping Slack notify"
+            echo "   (Install URL: $DOWNLOAD_URL)"
+            exit 0
+          fi
+
+          # Fetch PR metadata so the Slack card is informative
+          PR_JSON=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '{title,html_url,user:.user.login,body}')
+          PR_TITLE=$(echo "$PR_JSON" | python3 -c 'import json,sys;print(json.load(sys.stdin)["title"])')
+          PR_URL=$(echo "$PR_JSON" | python3 -c 'import json,sys;print(json.load(sys.stdin)["html_url"])')
+          PR_USER=$(echo "$PR_JSON" | python3 -c 'import json,sys;print(json.load(sys.stdin)["user"])')
+
+          python3 <<'PY'
+          import json, os, urllib.request
+
+          payload = {
+              "text": f"Android preview build ready for PR #{os.environ['PR_NUMBER']}",
+              "blocks": [
+                  {
+                      "type": "header",
+                      "text": {"type": "plain_text", "text": f"🤖 Android preview — PR #{os.environ['PR_NUMBER']}"},
+                  },
+                  {
+                      "type": "section",
+                      "text": {
+                          "type": "mrkdwn",
+                          "text": f"*<{os.environ['PR_URL']}|{os.environ.get('PR_TITLE','(no title)')}>*\n_by {os.environ.get('PR_USER','?')}_",
+                      },
+                  },
+                  {
+                      "type": "section",
+                      "fields": [
+                          {"type": "mrkdwn", "text": f"*Version*\n`{os.environ.get('APP_VERSION','?')} ({os.environ.get('BUILD_NUMBER','?')})`"},
+                          {"type": "mrkdwn", "text": f"*Source*\n<{os.environ['RUN_URL']}|CI run>"},
+                      ],
+                  },
+                  {
+                      "type": "actions",
+                      "elements": [
+                          {
+                              "type": "button",
+                              "style": "primary",
+                              "text": {"type": "plain_text", "text": "📱 Install on Android"},
+                              "url": os.environ["DOWNLOAD_URL"],
+                          },
+                          {
+                              "type": "button",
+                              "text": {"type": "plain_text", "text": "View PR"},
+                              "url": os.environ["PR_URL"],
+                          },
+                      ],
+                  },
+                  {
+                      "type": "context",
+                      "elements": [
+                          {"type": "mrkdwn", "text": "Open the install link on your Android device (must be signed into a Play Store tester account)."},
+                      ],
+                  },
+              ],
+          }
+
+          req = urllib.request.Request(
+              os.environ["SLACK_WEBHOOK_URL"],
+              data=json.dumps(payload).encode(),
+              headers={"Content-Type": "application/json"},
+          )
+          with urllib.request.urlopen(req) as resp:
+              print(f"Slack webhook status: {resp.status}")
+          PY
+
+          # Also export to the run summary so the URL is visible in the GH Actions UI
+          {
+            echo "## 📱 Android preview build"
+            echo ""
+            echo "- PR: [#$PR_NUMBER]($PR_URL) — $PR_TITLE"
+            echo "- Version: \`$APP_VERSION ($BUILD_NUMBER)\`"
+            echo "- Install URL: $DOWNLOAD_URL"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Monitor cache usage
         if: always()
@@ -1290,8 +1400,11 @@ jobs:
       contents: write
       pull-requests: write
     needs: [bump-version, build-ios, build-android]
+    # Skip when this is a per-PR preview build — preview builds must not mutate
+    # the repo's version lineage.
     if: |
       always() &&
+      inputs.pr_number == '' &&
       (github.event_name != 'pull_request' ||
         (github.event.action == 'closed' && github.event.pull_request.merged == true)) &&
       (needs.build-ios.result == 'success' || needs.build-android.result == 'success')

--- a/app/scripts/upload_to_play_store.py
+++ b/app/scripts/upload_to_play_store.py
@@ -79,6 +79,56 @@ def should_hold_for_manual_review(track):
     return track == 'production'
 
 
+def upload_to_internal_app_sharing(aab_path, package_name, credentials):
+    """Upload AAB to Google Play Internal App Sharing.
+
+    Returns a unique downloadUrl per upload. Designed for per-PR/per-build
+    preview distribution: does NOT advance any track, does NOT require a
+    unique versionCode, and does NOT go through review.
+    """
+    print(f"📤 Uploading {aab_path} to Internal App Sharing...")
+
+    try:
+        service = build('androidpublisher', 'v3', credentials=credentials)
+
+        media = MediaFileUpload(aab_path, mimetype='application/octet-stream')
+        request = service.internalappsharingartifacts().uploadbundle(
+            packageName=package_name,
+            media_body=media,
+        )
+        response = request.execute()
+
+        download_url = response.get('downloadUrl')
+        sha256 = response.get('sha256')
+        cert_fingerprint = response.get('certificateFingerprint')
+
+        if not download_url:
+            print("❌ IAS upload returned no downloadUrl")
+            print(f"Response: {response}")
+            return False
+
+        print(f"✅ Uploaded to Internal App Sharing")
+        print(f"🔗 downloadUrl: {download_url}")
+        if sha256:
+            print(f"🔐 sha256: {sha256}")
+        if cert_fingerprint:
+            print(f"📜 certificateFingerprint: {cert_fingerprint}")
+
+        # Expose the URL to GitHub Actions via $GITHUB_OUTPUT when available
+        github_output = os.environ.get('GITHUB_OUTPUT')
+        if github_output:
+            with open(github_output, 'a') as f:
+                f.write(f"download_url={download_url}\n")
+                if sha256:
+                    f.write(f"sha256={sha256}\n")
+
+        return True
+
+    except Exception as e:
+        print(f"❌ IAS upload failed: {e}")
+        return False
+
+
 def upload_to_play_store(aab_path, package_name, track, credentials):
     """Upload AAB to Google Play Store"""
     print(f"📤 Uploading {aab_path} to Play Store...")
@@ -160,7 +210,9 @@ def main():
     parser = argparse.ArgumentParser(description='Upload Android AAB to Google Play Store using WIF')
     parser.add_argument('--aab', required=True, help='Path to the AAB file')
     parser.add_argument('--package-name', required=True, help='Android package name')
-    parser.add_argument('--track', default='internal', help='Release track (internal, alpha, beta, production)')
+    parser.add_argument('--track', default='internal', help='Release track (internal, alpha, beta, production). Ignored when --mode=ias.')
+    parser.add_argument('--mode', default='track', choices=['track', 'ias'],
+                        help='Upload mode: "track" promotes to a Play Store track; "ias" uploads to Internal App Sharing and returns a unique downloadUrl.')
 
     args = parser.parse_args()
 
@@ -170,15 +222,20 @@ def main():
         print(f"❌ Error: AAB file not found: {aab_path}")
         sys.exit(1)
 
-    print("🚀 Starting Google Play Store upload with Workload Identity Federation")
+    print("🚀 Starting Google Play upload with Workload Identity Federation")
     print(f"📦 AAB: {aab_path}")
     print(f"📱 Package: {args.package_name}")
-    print(f"🎯 Track: {args.track}")
+    print(f"🧭 Mode: {args.mode}")
+    if args.mode == 'track':
+        print(f"🎯 Track: {args.track}")
     print()
 
     # Get credentials and upload
     credentials = get_credentials()
-    success = upload_to_play_store(str(aab_path), args.package_name, args.track, credentials)
+    if args.mode == 'ias':
+        success = upload_to_internal_app_sharing(str(aab_path), args.package_name, credentials)
+    else:
+        success = upload_to_play_store(str(aab_path), args.package_name, args.track, credentials)
 
     if success:
         print("\n🎉 Upload completed successfully!")


### PR DESCRIPTION
## Summary

Adds a per-PR Android preview build flow. An agent (or human) opens a PR to `dev`, dispatches `mobile-deploy.yml` with a new `pr_number` input, and the pipeline:

- Builds the AAB as today.
- Uploads to **Play Store Internal App Sharing** (unique `downloadUrl` per upload — not the internal track; no review, no versionCode uniqueness requirement).
- Posts a Slack message to `SLACK_WEBHOOK_QA_BUILDS` with PR metadata + tap-to-install button.
- **Skips** the version-bump PR job (previews must not mutate the repo's version lineage).
- **Skips** iOS (preview builds are Android-only for now — TestFlight has no equivalent unique-link primitive).

Reviewer taps the Slack link on Android → installs → tests → comments on the PR → merge. The normal post-merge-to-staging flow still controls what reaches TestFlight / Play internal track.

## Changes

### CI (`.github/workflows/mobile-deploy.yml`)

- New `workflow_dispatch` input `pr_number` (optional string).
- Concurrency key now includes PR number so parallel previews across PRs don't queue behind each other: `mobile-deploy-${pr_number ? 'pr-N' : track || ref}`.
- Android upload step split into two branches:
  - `pr_number != ''` → `upload_to_play_store.py --mode ias` (captures `download_url` via step output).
  - `pr_number == ''` → existing track upload (unchanged).
- New `Post PR preview build link to Slack` step: posts a Block Kit card with PR title, author, version, install button, PR link. Also writes the install URL to `$GITHUB_STEP_SUMMARY` as a fallback.
- `build-ios` and `create-version-bump-pr` gated off when `pr_number` is set.

### Upload script (`app/scripts/upload_to_play_store.py`)

- New `--mode=ias` branch calling `androidpublisher.v3.internalappsharingartifacts.uploadbundle`.
- Exports `download_url` (and `sha256`) to `$GITHUB_OUTPUT` when running under Actions.
- Existing `--mode=track` path is the default and unchanged.

## New repo secret required

- `SLACK_WEBHOOK_QA_BUILDS` — incoming webhook pointing at the QA channel. If absent, the Slack step no-ops and the URL lives only in the run summary.

WIF service account already has the `androidpublisher` scope (same one used by the existing track upload), so no Google-side changes needed.

## How the agent uses it

```bash
gh workflow run mobile-deploy.yml \
  --ref "<pr-branch>" \
  -f platform=android \
  -f deployment_track=internal \
  -f version_bump=build \
  -f pr_number="<pr-number>"
```

A `/android-pr-build` Claude Code skill covering this flow is provided separately (kept local, not in this PR).

## Test Plan

- [ ] Merge to `dev`, then from a throwaway feature branch run `gh workflow run mobile-deploy.yml --ref <branch> -f platform=android -f pr_number=<test-pr>` and confirm:
  - [ ] `build-ios` is skipped.
  - [ ] `Upload to Play Store Internal App Sharing (PR preview)` step runs and prints a `downloadUrl`.
  - [ ] `Post PR preview build link to Slack` posts to `#qa-builds` with a working install button (once `SLACK_WEBHOOK_QA_BUILDS` is configured).
  - [ ] `create-version-bump-pr` is skipped.
  - [ ] `yarn types` / existing CI still pass on this branch.
- [ ] Run a normal build (no `pr_number`) and confirm the existing track upload + version-bump PR still behave as before.
- [ ] Install the AAB via the `downloadUrl` on a real Android device signed into a Play Store tester account.

## Out of scope

- iOS/TestFlight previews.
- Agent-side PR-opening logic.
- Promoting preview builds to any track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Android preview build uploads to Google Play Internal App Sharing, enabling faster testing of pull request changes with download links shared via Slack notifications.
  * Introduced per-PR build configuration to streamline preview workflows while skipping unnecessary iOS builds during Android-only preview builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->