### PR TITLE
Make support diagnostic ID optional

### DIFF
--- a/app/src/components/support/SupportUuidRow.tsx
+++ b/app/src/components/support/SupportUuidRow.tsx
@@ -26,7 +26,7 @@ const SupportUuidRow: React.FC<SupportUuidRowProps> = ({
   title = 'Diagnostic ID',
 }) => {
   const [expanded, setExpanded] = useState(!collapsedByDefault);
-  const { supportUuid, copy } = useSupportUuid();
+  const { isEnabled, supportUuid, copy } = useSupportUuid();
   const diagnosticIdText = supportUuid ?? 'Loading diagnostic ID...';
 
   const handleCopy = useCallback(() => {
@@ -35,6 +35,10 @@ const SupportUuidRow: React.FC<SupportUuidRowProps> = ({
   }, [copy]);
 
   const toggle = useCallback(() => setExpanded(prev => !prev), []);
+
+  if (!isEnabled) {
+    return null;
+  }
 
   if (!expanded) {
     return (
@@ -47,7 +51,7 @@ const SupportUuidRow: React.FC<SupportUuidRowProps> = ({
         paddingVertical={10}
         paddingHorizontal={12}
       >
-        <BodyText style={{ color: slate500 }}>Show diagnostic info</BodyText>
+        <BodyText style={{ color: slate500 }}>Show diagnostic ID</BodyText>
       </Button>
     );
   }

--- a/app/src/config/sentry.ts
+++ b/app/src/config/sentry.ts
@@ -300,12 +300,16 @@ export const logProofEvent = (
   extra?: Record<string, unknown>,
 ) => logEvent(level, 'proof', message, context, extra);
 
-export const setSupportUuidInSentry = (supportUuid: string | null) => {
+export const setSupportUuidInSentry = (
+  supportUuid: string | null,
+  enabled = true,
+) => {
   if (isSentryDisabled) {
     return;
   }
 
-  setTag('support_uuid', supportUuid ?? 'unset');
+  setTag('support_uuid_enabled', enabled ? 'true' : 'false');
+  setTag('support_uuid', enabled ? (supportUuid ?? 'unset') : 'disabled');
 };
 
 export const wrapWithSentry = (App: React.ComponentType) => {

--- a/app/src/config/sentry.web.ts
+++ b/app/src/config/sentry.web.ts
@@ -10,6 +10,7 @@ import {
   captureMessage as sentryCaptureMessage,
   feedbackIntegration,
   init as sentryInit,
+  setTag,
   withProfiler,
   withScope,
 } from '@sentry/react';
@@ -267,7 +268,13 @@ export const logProofEvent = (
   extra?: Record<string, unknown>,
 ) => logEvent(level, 'proof', message, context, extra);
 
-export const setSupportUuidInSentry = (_supportUuid: string | null) => {};
+export const setSupportUuidInSentry = (
+  supportUuid: string | null,
+  enabled = true,
+) => {
+  setTag('support_uuid_enabled', enabled ? 'true' : 'false');
+  setTag('support_uuid', enabled ? (supportUuid ?? 'unset') : 'disabled');
+};
 
 export const wrapWithSentry = (App: React.ComponentType) => {
   return isSentryDisabled ? App : withProfiler(App);

--- a/app/src/config/sentry.web.ts
+++ b/app/src/config/sentry.web.ts
@@ -272,6 +272,9 @@ export const setSupportUuidInSentry = (
   supportUuid: string | null,
   enabled = true,
 ) => {
+  if (isSentryDisabled) {
+    return;
+  }
   setTag('support_uuid_enabled', enabled ? 'true' : 'false');
   setTag('support_uuid', enabled ? (supportUuid ?? 'unset') : 'disabled');
 };

--- a/app/src/hooks/useSupportUuid.ts
+++ b/app/src/hooks/useSupportUuid.ts
@@ -8,27 +8,33 @@ import {
   copySupportUuid,
   getSupportUuid,
   regenerateSupportUuid,
+  setSupportUuidCollectionEnabled,
 } from '@/services/supportUuid';
 import { useSettingStore } from '@/stores/settingStore';
 
 export interface UseSupportUuidResult {
+  isEnabled: boolean;
   supportUuid: string | null;
   isReady: boolean;
-  copy: () => string;
-  regenerate: () => string;
+  copy: () => string | null;
+  regenerate: () => string | null;
+  setEnabled: (enabled: boolean) => string | null;
 }
 
 export function useSupportUuid(): UseSupportUuidResult {
+  const supportUuidEnabled = useSettingStore(state => state.supportUuidEnabled);
   const supportUuid = useSettingStore(state => state.supportUuid);
 
   useEffect(() => {
-    if (!supportUuid) getSupportUuid();
-  }, [supportUuid]);
+    if (supportUuidEnabled && !supportUuid) getSupportUuid();
+  }, [supportUuidEnabled, supportUuid]);
 
   return {
+    isEnabled: supportUuidEnabled,
     supportUuid,
-    isReady: supportUuid != null,
+    isReady: !supportUuidEnabled || supportUuid != null,
     copy: copySupportUuid,
     regenerate: regenerateSupportUuid,
+    setEnabled: setSupportUuidCollectionEnabled,
   };
 }

--- a/app/src/screens/account/settings/SupportScreen.tsx
+++ b/app/src/screens/account/settings/SupportScreen.tsx
@@ -3,23 +3,26 @@
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
 import React, { useCallback } from 'react';
-import { Alert } from 'react-native';
+import { Alert, StyleSheet, Switch, View } from 'react-native';
 import { Button, ScrollView, YStack } from 'tamagui';
 
 import { BodyText } from '@selfxyz/mobile-sdk-alpha/components';
 import {
   black,
+  blue600,
   slate100,
   slate200,
   slate500,
   white,
 } from '@selfxyz/mobile-sdk-alpha/constants/colors';
+import { dinot } from '@selfxyz/mobile-sdk-alpha/constants/fonts';
 
 import useOpenSupportForm from '@/hooks/useOpenSupportForm';
 import { useSupportUuid } from '@/hooks/useSupportUuid';
 
 const SupportScreen: React.FC = () => {
-  const { supportUuid, copy, regenerate } = useSupportUuid();
+  const { isEnabled, supportUuid, copy, regenerate, setEnabled } =
+    useSupportUuid();
   const openSupportForm = useOpenSupportForm();
   const diagnosticIdText = supportUuid ?? 'Loading diagnostic ID...';
 
@@ -46,6 +49,13 @@ const SupportScreen: React.FC = () => {
     );
   }, [regenerate]);
 
+  const handleSupportUuidToggle = useCallback(
+    (enabled: boolean) => {
+      setEnabled(enabled);
+    },
+    [setEnabled],
+  );
+
   return (
     <ScrollView flex={1} backgroundColor={slate100}>
       <YStack padding={20} gap={20}>
@@ -58,50 +68,98 @@ const SupportScreen: React.FC = () => {
         </Button>
 
         <YStack gap={8}>
+          <View style={styles.settingRow}>
+            <View style={styles.settingTextContainer}>
+              <BodyText style={styles.settingLabel}>
+                Share diagnostic ID
+              </BodyText>
+              <BodyText style={styles.settingDescription}>
+                Enabled by default. Turn this off to stop attaching a diagnostic
+                ID to support requests and troubleshooting screens.
+              </BodyText>
+            </View>
+            <Switch
+              value={isEnabled}
+              onValueChange={handleSupportUuidToggle}
+              trackColor={{ false: slate200, true: blue600 }}
+              thumbColor={white}
+              testID="support-uuid-toggle"
+            />
+          </View>
+
           <BodyText style={{ color: slate500, fontSize: 13 }}>
-            Share the diagnostic ID below when contacting support so we can
-            locate your logs.
+            {isEnabled
+              ? 'Share the diagnostic ID below when contacting support so we can locate your logs.'
+              : 'Diagnostic IDs are off. Enable this setting whenever you want support requests to include a diagnostic identifier.'}
           </BodyText>
 
-          <YStack
-            borderWidth={1}
-            borderColor={slate200}
-            borderRadius={12}
-            backgroundColor={white}
-            padding={16}
-            gap={8}
-          >
-            <BodyText style={{ color: black, fontSize: 16 }}>
-              Diagnostic ID
-            </BodyText>
-            <BodyText style={{ color: slate500, fontSize: 14 }}>
-              {diagnosticIdText}
-            </BodyText>
-          </YStack>
+          {isEnabled ? (
+            <>
+              <YStack
+                borderWidth={1}
+                borderColor={slate200}
+                borderRadius={12}
+                backgroundColor={white}
+                padding={16}
+                gap={8}
+              >
+                <BodyText style={{ color: black, fontSize: 16 }}>
+                  Diagnostic ID
+                </BodyText>
+                <BodyText style={{ color: slate500, fontSize: 14 }}>
+                  {diagnosticIdText}
+                </BodyText>
+              </YStack>
 
-          <Button
-            backgroundColor={white}
-            borderColor={slate200}
-            borderWidth={1}
-            borderRadius={12}
-            onPress={handleCopy}
-          >
-            <BodyText style={{ color: black }}>Copy diagnostic ID</BodyText>
-          </Button>
+              <Button
+                backgroundColor={white}
+                borderColor={slate200}
+                borderWidth={1}
+                borderRadius={12}
+                onPress={handleCopy}
+              >
+                <BodyText style={{ color: black }}>Copy diagnostic ID</BodyText>
+              </Button>
 
-          <Button
-            backgroundColor={white}
-            borderColor={slate200}
-            borderWidth={1}
-            borderRadius={12}
-            onPress={handleRegenerate}
-          >
-            <BodyText style={{ color: black }}>Regenerate</BodyText>
-          </Button>
+              <Button
+                backgroundColor={white}
+                borderColor={slate200}
+                borderWidth={1}
+                borderRadius={12}
+                onPress={handleRegenerate}
+              >
+                <BodyText style={{ color: black }}>Regenerate</BodyText>
+              </Button>
+            </>
+          ) : null}
         </YStack>
       </YStack>
     </ScrollView>
   );
 };
+
+const styles = StyleSheet.create({
+  settingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 16,
+  },
+  settingTextContainer: {
+    flex: 1,
+    gap: 4,
+  },
+  settingLabel: {
+    fontSize: 16,
+    fontFamily: dinot,
+    fontWeight: '500',
+    color: black,
+  },
+  settingDescription: {
+    fontSize: 14,
+    fontFamily: dinot,
+    color: slate500,
+  },
+});
 
 export default SupportScreen;

--- a/app/src/services/analytics.ts
+++ b/app/src/services/analytics.ts
@@ -231,22 +231,14 @@ const identifyInSegment = (nextSupportUuid: string) => {
   });
 };
 
-export const resetAnalyticsIdentityForSupportUuid = (
-  nextSupportUuid: string,
-) => {
-  supportUuid = nextSupportUuid;
+const resetSegmentIdentity = () => {
+  if (!segmentClient) return Promise.resolve();
+  return segmentClient.reset().catch(err => {
+    if (__DEV__) console.warn('Failed to reset Segment identity:', err);
+  });
+};
 
-  if (segmentClient) {
-    segmentClient
-      .reset()
-      .catch(err => {
-        if (__DEV__) console.warn('Failed to reset Segment identity:', err);
-      })
-      .then(() => identifyInSegment(nextSupportUuid));
-  } else {
-    identifyInSegment(nextSupportUuid);
-  }
-
+const resetMixpanelIdentity = () => {
   if (PassportReader && typeof PassportReader.resetIdentity === 'function') {
     try {
       PassportReader.resetIdentity();
@@ -256,7 +248,9 @@ export const resetAnalyticsIdentityForSupportUuid = (
       }
     }
   }
+};
 
+const setMixpanelDistinctId = (nextSupportUuid: string) => {
   if (PassportReader && typeof PassportReader.setDistinctId === 'function') {
     try {
       PassportReader.setDistinctId(nextSupportUuid);
@@ -268,20 +262,32 @@ export const resetAnalyticsIdentityForSupportUuid = (
   }
 };
 
-export const setAnalyticsSupportUuid = (nextSupportUuid: string) => {
+export const resetAnalyticsIdentityForSupportUuid = (
+  nextSupportUuid: string,
+) => {
   supportUuid = nextSupportUuid;
 
-  identifyInSegment(nextSupportUuid);
-
-  if (PassportReader && typeof PassportReader.setDistinctId === 'function') {
-    try {
-      PassportReader.setDistinctId(nextSupportUuid);
-    } catch (error) {
-      if (__DEV__) {
-        console.warn('Failed to set Mixpanel distinct_id:', error);
-      }
-    }
+  if (segmentClient) {
+    resetSegmentIdentity().then(() => identifyInSegment(nextSupportUuid));
+  } else {
+    identifyInSegment(nextSupportUuid);
   }
+
+  resetMixpanelIdentity();
+  setMixpanelDistinctId(nextSupportUuid);
+};
+
+export const setAnalyticsSupportUuid = (nextSupportUuid: string | null) => {
+  supportUuid = nextSupportUuid;
+
+  if (!nextSupportUuid) {
+    resetSegmentIdentity();
+    resetMixpanelIdentity();
+    return;
+  }
+
+  identifyInSegment(nextSupportUuid);
+  setMixpanelDistinctId(nextSupportUuid);
 };
 
 /**

--- a/app/src/services/analytics.ts
+++ b/app/src/services/analytics.ts
@@ -281,6 +281,11 @@ export const setAnalyticsSupportUuid = (nextSupportUuid: string | null) => {
   supportUuid = nextSupportUuid;
 
   if (!nextSupportUuid) {
+    for (const evt of eventQueue) {
+      if (evt.properties) {
+        delete (evt.properties as Record<string, unknown>).support_uuid;
+      }
+    }
     resetSegmentIdentity();
     resetMixpanelIdentity();
     return;

--- a/app/src/services/logging/logger/lokiTransport.ts
+++ b/app/src/services/logging/logger/lokiTransport.ts
@@ -200,15 +200,23 @@ const lokiTransport: transportFunctionType<LokiTransportOptions> = props => {
     message: string;
     timestamp: string;
     session_id: string;
-    support_uuid: string;
+    support_uuid_enabled: boolean;
+    support_uuid?: string;
     data?: unknown;
-  } = {
-    level: level.text,
-    message: actualMessage,
-    timestamp,
-    session_id: sessionId,
-    support_uuid: useSettingStore.getState().supportUuid ?? 'unset',
-  };
+  } = (() => {
+    const { supportUuid, supportUuidEnabled } = useSettingStore.getState();
+
+    return {
+      level: level.text,
+      message: actualMessage,
+      timestamp,
+      session_id: sessionId,
+      support_uuid_enabled: supportUuidEnabled,
+      ...(supportUuidEnabled
+        ? { support_uuid: supportUuid ?? 'unset' }
+        : undefined),
+    };
+  })();
 
   if (actualData) {
     logObject.data = actualData;

--- a/app/src/services/supportUuid.ts
+++ b/app/src/services/supportUuid.ts
@@ -29,22 +29,17 @@ const ensureSupportUuid = (): string | null => {
 
 export const appendSupportUuidToUrl = (url: string): string => {
   const supportUuid = ensureSupportUuid();
-  if (!supportUuid) {
-    return url;
-  }
 
   try {
     const parsed = new URL(url);
-    parsed.searchParams.set('support_uuid', supportUuid);
+    if (supportUuid) {
+      parsed.searchParams.set('support_uuid', supportUuid);
+    } else {
+      parsed.searchParams.delete('support_uuid');
+    }
     return parsed.toString();
   } catch {
-    // Fallback for malformed URLs / unsupported URL parsing edge-cases.
-    // Preserve any fragment by appending the query before `#`.
-    const hashIndex = url.indexOf('#');
-    const baseUrl = hashIndex === -1 ? url : url.slice(0, hashIndex);
-    const hash = hashIndex === -1 ? '' : url.slice(hashIndex);
-    const separator = baseUrl.includes('?') ? '&' : '?';
-    return `${baseUrl}${separator}support_uuid=${encodeURIComponent(supportUuid)}${hash}`;
+    return url;
   }
 };
 

--- a/app/src/services/supportUuid.ts
+++ b/app/src/services/supportUuid.ts
@@ -12,8 +12,12 @@ import {
 } from '@/services/analytics';
 import { useSettingStore } from '@/stores/settingStore';
 
-const ensureSupportUuid = (): string => {
+const ensureSupportUuid = (): string | null => {
   const state = useSettingStore.getState();
+  if (!state.supportUuidEnabled) {
+    return null;
+  }
+
   if (state.supportUuid) {
     return state.supportUuid;
   }
@@ -25,6 +29,9 @@ const ensureSupportUuid = (): string => {
 
 export const appendSupportUuidToUrl = (url: string): string => {
   const supportUuid = ensureSupportUuid();
+  if (!supportUuid) {
+    return url;
+  }
 
   try {
     const parsed = new URL(url);
@@ -41,30 +48,64 @@ export const appendSupportUuidToUrl = (url: string): string => {
   }
 };
 
-export const copySupportUuid = (): string => {
+export const copySupportUuid = (): string | null => {
   const supportUuid = ensureSupportUuid();
+  if (!supportUuid) {
+    return null;
+  }
+
   Clipboard.setString(supportUuid);
   return supportUuid;
 };
 
-export const getSupportUuid = (): string => {
+export const getSupportUuid = (): string | null => {
   return ensureSupportUuid();
 };
 
-export const initializeSupportUuidContext = (): string => {
+export const initializeSupportUuidContext = (): string | null => {
+  const { supportUuidEnabled } = useSettingStore.getState();
   const supportUuid = ensureSupportUuid();
-  setSupportUuidInSentry(supportUuid);
-  setAnalyticsSupportUuid(supportUuid);
+  setSupportUuidInSentry(supportUuid, supportUuidEnabled);
+  setAnalyticsSupportUuid(supportUuidEnabled ? supportUuid : null);
   return supportUuid;
 };
 
-export const regenerateSupportUuid = (): string => {
-  const nextUuid = uuidv4();
+export const regenerateSupportUuid = (): string | null => {
   const state = useSettingStore.getState();
+  if (!state.supportUuidEnabled) {
+    return null;
+  }
+
+  const nextUuid = uuidv4();
   state.setSupportUuid(nextUuid);
 
-  setSupportUuidInSentry(nextUuid);
+  setSupportUuidInSentry(nextUuid, true);
   resetAnalyticsIdentityForSupportUuid(nextUuid);
 
+  return nextUuid;
+};
+
+export const setSupportUuidCollectionEnabled = (
+  enabled: boolean,
+): string | null => {
+  const state = useSettingStore.getState();
+
+  if (enabled === state.supportUuidEnabled) {
+    return enabled ? ensureSupportUuid() : null;
+  }
+
+  state.setSupportUuidEnabled(enabled);
+
+  if (!enabled) {
+    state.setSupportUuid(null);
+    setSupportUuidInSentry(null, false);
+    setAnalyticsSupportUuid(null);
+    return null;
+  }
+
+  const nextUuid = uuidv4();
+  state.setSupportUuid(nextUuid);
+  setSupportUuidInSentry(nextUuid, true);
+  resetAnalyticsIdentityForSupportUuid(nextUuid);
   return nextUuid;
 };

--- a/app/src/stores/settingStore.ts
+++ b/app/src/stores/settingStore.ts
@@ -23,6 +23,7 @@ interface PersistedSettingsState {
   isDevMode: boolean;
   loggingSeverity: LoggingSeverity;
   pointsAddress: string | null;
+  supportUuidEnabled: boolean;
   supportUuid: string | null;
   removeSubscribedTopic: (topic: string) => void;
   resetBackupForPoints: () => void;
@@ -35,6 +36,7 @@ interface PersistedSettingsState {
   setKeychainMigrationCompleted: () => void;
   setLoggingSeverity: (severity: LoggingSeverity) => void;
   setPointsAddress: (address: string | null) => void;
+  setSupportUuidEnabled: (enabled: boolean) => void;
   setSupportUuid: (supportUuid: string | null) => void;
   setSkipDocumentSelector: (value: boolean) => void;
   setSubscribedTopics: (topics: string[]) => void;
@@ -141,6 +143,9 @@ export const useSettingStore = create<SettingsState>()(
       setPointsAddress: (address: string | null) =>
         set({ pointsAddress: address }),
 
+      supportUuidEnabled: true,
+      setSupportUuidEnabled: (supportUuidEnabled: boolean) =>
+        set({ supportUuidEnabled }),
       supportUuid: null,
       setSupportUuid: (supportUuid: string | null) => set({ supportUuid }),
 

--- a/app/tests/src/components/support/SupportUuidRow.test.tsx
+++ b/app/tests/src/components/support/SupportUuidRow.test.tsx
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+import SupportUuidRow from '@/components/support/SupportUuidRow';
+import { useSupportUuid } from '@/hooks/useSupportUuid';
+
+jest.mock('@selfxyz/mobile-sdk-alpha/components', () => ({
+  BodyText: ({ children, ...props }: any) => (
+    <mock-text {...props}>{children}</mock-text>
+  ),
+}));
+
+jest.mock('@/hooks/useSupportUuid', () => ({
+  useSupportUuid: jest.fn(),
+}));
+
+describe('SupportUuidRow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not render when diagnostic IDs are disabled', () => {
+    (useSupportUuid as jest.Mock).mockReturnValue({
+      isEnabled: false,
+      supportUuid: null,
+      isReady: true,
+      copy: jest.fn(),
+      regenerate: jest.fn(),
+      setEnabled: jest.fn(),
+    });
+
+    const { toJSON } = render(<SupportUuidRow />);
+
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders the collapsed affordance when diagnostic IDs are enabled', () => {
+    (useSupportUuid as jest.Mock).mockReturnValue({
+      isEnabled: true,
+      supportUuid: '11111111-1111-1111-1111-111111111111',
+      isReady: true,
+      copy: jest.fn(),
+      regenerate: jest.fn(),
+      setEnabled: jest.fn(),
+    });
+
+    const { toJSON } = render(<SupportUuidRow />);
+
+    expect(JSON.stringify(toJSON())).toContain('Show diagnostic ID');
+  });
+});

--- a/app/tests/src/services/analytics.test.ts
+++ b/app/tests/src/services/analytics.test.ts
@@ -366,6 +366,11 @@ describe('analytics', () => {
       expect(mockSegmentClient.identify).toHaveBeenCalledWith('uuid-1');
     });
 
+    it('resets analytics identity when support UUID is cleared', () => {
+      setAnalyticsSupportUuid(null);
+      expect(mockSegmentClient.reset).toHaveBeenCalled();
+    });
+
     it('resets and re-identifies on resetAnalyticsIdentityForSupportUuid', async () => {
       resetAnalyticsIdentityForSupportUuid('uuid-2');
       expect(mockSegmentClient.reset).toHaveBeenCalled();

--- a/app/tests/src/services/logging/lokiTransport.test.ts
+++ b/app/tests/src/services/logging/lokiTransport.test.ts
@@ -29,10 +29,16 @@ jest.mock('../../../../env', () => ({
 }));
 
 jest.mock('@/stores/settingStore', () => {
-  const state = { supportUuid: null as string | null };
+  const state = {
+    supportUuid: null as string | null,
+    supportUuidEnabled: true,
+  };
   return {
     useSettingStore: {
       getState: () => ({
+        get supportUuidEnabled() {
+          return state.supportUuidEnabled;
+        },
         get supportUuid() {
           return state.supportUuid;
         },
@@ -44,7 +50,7 @@ jest.mock('@/stores/settingStore', () => {
 
 const storeState = (
   useSettingStore as unknown as {
-    __state: { supportUuid: string | null };
+    __state: { supportUuid: string | null; supportUuidEnabled: boolean };
   }
 ).__state;
 
@@ -65,6 +71,7 @@ describe('lokiTransport', () => {
     fetchMock = jest.fn().mockResolvedValue({ ok: true });
     (global as unknown as { fetch: jest.Mock }).fetch = fetchMock;
     storeState.supportUuid = null;
+    storeState.supportUuidEnabled = true;
   });
 
   afterEach(() => {
@@ -84,6 +91,7 @@ describe('lokiTransport', () => {
     const payload = JSON.parse(init.body as string);
     const logLine = JSON.parse(payload.streams[0].values[0][1]);
     expect(logLine.support_uuid).toBe('abc-123');
+    expect(logLine.support_uuid_enabled).toBe(true);
   });
 
   it('falls back to "unset" when no support UUID is stored', async () => {
@@ -96,6 +104,21 @@ describe('lokiTransport', () => {
     const payload = JSON.parse(init.body as string);
     const logLine = JSON.parse(payload.streams[0].values[0][1]);
     expect(logLine.support_uuid).toBe('unset');
+    expect(logLine.support_uuid_enabled).toBe(true);
+  });
+
+  it('omits support_uuid when diagnostic IDs are disabled', async () => {
+    storeState.supportUuidEnabled = false;
+    callTransport();
+    flushLokiTransport();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const [, init] = fetchMock.mock.calls[0];
+    const payload = JSON.parse(init.body as string);
+    const logLine = JSON.parse(payload.streams[0].values[0][1]);
+    expect(logLine).not.toHaveProperty('support_uuid');
+    expect(logLine.support_uuid_enabled).toBe(false);
   });
 
   it('does not put support_uuid or session_id in Loki stream labels', async () => {

--- a/app/tests/src/services/supportUuid.test.ts
+++ b/app/tests/src/services/supportUuid.test.ts
@@ -128,21 +128,27 @@ describe('supportUuid service', () => {
       expect(result).not.toContain('support_uuid=stale');
     });
 
-    it('preserves fragments when falling back on malformed URLs', () => {
+    it('returns the URL unchanged when URL parsing fails', () => {
       const urlSpy = jest.spyOn(global, 'URL').mockImplementationOnce(() => {
         throw new TypeError('invalid');
       });
-      const result = appendSupportUuidToUrl('support?x=1#section');
-      expect(result).toBe(
-        `support?x=1&support_uuid=${storeState.supportUuid}#section`,
+      expect(appendSupportUuidToUrl('support?x=1#section')).toBe(
+        'support?x=1#section',
       );
       urlSpy.mockRestore();
     });
 
-    it('leaves the URL unchanged when diagnostic IDs are disabled', () => {
+    it('strips support_uuid from the URL when diagnostic IDs are disabled', () => {
       storeState.supportUuidEnabled = false;
-      const url = 'https://example.com/help?x=1';
-      expect(appendSupportUuidToUrl(url)).toBe(url);
+      expect(
+        appendSupportUuidToUrl('https://example.com/help?x=1&support_uuid=abc'),
+      ).toBe('https://example.com/help?x=1');
+      expect(
+        appendSupportUuidToUrl('https://example.com/help?support_uuid=abc'),
+      ).toBe('https://example.com/help');
+      expect(appendSupportUuidToUrl('https://example.com/help?x=1')).toBe(
+        'https://example.com/help?x=1',
+      );
     });
   });
 

--- a/app/tests/src/services/supportUuid.test.ts
+++ b/app/tests/src/services/supportUuid.test.ts
@@ -15,23 +15,35 @@ import {
   getSupportUuid,
   initializeSupportUuidContext,
   regenerateSupportUuid,
+  setSupportUuidCollectionEnabled,
 } from '@/services/supportUuid';
 import { useSettingStore } from '@/stores/settingStore';
 
 jest.mock('@/stores/settingStore', () => {
-  const state = { supportUuid: null as string | null };
+  const state = {
+    supportUuid: null as string | null,
+    supportUuidEnabled: true,
+  };
   const setSupportUuid = jest.fn((next: string | null) => {
     state.supportUuid = next;
+  });
+  const setSupportUuidEnabled = jest.fn((next: boolean) => {
+    state.supportUuidEnabled = next;
   });
   return {
     useSettingStore: {
       getState: () => ({
+        get supportUuidEnabled() {
+          return state.supportUuidEnabled;
+        },
         get supportUuid() {
           return state.supportUuid;
         },
+        setSupportUuidEnabled,
         setSupportUuid,
       }),
       __state: state,
+      __setSupportUuidEnabled: setSupportUuidEnabled,
       __setSupportUuid: setSupportUuid,
     },
   };
@@ -52,15 +64,21 @@ jest.mock('@react-native-clipboard/clipboard', () => ({
 }));
 
 const storeState = (
-  useSettingStore as unknown as { __state: { supportUuid: string | null } }
+  useSettingStore as unknown as {
+    __state: { supportUuid: string | null; supportUuidEnabled: boolean };
+  }
 ).__state;
 const mockSetSupportUuid = (
   useSettingStore as unknown as { __setSupportUuid: jest.Mock }
 ).__setSupportUuid;
+const mockSetSupportUuidEnabled = (
+  useSettingStore as unknown as { __setSupportUuidEnabled: jest.Mock }
+).__setSupportUuidEnabled;
 
 describe('supportUuid service', () => {
   beforeEach(() => {
     storeState.supportUuid = null;
+    storeState.supportUuidEnabled = true;
     jest.clearAllMocks();
   });
 
@@ -74,6 +92,12 @@ describe('supportUuid service', () => {
     it('returns the persisted UUID on subsequent calls', () => {
       storeState.supportUuid = '11111111-1111-1111-1111-111111111111';
       expect(getSupportUuid()).toBe(storeState.supportUuid);
+      expect(mockSetSupportUuid).not.toHaveBeenCalled();
+    });
+
+    it('returns null when diagnostic IDs are disabled', () => {
+      storeState.supportUuidEnabled = false;
+      expect(getSupportUuid()).toBeNull();
       expect(mockSetSupportUuid).not.toHaveBeenCalled();
     });
   });
@@ -114,13 +138,26 @@ describe('supportUuid service', () => {
       );
       urlSpy.mockRestore();
     });
+
+    it('leaves the URL unchanged when diagnostic IDs are disabled', () => {
+      storeState.supportUuidEnabled = false;
+      const url = 'https://example.com/help?x=1';
+      expect(appendSupportUuidToUrl(url)).toBe(url);
+    });
   });
 
   describe('initializeSupportUuidContext', () => {
     it('wires the UUID into Sentry and analytics', () => {
       const uuid = initializeSupportUuidContext();
-      expect(setSupportUuidInSentry).toHaveBeenCalledWith(uuid);
+      expect(setSupportUuidInSentry).toHaveBeenCalledWith(uuid, true);
       expect(setAnalyticsSupportUuid).toHaveBeenCalledWith(uuid);
+    });
+
+    it('clears support UUID context when diagnostic IDs are disabled', () => {
+      storeState.supportUuidEnabled = false;
+      expect(initializeSupportUuidContext()).toBeNull();
+      expect(setSupportUuidInSentry).toHaveBeenCalledWith(null, false);
+      expect(setAnalyticsSupportUuid).toHaveBeenCalledWith(null);
     });
   });
 
@@ -132,8 +169,15 @@ describe('supportUuid service', () => {
       expect(next).not.toBe('old-uuid');
       expect(mockSetSupportUuid).toHaveBeenCalledWith(next);
       expect(setSupportUuidInSentry).toHaveBeenCalledTimes(1);
-      expect(setSupportUuidInSentry).toHaveBeenCalledWith(next);
+      expect(setSupportUuidInSentry).toHaveBeenCalledWith(next, true);
       expect(resetAnalyticsIdentityForSupportUuid).toHaveBeenCalledWith(next);
+    });
+
+    it('returns null when regenerate is called while disabled', () => {
+      storeState.supportUuidEnabled = false;
+      expect(regenerateSupportUuid()).toBeNull();
+      expect(mockSetSupportUuid).not.toHaveBeenCalled();
+      expect(resetAnalyticsIdentityForSupportUuid).not.toHaveBeenCalled();
     });
   });
 
@@ -143,6 +187,38 @@ describe('supportUuid service', () => {
       const uuid = copySupportUuid();
       expect(uuid).toBe(storeState.supportUuid);
       expect(Clipboard.setString).toHaveBeenCalledWith(storeState.supportUuid);
+    });
+
+    it('returns null when copy is called while disabled', () => {
+      storeState.supportUuidEnabled = false;
+      expect(copySupportUuid()).toBeNull();
+      expect(Clipboard.setString).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('setSupportUuidCollectionEnabled', () => {
+    it('disables diagnostic IDs and clears the current UUID', () => {
+      storeState.supportUuid = 'existing-uuid';
+      expect(setSupportUuidCollectionEnabled(false)).toBeNull();
+
+      expect(mockSetSupportUuidEnabled).toHaveBeenCalledWith(false);
+      expect(mockSetSupportUuid).toHaveBeenCalledWith(null);
+      expect(setSupportUuidInSentry).toHaveBeenCalledWith(null, false);
+      expect(setAnalyticsSupportUuid).toHaveBeenCalledWith(null);
+    });
+
+    it('re-enables diagnostic IDs with a fresh UUID', () => {
+      storeState.supportUuidEnabled = false;
+
+      const nextUuid = setSupportUuidCollectionEnabled(true);
+
+      expect(nextUuid).toMatch(/^[0-9a-f-]{36}$/);
+      expect(mockSetSupportUuidEnabled).toHaveBeenCalledWith(true);
+      expect(mockSetSupportUuid).toHaveBeenCalledWith(nextUuid);
+      expect(setSupportUuidInSentry).toHaveBeenCalledWith(nextUuid, true);
+      expect(resetAnalyticsIdentityForSupportUuid).toHaveBeenCalledWith(
+        nextUuid,
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add a Support settings toggle letting users disable the diagnostic ID; defaults to enabled for existing and new users.
- When disabled, clear the stored UUID, stop appending `support_uuid` to support URLs, reset Segment/Mixpanel identity, and hide the diagnostic ID row on all error/trouble screens.
- Preserve observability parity by recording `support_uuid_enabled` state in Loki and Sentry (native + web) without collapsing opted-out users onto a shared sentinel UUID.

## Changes

### React Native app

- `stores/settingStore.ts` — add persisted `supportUuidEnabled` flag (default `true`) with setter.
- `services/supportUuid.ts` — gate UUID generation on the flag; add `setSupportUuidCollectionEnabled` that clears state and resets downstream identity; `initializeSupportUuidContext` now propagates the enabled state.
- `services/analytics.ts` — add `setAnalyticsSupportUuid` to identify/reset Segment + Mixpanel based on the flag.
- `services/logging/logger/lokiTransport.ts` — emit `support_uuid_enabled` on every log line; omit `support_uuid` entirely when disabled.
- `config/sentry.ts` / `config/sentry.web.ts` — set `support_uuid_enabled` and `support_uuid` tags (web parity added).
- `screens/account/settings/SupportScreen.tsx` — new toggle row with description; hides Copy/Regenerate affordances when disabled.
- `components/support/SupportUuidRow.tsx` — returns `null` when disabled, removing the row from NFC/KYC/QR/document trouble screens automatically.
- `hooks/useSupportUuid.ts` — expose `isEnabled`, `setEnabled`, and ensure UUID lazy-creation only when enabled.

### Tests

- New `tests/src/components/support/SupportUuidRow.test.tsx` — covers disabled (renders null) and enabled (renders collapsed affordance).
- Extended `supportUuid.test.ts`, `lokiTransport.test.ts`, `analytics.test.ts` for the disabled path (URL passthrough, log shape, analytics reset).

## Linear Issues

- Closes [SELF-2658](https://linear.app/selfprotocol/issue/SELF-2658/make-support-diagnostic-id-optional-and-hide-it-when-disabled) — Make support diagnostic ID optional and hide it when disabled

## Test Plan

- [ ] `yarn workspace @selfxyz/mobile-app lint` passes
- [ ] `yarn workspace @selfxyz/mobile-app types` passes
- [ ] `yarn workspace @selfxyz/mobile-app jest:run app/tests/src/services/supportUuid.test.ts app/tests/src/services/logging/lokiTransport.test.ts app/tests/src/services/analytics.test.ts app/tests/src/components/support/SupportUuidRow.test.tsx --runInBand` passes
- [ ] Manual: toggle off in Support settings → Diagnostic ID card hides; NFC/KYC/QR trouble screens no longer show the row; outgoing support form URL lacks `support_uuid`.
- [ ] Manual: toggle back on → fresh UUID generated, appears in row, attached to support URL, visible as Sentry tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "Share diagnostic ID" toggle in settings to control diagnostic ID collection and sharing
  * When disabled, diagnostic IDs are not collected or sent in logs and analytics
  * When enabled, users can view, copy, and regenerate their diagnostic ID
  * UI dynamically displays diagnostic ID management options based on the toggle state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->