### PR TITLE
fix: address Greptile review feedback from staging PR #1986

### DIFF
--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -1290,9 +1290,9 @@ jobs:
 
           # Fetch PR metadata so the Slack card is informative
           PR_JSON=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '{title,html_url,user:.user.login,body}')
-          PR_TITLE=$(echo "$PR_JSON" | python3 -c 'import json,sys;print(json.load(sys.stdin)["title"])')
-          PR_URL=$(echo "$PR_JSON" | python3 -c 'import json,sys;print(json.load(sys.stdin)["html_url"])')
-          PR_USER=$(echo "$PR_JSON" | python3 -c 'import json,sys;print(json.load(sys.stdin)["user"])')
+          export PR_TITLE=$(echo "$PR_JSON" | python3 -c 'import json,sys;print(json.load(sys.stdin)["title"])')
+          export PR_URL=$(echo "$PR_JSON" | python3 -c 'import json,sys;print(json.load(sys.stdin)["html_url"])')
+          export PR_USER=$(echo "$PR_JSON" | python3 -c 'import json,sys;print(json.load(sys.stdin)["user"])')
 
           python3 <<'PY'
           import json, os, urllib.request

--- a/app/src/components/homescreen/KycIdCard.tsx
+++ b/app/src/components/homescreen/KycIdCard.tsx
@@ -201,7 +201,7 @@ const KycIdCard: FC<KycIdCardProps> = ({ idDocument, selected, hidden }) => {
             <YStack
               width={imageSize.width}
               height={imageSize.height}
-              backgroundColor="#F5F5F5"
+              backgroundColor={slate100}
               borderRadius={revealedBorderRadius * 0.5}
               justifyContent="center"
               alignItems="center"

--- a/packages/webview-app/src/screens/tunnel/TunnelKycPendingScreen.tsx
+++ b/packages/webview-app/src/screens/tunnel/TunnelKycPendingScreen.tsx
@@ -9,13 +9,14 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { KycPendingScreen } from '@selfxyz/euclid';
 
 import { WEB_SAFE_AREA } from '../../utils/insets';
-import { createMockProviderResult } from '../../utils/mockOnboardingFlow';
+import { createMockProviderResult, isDemoMode } from '../../utils/mockOnboardingFlow';
 
 export const TunnelKycPendingScreen: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
 
   const handleTap = useCallback(() => {
+    if (!isDemoMode(location.search)) return;
     navigate(`/tunnel/kyc-success${location.search}`, {
       state: { providerResult: createMockProviderResult({ outcome: 'demo' }) },
     });


### PR DESCRIPTION
## Summary

- Fix Slack notify step in Android preview workflow that would crash with `KeyError` because PR metadata vars weren't exported to the Python subprocess.
- Guard the tunnel KYC-pending demo tap so `createMockProviderResult` can't throw in production builds.
- Replace a raw hex colour in `KycIdCard` with the existing `slate100` design token.

## Changes

### Config/infra

- `.github/workflows/mobile-deploy.yml` — `export` `PR_TITLE` / `PR_URL` / `PR_USER` so the `python3 <<'PY'` heredoc can read them via `os.environ`.

### WebView app

- `TunnelKycPendingScreen.tsx` — short-circuit `handleTap` via `isDemoMode(location.search)` before invoking the mock provider result.

### React Native app

- `KycIdCard.tsx` — swap `#F5F5F5` for `slate100` (already imported) on the revealed-card photo placeholder.

## Test Plan

- [ ] `yarn lint && yarn types` passes
- [ ] Trigger the Android preview workflow on a test PR and confirm the Slack card renders with PR title/URL/author populated (no `KeyError`).
- [ ] In a prod build, navigate to `/tunnel/kyc-pending` and tap the overlay — confirm no exception (navigation should no-op).
- [ ] Visual check: revealed `KycIdCard` photo placeholder still renders with the expected light-grey background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed demo mode handling in KYC flow to prevent success navigation outside of demo mode.

* **Style**
  * Aligned KYC ID card background color to use shared theme constants for design consistency.

* **Chores**
  * Updated CI/CD workflow environment variable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->