### PR TITLE
SELF-2641 Enable logs

### DIFF
--- a/app/ios/Podfile
+++ b/app/ios/Podfile
@@ -144,7 +144,7 @@ target "Self" do
       nfc_repo_url = "git@github.com:selfxyz/NFCPassportReader.git"
     end
 
-    pod "SelfNFCPassportReader", git: nfc_repo_url, commit: "2cdc50a5c27b75594b94b27fdc4bb6172ada0f96"
+    pod "SelfNFCPassportReader", git: nfc_repo_url, commit: "b478e1f1320e86f72c5755bc5adf156fff950585"
   end
 
   # Explicitly declare Mixpanel to ensure it's available even in E2E builds

--- a/app/src/services/logging/logger/lokiTransport.ts
+++ b/app/src/services/logging/logger/lokiTransport.ts
@@ -88,12 +88,11 @@ const sendBatch = async (
     });
 
     if (!response.ok) {
-      console.warn(
-        `Loki transport failed: ${response.status} ${response.statusText}`,
-      );
+      // Silently fail — console.warn here would trigger consoleInterceptor
+      // feedback loop when logger is enabled in dev
     }
-  } catch (error) {
-    console.warn('Loki transport error:', error);
+  } catch {
+    // Silently fail — same feedback loop risk
   }
 };
 

--- a/app/src/services/logging/logger/lokiTransport.ts
+++ b/app/src/services/logging/logger/lokiTransport.ts
@@ -29,6 +29,9 @@ interface LokiPayload {
   streams: LokiStream[];
 }
 
+// Per-session ID for grouping logs in Grafana (not persistent, not user-identifiable)
+const sessionId = `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+
 // Batch management state
 let batch: LokiLogEntry[] = [];
 let batchTimer: NodeJS.Timeout | null = null;
@@ -63,6 +66,7 @@ const sendBatch = async (
           app: 'self-mobile',
           platform: 'react-native',
           level,
+          session_id: sessionId,
         },
         values,
       }),

--- a/app/src/services/logging/logger/lokiTransport.ts
+++ b/app/src/services/logging/logger/lokiTransport.ts
@@ -198,11 +198,13 @@ const lokiTransport: transportFunctionType<LokiTransportOptions> = props => {
     level: string;
     message: string;
     timestamp: string;
+    session_id: string;
     data?: unknown;
   } = {
     level: level.text,
     message: actualMessage,
     timestamp,
+    session_id: sessionId,
   };
 
   if (actualData) {


### PR DESCRIPTION
## Summary

- Updated NFCPassportReader pod to include comprehensive NFC observability logging (PACE sub-steps, SecureMessaging errors, chip auth, verification results)
- Suppressed console.warn in Loki transport to prevent feedback loop with consoleInterceptor when logger is enabled in dev

## Environment flags

For NFC logs to reach Grafana Loki, the following must be set:

| Flag | Where | Purpose |
|------|-------|---------|
| `GRAFANA_LOKI_URL` | `.env` | Loki push endpoint |
| `GRAFANA_LOKI_USERNAME` | `.env` | Basic auth username |
| `GRAFANA_LOKI_PASSWORD` | `.env` | Basic auth password |
| `ENABLE_DEBUG_LOGS=true` | `.env` | Enables NFC analytics forwarding from native to JS |
| `loggingSeverity` | Settings store (runtime) | Must be `info` or lower for NFC events to pass through to the transport |
| `enabled: true` | `logging/index.ts` | Currently `false` in dev (`__DEV__`), `true` in production |

## Test plan

- [x] Trigger NFC scan → verify native log events received in Metro console (bridge works)
- [x] Confirm no console feedback loop when logger enabled in dev
- [ ] Production build: verify logs arrive in Grafana with NFC event names

---

### Native Consolidation Checklist

- [ ] CONTRACTS.md reviewed - no unintended contract changes
- [ ] Layer 1 bridge contract tests pass (`cd app && yarn jest:run` / `yarn workspace @selfxyz/rn-sdk-test-app test`)
- [ ] Layer 3 builds pass (app iOS, RN test app iOS, RN test app Android)
- [ ] Layer 4 manual smoke test signed off (if consolidation PR)
- [ ] No new native business logic added (logic belongs in TypeScript)