### PR TITLE
Fix - Self points disclosure

### DIFF
--- a/app/src/screens/verification/ProveScreen.tsx
+++ b/app/src/screens/verification/ProveScreen.tsx
@@ -366,31 +366,35 @@ const ProveScreen: React.FC = () => {
     }
 
     const trackAlreadyDisclosed = async () => {
-      const whitelistedAddresses = await getWhiteListedDisclosureAddresses();
-      const isPointsDisclosure = whitelistedAddresses.some(
-        contract =>
-          contract.contract_address.toLowerCase() ===
-          selectedApp?.endpoint?.toLowerCase(),
-      );
+      try {
+        const whitelistedAddresses = await getWhiteListedDisclosureAddresses();
+        const isPointsDisclosure = whitelistedAddresses.some(
+          contract =>
+            contract.contract_address.toLowerCase() ===
+            selectedApp?.endpoint?.toLowerCase(),
+        );
 
-      if (!isPointsDisclosure) {
-        return;
+        if (!isPointsDisclosure) {
+          return;
+        }
+
+        const pointsAddress =
+          selectedApp?.selfDefinedData || (await getPointsAddress());
+
+        trackEvent(ProofEvents.POINTS_NULLIFIER_ALREADY_USED, {
+          pointsAddress,
+          endpoint: selectedApp?.endpoint,
+          sessionId: provingStore.uuid,
+        });
+
+        captureMessage('Points disclosure already registered on-chain', {
+          pointsAddress,
+          endpoint: selectedApp?.endpoint,
+          sessionId: provingStore.uuid,
+        });
+      } catch (error) {
+        console.error('Failed tracking NullifierAlreadyUsed event:', error);
       }
-
-      const pointsAddress =
-        selectedApp?.selfDefinedData || (await getPointsAddress());
-
-      trackEvent(ProofEvents.POINTS_NULLIFIER_ALREADY_USED, {
-        pointsAddress,
-        endpoint: selectedApp?.endpoint,
-        sessionId: provingStore.uuid,
-      });
-
-      captureMessage('Points disclosure already registered on-chain', {
-        pointsAddress,
-        endpoint: selectedApp?.endpoint,
-        sessionId: provingStore.uuid,
-      });
     };
 
     trackAlreadyDisclosed();

--- a/app/src/screens/verification/ProveScreen.tsx
+++ b/app/src/screens/verification/ProveScreen.tsx
@@ -39,6 +39,7 @@ import {
   truncateAddress,
   WalletAddressModal,
 } from '@/components/proof-request';
+import { captureMessage } from '@/config/sentry';
 import { useSelfAppData } from '@/hooks/useSelfAppData';
 import { buttonTap } from '@/integrations/haptics';
 import type { RootStackParamList } from '@/navigation';
@@ -49,6 +50,7 @@ import {
 import {
   getPointsAddress,
   getWhiteListedDisclosureAddresses,
+  NULLIFIER_ALREADY_USED_ERROR_PREFIX,
 } from '@/services/points';
 import { useProofHistoryStore } from '@/stores/proofHistoryStore';
 import { ProofStatus } from '@/stores/proofTypes';
@@ -102,6 +104,7 @@ const ProveScreen: React.FC = () => {
   );
   const provingStore = useProvingStore();
   const currentState = useProvingStore(state => state.currentState);
+  const reason = useProvingStore(state => state.reason);
   const isReadyToProve = currentState === 'ready_to_prove';
 
   // Use window dimensions for dynamic scroll offset padding
@@ -299,6 +302,40 @@ const ProveScreen: React.FC = () => {
         !isExpired &&
         selectedAppRef.current?.sessionId !== selectedApp.sessionId
       ) {
+        // Set selfDefinedData before init so the proving machine has the address
+        if (
+          !selectedApp.selfDefinedData &&
+          !processedSessionsRef.current.has(selectedApp.sessionId)
+        ) {
+          try {
+            const [address, whitelistedAddresses] = await Promise.all([
+              getPointsAddress(),
+              getWhiteListedDisclosureAddresses(),
+            ]);
+
+            const isWhitelisted = whitelistedAddresses.some(
+              contract =>
+                contract.contract_address.toLowerCase() ===
+                selectedApp.endpoint?.toLowerCase(),
+            );
+
+            if (isWhitelisted) {
+              console.log(
+                'enhancing app with whitelisted points address',
+                address,
+              );
+              selfClient.getSelfAppState().setSelfApp({
+                ...selectedApp,
+                selfDefinedData: address.toLowerCase(),
+              });
+            }
+
+            processedSessionsRef.current.add(selectedApp.sessionId);
+          } catch (error) {
+            console.error('Failed enhancing app with points address:', error);
+          }
+        }
+
         provingStore.init(selfClient, 'disclose');
       }
       selectedAppRef.current = selectedApp;
@@ -315,57 +352,49 @@ const ProveScreen: React.FC = () => {
     hasCheckedForInactiveDocument,
   ]);
 
-  // Enhance selfApp with user's points address if not already set
+  // Track "already disclosed" failures for points disclosures so we can fix
+  // the backend state for affected users.
   useEffect(() => {
-    console.log('useEffect selectedApp', selectedApp);
     if (
-      !selectedApp ||
-      selectedApp.selfDefinedData ||
-      !hasCheckedForInactiveDocument
+      currentState !== 'failure' ||
+      !(
+        reason?.includes(NULLIFIER_ALREADY_USED_ERROR_PREFIX) ||
+        reason?.includes('NullifierAlreadyUsed')
+      )
     ) {
       return;
     }
 
-    const sessionId = selectedApp.sessionId;
+    const trackAlreadyDisclosed = async () => {
+      const whitelistedAddresses = await getWhiteListedDisclosureAddresses();
+      const isPointsDisclosure = whitelistedAddresses.some(
+        contract =>
+          contract.contract_address.toLowerCase() ===
+          selectedApp?.endpoint?.toLowerCase(),
+      );
 
-    if (processedSessionsRef.current.has(sessionId)) {
-      return;
-    }
-
-    const enhanceApp = async () => {
-      const currentSessionId = sessionId;
-
-      try {
-        const address = await getPointsAddress();
-        const whitelistedAddresses = await getWhiteListedDisclosureAddresses();
-
-        const isWhitelisted = whitelistedAddresses.some(
-          contract =>
-            contract.contract_address.toLowerCase() === address.toLowerCase(),
-        );
-
-        const currentApp = selfClient.getSelfAppState().selfApp;
-        if (currentApp?.sessionId === currentSessionId) {
-          if (isWhitelisted) {
-            console.log(
-              'enhancing app with whitelisted points address',
-              address,
-            );
-            selfClient.getSelfAppState().setSelfApp({
-              ...currentApp,
-              selfDefinedData: address.toLowerCase(),
-            });
-          }
-        }
-
-        processedSessionsRef.current.add(currentSessionId);
-      } catch (error) {
-        console.error('Failed enhancing app:', error);
+      if (!isPointsDisclosure) {
+        return;
       }
+
+      const pointsAddress =
+        selectedApp?.selfDefinedData || (await getPointsAddress());
+
+      trackEvent(ProofEvents.POINTS_NULLIFIER_ALREADY_USED, {
+        pointsAddress,
+        endpoint: selectedApp?.endpoint,
+        sessionId: provingStore.uuid,
+      });
+
+      captureMessage('Points disclosure already registered on-chain', {
+        pointsAddress,
+        endpoint: selectedApp?.endpoint,
+        sessionId: provingStore.uuid,
+      });
     };
 
-    enhanceApp();
-  }, [selectedApp, selfClient, hasCheckedForInactiveDocument]);
+    trackAlreadyDisclosed();
+  }, [currentState, reason, selectedApp, provingStore.uuid, trackEvent]);
 
   function onVerify() {
     buttonTap();

--- a/app/src/services/points/index.ts
+++ b/app/src/services/points/index.ts
@@ -8,10 +8,9 @@ export type {
   PointEvent,
   PointEventType,
 } from '@/services/points/types';
-export { POINT_VALUES } from '@/services/points/types';
-
 // Re-export all utility functions
 export {
+  NULLIFIER_ALREADY_USED_ERROR_PREFIX,
   formatTimeUntilDate,
   getIncomingPoints,
   getNextSundayNoonUTC,
@@ -22,6 +21,8 @@ export {
   hasUserDoneThePointsDisclosure,
   pointsSelfApp,
 } from '@/services/points/utils';
+
+export { POINT_VALUES } from '@/services/points/types';
 
 // Re-export event getter functions
 export {

--- a/app/src/services/points/utils.ts
+++ b/app/src/services/points/utils.ts
@@ -17,6 +17,8 @@ export type WhitelistedContract = {
   num_disclosures: number;
 };
 
+export const NULLIFIER_ALREADY_USED_ERROR_PREFIX = '0xdc215c0a';
+
 export const formatTimeUntilDate = (targetDate: Date): string => {
   const now = new Date();
   const diffMs = targetDate.getTime() - now.getTime();

--- a/packages/mobile-sdk-alpha/src/constants/analytics.ts
+++ b/packages/mobile-sdk-alpha/src/constants/analytics.ts
@@ -185,6 +185,7 @@ export const ProofEvents = {
   PROOF_COMPLETED: 'Proof: Proof Completed',
   PROOF_DISCLOSURES_SCROLLED: 'Proof: Proof Disclosures Scrolled',
   PROOF_FAILED: 'Proof: Proof Failed',
+  POINTS_NULLIFIER_ALREADY_USED: 'Proof: Points Nullifier Already Used',
   PROOF_RESULT_ACKNOWLEDGED: 'Proof: Proof Result Acknowledged',
   PROOF_VERIFY_CONFIRMATION_ACCEPTED: 'Proof: Verify Confirmation Accepted',
   PROOF_VERIFY_LONG_PRESS: 'Proof: Verify Button Long Pressed',


### PR DESCRIPTION
## Summary

<!-- Brief description of changes -->
1. Fixes SelfDefinedData not set during points verification
2. Tracks `NullifierAlreadyUsed` error
## Test plan

<!-- How was this tested? -->

---

### Native Consolidation Checklist

<!-- Check items that apply to this PR. Delete section if not touching native code. -->

- [ ] CONTRACTS.md reviewed - no unintended contract changes
- [ ] Layer 1 bridge contract tests pass (`cd app && yarn jest:run` / `yarn workspace @selfxyz/rn-sdk-test-app test`)
- [ ] Layer 3 builds pass (app iOS, RN test app iOS, RN test app Android)
- [ ] Layer 4 manual smoke test signed off (if consolidation PR)
- [ ] No new native business logic added (logic belongs in TypeScript)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable detection and messaging for already-registered points disclosures; failure handling now only triggers for duplicate nullifier cases.
  * Whitelist checks and session enrichment for points disclosures occur before proving begins to prevent unauthorized disclosures.
* **New Features**
  * Added tracking/event emission for on-chain duplicate points disclosures to improve monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->