### PR TITLE
[codex] Stabilize Android E2E Gradle build

### DIFF
--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -11,7 +11,7 @@ env:
   GH_GEMS_CACHE_VERSION: v1 # Ruby gems cache version
   # Performance optimizations
   YARN_TASK_POOL_CONCURRENCY: 2 # Limit parallel native module builds to prevent OOM on self-hosted runners
-  GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dorg.gradle.parallel=true -Dorg.gradle.caching=true -Dorg.gradle.jvmargs='-Xmx6144m -XX:MaxMetaspaceSize=1024m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8'
+  GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=1 -Dorg.gradle.parallel=true -Dorg.gradle.caching=true -Dorg.gradle.jvmargs='-Xmx4096m -XX:MaxMetaspaceSize=1024m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8'
   CI: true
   # Disable Maestro analytics in CI
   MAESTRO_CLI_NO_ANALYTICS: true
@@ -343,12 +343,33 @@ jobs:
           MONITOR_PID=$!
           trap 'kill "${MONITOR_PID}" 2>/dev/null || true' EXIT
 
-          (
-            cd app/android &&
-            E2E_BUILD=true ./gradlew assembleDebug -PbundleInDebug=true --quiet --build-cache --no-configuration-cache
-          ) || { echo "❌ Android build failed"; exit 1; }
+          build_attempt() {
+            (
+              cd app/android &&
+              E2E_BUILD=true ./gradlew assembleDebug -PbundleInDebug=true --quiet --build-cache --no-configuration-cache
+            )
+          }
+
+          BUILD_OK=false
+          for attempt in 1 2; do
+            echo "Gradle build attempt ${attempt}/2..."
+            if build_attempt; then
+              BUILD_OK=true
+              break
+            fi
+            echo "⚠️ Gradle build failed on attempt ${attempt}."
+            if [ "${attempt}" -lt 2 ]; then
+              echo "Cleaning Gradle daemons and retrying in 15s..."
+              (cd app/android && ./gradlew --stop) || true
+              sleep 15
+            fi
+          done
 
           kill "${MONITOR_PID}" 2>/dev/null || true
+          if [ "${BUILD_OK}" != "true" ]; then
+            echo "❌ Android build failed after retries"
+            exit 1
+          fi
           echo "✅ Android build succeeded"
 
       - name: Clean up Gradle build artifacts

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -359,8 +359,7 @@ jobs:
             fi
             echo "⚠️ Gradle build failed on attempt ${attempt}."
             if [ "${attempt}" -lt 2 ]; then
-              echo "Cleaning Gradle daemons and retrying in 15s..."
-              (cd app/android && ./gradlew --stop) || true
+              echo "Sleeping 15s before retry (no Gradle daemon to stop since daemon=false)..."
               sleep 15
             fi
           done

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -11,7 +11,7 @@ env:
   GH_GEMS_CACHE_VERSION: v1 # Ruby gems cache version
   # Performance optimizations
   YARN_TASK_POOL_CONCURRENCY: 2 # Limit parallel native module builds to prevent OOM on self-hosted runners
-  GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=1 -Dorg.gradle.parallel=true -Dorg.gradle.caching=true -Dorg.gradle.jvmargs='-Xmx4096m -XX:MaxMetaspaceSize=1024m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8'
+  GRADLE_OPTS: -Dorg.gradle.workers.max=1 -Dorg.gradle.parallel=true -Dorg.gradle.caching=true -Dorg.gradle.jvmargs='-Xmx4096m -XX:MaxMetaspaceSize=1024m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8'
   CI: true
   # Disable Maestro analytics in CI
   MAESTRO_CLI_NO_ANALYTICS: true
@@ -324,7 +324,31 @@ jobs:
         env:
           SELFXYZ_APP_TOKEN: ${{ steps.github-token.outputs.token }}
           CI: true
+
+      - name: Capture private module SHAs for APK cache key
+        run: |
+          set -euo pipefail
+          : > .apk-cache-inputs.txt
+          for dir in app/android/android-passport-nfc-reader app/android/react-native-passport-reader; do
+            if [ -d "$dir/.git" ]; then
+              sha=$(git -C "$dir" rev-parse HEAD)
+              echo "$(basename "$dir")=$sha" >> .apk-cache-inputs.txt
+            fi
+          done
+          cat .apk-cache-inputs.txt
+
+      - name: Stage APK path for cache restore
+        run: rm -f app/android/app/build/outputs/apk/debug/app-debug.apk
+
+      - name: Restore Android APK cache
+        id: apk-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: app/android/app/build/outputs/apk/debug/app-debug.apk
+          key: ${{ runner.os }}-apk-v1-${{ hashFiles('app/android/app/src/**', 'app/android/app/build.gradle', 'app/android/app/proguard-rules.pro', 'app/android/build.gradle', 'app/android/settings.gradle', 'app/android/gradle.properties', 'app/android/gradle/wrapper/**', 'app/android/gradlew', 'app/src/**', 'app/App.tsx', 'app/index.js', 'app/app.json', 'app/package.json', 'app/babel.config.cjs', 'app/metro.config.cjs', 'app/react-native.config.cjs', 'app/patches/**', 'patches/**', 'packages/mobile-sdk-alpha/src/**', 'packages/mobile-sdk-alpha/package.json', 'yarn.lock', '.nvmrc', '.apk-cache-inputs.txt') }}
+
       - name: Build Android APK
+        if: steps.apk-cache.outputs.cache-hit != 'true'
         run: |
           echo "Building Android APK..."
           chmod +x app/android/gradlew
@@ -359,7 +383,8 @@ jobs:
             fi
             echo "⚠️ Gradle build failed on attempt ${attempt}."
             if [ "${attempt}" -lt 2 ]; then
-              echo "Sleeping 15s before retry (no Gradle daemon to stop since daemon=false)..."
+              echo "Stopping Gradle daemon and retrying in 15s..."
+              (cd app/android && ./gradlew --stop) || true
               sleep 15
             fi
           done
@@ -371,7 +396,15 @@ jobs:
           fi
           echo "✅ Android build succeeded"
 
+      - name: Save Android APK cache
+        if: steps.apk-cache.outputs.cache-hit != 'true' && success()
+        uses: actions/cache/save@v4
+        with:
+          path: app/android/app/build/outputs/apk/debug/app-debug.apk
+          key: ${{ steps.apk-cache.outputs.cache-primary-key }}
+
       - name: Clean up Gradle build artifacts
+        if: steps.apk-cache.outputs.cache-hit != 'true'
         uses: ./.github/actions/cleanup-gradle-artifacts
       - name: Verify APK and android-passport-nfc-reader integration
         env:


### PR DESCRIPTION
## Summary
- reduce Android E2E Gradle concurrency from 2 workers to 1 and lower the Gradle JVM heap from 6144m to 4096m to reduce peak runner memory pressure
- wrap the Android `assembleDebug` step in a two-attempt retry loop
- stop Gradle daemons and wait 15 seconds before the retry so transient daemon state does not require a manual rerun

## Why
Android E2E builds on the self-hosted runner have been failing intermittently during the Gradle assemble step. This change aims to reduce peak memory spikes and make transient Gradle failures self-heal inside the workflow.

## Validation
- reviewed the workflow diff for shell correctness and cleanup behavior
- `git diff --check`
- commit hooks passed: `yarn gitleaks` and `node scripts/check-license-headers.mjs --check`

## Notes
- `yarn prettier --parser yaml --check .github/workflows/mobile-e2e.yml` wants to normalize quote style across the whole workflow file, so this PR keeps the functional diff narrowly scoped instead of reformatting unrelated lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Android CI to reduce Gradle resource usage and lower JVM memory/worker settings.
  * Added APK caching to speed up e2e runs and avoid unnecessary rebuilds when inputs haven't changed.
  * Only persists caches and runs cleanup when appropriate to avoid stale artifacts.

* **Bug Fixes**
  * Added an automatic two-attempt retry for Android assemble steps with a graceful retry path to improve build reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->