### PR TITLE
Add Troubleshooting screen with points disclosure fix

### DIFF
--- a/app/src/navigation/devTools.tsx
+++ b/app/src/navigation/devTools.tsx
@@ -12,6 +12,7 @@ import DevFeatureFlagsScreen from '@/screens/dev/DevFeatureFlagsScreen';
 import DevHapticFeedbackScreen from '@/screens/dev/DevHapticFeedbackScreen';
 import DevLoadingScreen from '@/screens/dev/DevLoadingScreen';
 import DevPrivateKeyScreen from '@/screens/dev/DevPrivateKeyScreen';
+import TroubleshootingScreen from '@/screens/dev/TroubleshootingScreen';
 import DevSettingsScreen from '@/screens/dev/DevSettingsScreen';
 import SocialLoginDemoScreen from '@/screens/dev/SocialLoginDemoScreen';
 
@@ -87,6 +88,13 @@ const devScreens = {
     options: {
       ...devHeaderOptions,
       title: 'Social Login Demo',
+    } as NativeStackNavigationOptions,
+  },
+  Troubleshooting: {
+    screen: TroubleshootingScreen,
+    options: {
+      ...devHeaderOptions,
+      title: 'Troubleshooting',
     } as NativeStackNavigationOptions,
   },
 };

--- a/app/src/navigation/devTools.tsx
+++ b/app/src/navigation/devTools.tsx
@@ -12,9 +12,9 @@ import DevFeatureFlagsScreen from '@/screens/dev/DevFeatureFlagsScreen';
 import DevHapticFeedbackScreen from '@/screens/dev/DevHapticFeedbackScreen';
 import DevLoadingScreen from '@/screens/dev/DevLoadingScreen';
 import DevPrivateKeyScreen from '@/screens/dev/DevPrivateKeyScreen';
-import TroubleshootingScreen from '@/screens/dev/TroubleshootingScreen';
 import DevSettingsScreen from '@/screens/dev/DevSettingsScreen';
 import SocialLoginDemoScreen from '@/screens/dev/SocialLoginDemoScreen';
+import TroubleshootingScreen from '@/screens/dev/TroubleshootingScreen';
 
 const devHeaderOptions: NativeStackNavigationOptions = {
   headerStyle: {

--- a/app/src/screens/account/settings/SettingsScreen.tsx
+++ b/app/src/screens/account/settings/SettingsScreen.tsx
@@ -3,7 +3,7 @@
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
 import type { PropsWithChildren } from 'react';
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { Linking, Platform, Share, View as RNView } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -11,7 +11,7 @@ import type { SvgProps } from 'react-native-svg';
 import { Button, ScrollView, View, XStack, YStack } from 'tamagui';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { Bug, FileText, Settings2 } from '@tamagui/lucide-icons';
+import { Bug, FileText, Settings2, Wrench } from '@tamagui/lucide-icons';
 
 import { BodyText, pressedStyle } from '@selfxyz/mobile-sdk-alpha/components';
 import {
@@ -80,6 +80,7 @@ const ROUTE_ICONS: Record<SettingsRouteKey, React.FC<SvgProps>> = {
   Support: Feedback,
   share: ShareIcon,
   DevSettings: Bug as React.FC<SvgProps>,
+  Troubleshooting: Wrench as React.FC<SvgProps>,
 };
 
 const social = [
@@ -133,6 +134,7 @@ const SocialButton: React.FC<SocialButtonProps> = ({
 
 const SettingsScreen: React.FC = () => {
   const { isDevMode, setDevModeOn } = useSettingStore();
+  const [isTroubleshootingMode, setTroubleshootingMode] = useState(false);
   const navigation =
     useNavigation<NativeStackNavigationProp<MinimalRootStackParamList>>();
   const { hasRealDocument } = useHasRealDocument('SettingsScreen');
@@ -147,15 +149,24 @@ const SettingsScreen: React.FC = () => {
         platform: CURRENT_PLATFORM,
         hasRealDocument: hasRealDocument === true,
         isDevMode,
+        isTroubleshootingMode,
       }),
-    [hasRealDocument, isDevMode],
+    [hasRealDocument, isDevMode, isTroubleshootingMode],
   );
+
+  const troubleshootingTap = Gesture.Tap()
+    .numberOfTaps(3)
+    .onStart(() => {
+      setTroubleshootingMode(true);
+    });
 
   const devModeTap = Gesture.Tap()
     .numberOfTaps(5)
     .onStart(() => {
       setDevModeOn();
     });
+
+  const combinedTap = Gesture.Exclusive(devModeTap, troubleshootingTap);
 
   const onMenuPress = useCallback(
     (menuRoute: SettingsRouteKey) => {
@@ -180,7 +191,7 @@ const SettingsScreen: React.FC = () => {
   );
   const { bottom } = useSafeAreaInsets();
   return (
-    <GestureDetector gesture={devModeTap}>
+    <GestureDetector gesture={combinedTap}>
       <RNView collapsable={false}>
         <View backgroundColor={white}>
           <YStack

--- a/app/src/screens/account/settings/SupportScreen.tsx
+++ b/app/src/screens/account/settings/SupportScreen.tsx
@@ -34,7 +34,7 @@ const SupportScreen: React.FC = () => {
   const handleRegenerate = useCallback(() => {
     Alert.alert(
       'Regenerate diagnostic ID?',
-      'This will immediately replace the current ID for future support diagnostics.',
+      "Use this if you've shared your ID publicly or want a fresh one for a new issue. Future support requests will use the new ID.",
       [
         { text: 'Cancel', style: 'cancel' },
         {
@@ -42,7 +42,7 @@ const SupportScreen: React.FC = () => {
           style: 'destructive',
           onPress: () => {
             regenerate();
-            Alert.alert('Updated', 'Diagnostic ID regenerated successfully.');
+            Alert.alert('Updated', 'Your diagnostic ID has been replaced.');
           },
         },
       ],
@@ -68,14 +68,20 @@ const SupportScreen: React.FC = () => {
         </Button>
 
         <YStack gap={8}>
+          <BodyText style={{ color: slate500, fontSize: 13 }}>
+            A diagnostic ID helps our team find the activity related to your
+            report. It's not tied to your identity.
+          </BodyText>
+
           <View style={styles.settingRow}>
             <View style={styles.settingTextContainer}>
               <BodyText style={styles.settingLabel}>
                 Share diagnostic ID
               </BodyText>
               <BodyText style={styles.settingDescription}>
-                Enabled by default. Turn this off to stop attaching a diagnostic
-                ID to support requests and troubleshooting screens.
+                {isEnabled
+                  ? 'Share the diagnostic ID below with support so we can find the activity related to your report. Turn this off to keep it out of support requests and error screens.'
+                  : 'Diagnostic ID is off. Turn it on to include it in future support requests.'}
               </BodyText>
             </View>
             <Switch
@@ -86,12 +92,6 @@ const SupportScreen: React.FC = () => {
               testID="support-uuid-toggle"
             />
           </View>
-
-          <BodyText style={{ color: slate500, fontSize: 13 }}>
-            {isEnabled
-              ? 'Share the diagnostic ID below when contacting support so we can locate your logs.'
-              : 'Diagnostic IDs are off. Enable this setting whenever you want support requests to include a diagnostic identifier.'}
-          </BodyText>
 
           {isEnabled ? (
             <>

--- a/app/src/screens/account/settings/settingsMenu.ts
+++ b/app/src/screens/account/settings/settingsMenu.ts
@@ -30,11 +30,6 @@ export const DEBUG_SETTINGS_ENTRY: SettingsEntry = {
   route: 'DevSettings',
 };
 
-export const TROUBLESHOOTING_ENTRY: SettingsEntry = {
-  label: 'Troubleshooting',
-  route: 'Troubleshooting',
-};
-
 export const SETTINGS_ENTRIES_NATIVE: readonly SettingsEntry[] = [
   { label: 'Manage ID documents', route: 'ManageDocuments' },
   { label: 'Security & backup', route: 'SecurityAndBackup' },
@@ -48,6 +43,11 @@ export const SETTINGS_ENTRIES_WEB: readonly SettingsEntry[] = [
   { label: 'Proof settings', route: 'ProofSettings' },
   { label: 'Get support', route: 'Support' },
 ];
+
+export const TROUBLESHOOTING_ENTRY: SettingsEntry = {
+  label: 'Troubleshooting',
+  route: 'Troubleshooting',
+};
 
 export const baseEntriesForPlatform = (
   platform: SettingsPlatform,

--- a/app/src/screens/account/settings/settingsMenu.ts
+++ b/app/src/screens/account/settings/settingsMenu.ts
@@ -11,6 +11,7 @@ export type SettingsGatingContext = {
   platform: SettingsPlatform;
   hasRealDocument: boolean;
   isDevMode: boolean;
+  isTroubleshootingMode: boolean;
 };
 
 export type SettingsPlatform = 'ios' | 'android' | 'web';
@@ -21,11 +22,17 @@ export type SettingsRouteKey =
   | 'ProofSettings'
   | 'Support'
   | 'share'
-  | 'DevSettings';
+  | 'DevSettings'
+  | 'Troubleshooting';
 
 export const DEBUG_SETTINGS_ENTRY: SettingsEntry = {
   label: 'Debug menu',
   route: 'DevSettings',
+};
+
+export const TROUBLESHOOTING_ENTRY: SettingsEntry = {
+  label: 'Troubleshooting',
+  route: 'Troubleshooting',
 };
 
 export const SETTINGS_ENTRIES_NATIVE: readonly SettingsEntry[] = [
@@ -55,10 +62,14 @@ export const baseEntriesForPlatform = (
 export const buildSettingsMenu = (
   context: SettingsGatingContext,
 ): SettingsEntry[] => {
-  const { platform, isDevMode } = context;
+  const { platform, isDevMode, isTroubleshootingMode } = context;
   const base = baseEntriesForPlatform(platform);
-  const withDebug = isDevMode ? [...base, DEBUG_SETTINGS_ENTRY] : base;
-  return withDebug.filter(entry => shouldShowSettingsEntry(entry, context));
+  const entries = [
+    ...base,
+    ...(isTroubleshootingMode ? [TROUBLESHOOTING_ENTRY] : []),
+    ...(isDevMode ? [DEBUG_SETTINGS_ENTRY] : []),
+  ];
+  return entries.filter(entry => shouldShowSettingsEntry(entry, context));
 };
 
 export const shouldShowSettingsEntry = (

--- a/app/src/screens/account/settings/settingsMenu.ts
+++ b/app/src/screens/account/settings/settingsMenu.ts
@@ -66,7 +66,7 @@ export const buildSettingsMenu = (
   const base = baseEntriesForPlatform(platform);
   const entries = [
     ...base,
-    ...(isTroubleshootingMode ? [TROUBLESHOOTING_ENTRY] : []),
+    ...(isTroubleshootingMode || isDevMode ? [TROUBLESHOOTING_ENTRY] : []),
     ...(isDevMode ? [DEBUG_SETTINGS_ENTRY] : []),
   ];
   return entries.filter(entry => shouldShowSettingsEntry(entry, context));

--- a/app/src/screens/dev/TroubleshootingScreen.tsx
+++ b/app/src/screens/dev/TroubleshootingScreen.tsx
@@ -49,7 +49,7 @@ const FixDisclosureScreen: React.FC = () => {
       ]).toString();
       const userAddress = await getPointsAddress();
 
-      console.log(userAddress, nullifier);
+      console.log(userAddress);
 
       const response = await fetch(
         `${POINTS_API_BASE_URL}/points-disclose-fix`,

--- a/app/src/screens/dev/TroubleshootingScreen.tsx
+++ b/app/src/screens/dev/TroubleshootingScreen.tsx
@@ -10,7 +10,6 @@ import { hashEndpointWithScope } from '@selfxyz/common/utils/scope';
 import {
   black,
   slate200,
-  slate500,
   teal500,
   white,
 } from '@selfxyz/mobile-sdk-alpha/constants/colors';
@@ -22,7 +21,7 @@ import { getPointsAddress } from '@/services/points/utils';
 const POINTS_ENDPOINT = '0x829d183faaa675f8f80e8bb25fb1476cd4f7c1f0';
 const POINTS_SCOPE = 'minimal-disclosure-quest';
 
-const FixDisclosureScreen: React.FC = () => {
+const TroubleshootingScreen: React.FC = () => {
   const [status, setStatus] = useState<
     'idle' | 'loading' | 'success' | 'error'
   >('idle');
@@ -48,8 +47,6 @@ const FixDisclosureScreen: React.FC = () => {
         BigInt(scopeHash),
       ]).toString();
       const userAddress = await getPointsAddress();
-
-      console.log(userAddress);
 
       const response = await fetch(
         `${POINTS_API_BASE_URL}/points-disclose-fix`,
@@ -111,4 +108,4 @@ const FixDisclosureScreen: React.FC = () => {
   );
 };
 
-export default FixDisclosureScreen;
+export default TroubleshootingScreen;

--- a/app/src/screens/dev/TroubleshootingScreen.tsx
+++ b/app/src/screens/dev/TroubleshootingScreen.tsx
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { poseidon2 } from 'poseidon-lite';
+import React, { useState } from 'react';
+import { Button, Spinner, Text, YStack } from 'tamagui';
+
+import { hashEndpointWithScope } from '@selfxyz/common/utils/scope';
+import {
+  black,
+  slate200,
+  slate500,
+  teal500,
+  white,
+} from '@selfxyz/mobile-sdk-alpha/constants/colors';
+
+import { unsafe_getPrivateKey } from '@/providers/authProvider';
+import { POINTS_API_BASE_URL } from '@/services/points/constants';
+import { getPointsAddress } from '@/services/points/utils';
+
+const POINTS_ENDPOINT = '0x829d183faaa675f8f80e8bb25fb1476cd4f7c1f0';
+const POINTS_SCOPE = 'minimal-disclosure-quest';
+
+const FixDisclosureScreen: React.FC = () => {
+  const [status, setStatus] = useState<
+    'idle' | 'loading' | 'success' | 'error'
+  >('idle');
+  const [message, setMessage] = useState('');
+
+  const handleFix = async () => {
+    setStatus('loading');
+    setMessage('');
+
+    try {
+      const secret = await unsafe_getPrivateKey();
+      if (!secret) {
+        setStatus('error');
+        setMessage(
+          'Could not retrieve secret. Biometric auth may have failed.',
+        );
+        return;
+      }
+
+      const scopeHash = hashEndpointWithScope(POINTS_ENDPOINT, POINTS_SCOPE);
+      const nullifier = poseidon2([
+        BigInt(secret),
+        BigInt(scopeHash),
+      ]).toString();
+      const userAddress = await getPointsAddress();
+
+      console.log(userAddress, nullifier);
+
+      const response = await fetch(
+        `${POINTS_API_BASE_URL}/points-disclose-fix`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            nullifier,
+            points_address: userAddress.toLowerCase(),
+          }),
+        },
+      );
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        setStatus('error');
+        setMessage(data?.message ?? `Request failed (${response.status})`);
+        return;
+      }
+
+      setStatus('success');
+      setMessage('Disclosure status fixed successfully.');
+    } catch (error) {
+      setStatus('error');
+      setMessage(
+        error instanceof Error
+          ? error.message
+          : 'An unexpected error occurred.',
+      );
+    }
+  };
+
+  return (
+    <YStack padding="$4" gap="$4">
+      <Button
+        backgroundColor={status === 'success' ? teal500 : black}
+        color={white}
+        borderColor={slate200}
+        borderRadius="$3"
+        height="$5"
+        disabled={status === 'loading'}
+        onPress={handleFix}
+      >
+        {status === 'loading' ? (
+          <Spinner color={white} />
+        ) : status === 'success' ? (
+          'Fixed'
+        ) : (
+          'Fix Points Issue'
+        )}
+      </Button>
+
+      {message !== '' && (
+        <Text fontSize="$3" color={status === 'error' ? '#ef4444' : teal500}>
+          {message}
+        </Text>
+      )}
+    </YStack>
+  );
+};
+
+export default FixDisclosureScreen;

--- a/app/src/screens/dev/TroubleshootingScreen.tsx
+++ b/app/src/screens/dev/TroubleshootingScreen.tsx
@@ -4,12 +4,14 @@
 
 import { poseidon2 } from 'poseidon-lite';
 import React, { useState } from 'react';
-import { Button, Spinner, Text, YStack } from 'tamagui';
+import { Button, H4, Paragraph, Spinner, Text, YStack } from 'tamagui';
 
 import { hashEndpointWithScope } from '@selfxyz/common/utils/scope';
 import {
   black,
+  red500,
   slate200,
+  slate500,
   teal500,
   white,
 } from '@selfxyz/mobile-sdk-alpha/constants/colors';
@@ -81,6 +83,15 @@ const TroubleshootingScreen: React.FC = () => {
 
   return (
     <YStack padding="$4" gap="$4">
+      <YStack gap="$2">
+        <H4>Fix points disclosure</H4>
+        <Paragraph color={slate500}>
+          If your points haven't updated after a successful verification, tap
+          below to repair your disclosure state. This is safe to run more than
+          once.
+        </Paragraph>
+      </YStack>
+
       <Button
         backgroundColor={status === 'success' ? teal500 : black}
         color={white}
@@ -100,7 +111,7 @@ const TroubleshootingScreen: React.FC = () => {
       </Button>
 
       {message !== '' && (
-        <Text fontSize="$3" color={status === 'error' ? '#ef4444' : teal500}>
+        <Text fontSize="$3" color={status === 'error' ? red500 : teal500}>
           {message}
         </Text>
       )}

--- a/app/src/screens/verification/ProofRequestStatusScreen.tsx
+++ b/app/src/screens/verification/ProofRequestStatusScreen.tsx
@@ -70,7 +70,7 @@ const SuccessScreen: React.FC = () => {
   const timerRef = useRef<NodeJS.Timeout | null>(null);
 
   const onOkPress = useCallback(async () => {
-    if (whitelistedPoints === undefined) return;
+    if (currentState === 'completed' && whitelistedPoints === undefined) return;
     buttonTap();
     const completedSessionId = sessionId;
 
@@ -106,6 +106,7 @@ const SuccessScreen: React.FC = () => {
     goHome();
     cleanupLater();
   }, [
+    currentState,
     whitelistedPoints,
     navigation,
     goHome,
@@ -296,7 +297,8 @@ const SuccessScreen: React.FC = () => {
             <Spinner />
           ) : countdown !== null && countdown > 0 ? (
             'Cancel'
-          ) : whitelistedPoints === undefined ? (
+          ) : currentState === 'completed' &&
+            whitelistedPoints === undefined ? (
             <Spinner />
           ) : (
             'OK'

--- a/app/tests/src/navigation.test.tsx
+++ b/app/tests/src/navigation.test.tsx
@@ -111,6 +111,7 @@ describe('navigation', () => {
         'Splash',
         'StarfallPushCode',
         'Support',
+        'Troubleshooting',
         'WebView',
       ]);
     });


### PR DESCRIPTION
## Summary

- Adds a hidden Troubleshooting entry to Settings (revealed via 3-tap gesture) that lets users repair a stuck points disclosure state by calling a new `points-disclose-fix` endpoint.
- Fixes a bug on `ProofRequestStatusScreen` where the OK button stayed disabled as a spinner when `whitelistedPoints` was undefined outside the `completed` state.
- Registers the new `Troubleshooting` dev screen in navigation and updates the settings menu builder to gate it behind the troubleshooting-mode flag.

## Changes

### React Native app

- `app/src/screens/dev/TroubleshootingScreen.tsx` — new screen: derives the points nullifier from the user's secret + scope hash and POSTs to `/points-disclose-fix` with the user's points address.
- `app/src/screens/account/settings/SettingsScreen.tsx` — adds a 3-tap gesture that flips `isTroubleshootingMode`, combined exclusively with the existing 5-tap dev-mode gesture.
- `app/src/screens/account/settings/settingsMenu.ts` — adds `Troubleshooting` route key + entry, gated on `isTroubleshootingMode` in `buildSettingsMenu`.
- `app/src/navigation/devTools.tsx` — registers `TroubleshootingScreen` under the dev stack.
- `app/src/screens/verification/ProofRequestStatusScreen.tsx` — only block OK press / show spinner for missing `whitelistedPoints` when `currentState === 'completed'`.

### Tests

- `app/tests/src/navigation.test.tsx` — adds `Troubleshooting` to the expected route list.

## Test Plan

- [ ] `yarn lint && yarn types` passes
- [ ] `cd app && yarn jest:run` passes
- [ ] Triple-tap the Settings header → Troubleshooting row appears; tap it → screen renders
- [ ] Tap "Fix Points Issue" with a stuck account → button turns teal and shows "Fixed"
- [ ] Error path shows red message (e.g., force a non-OK response)
- [ ] Proof request flow: reach success screen in a non-`completed` state with undefined `whitelistedPoints` → OK button is tappable (no stuck spinner)

### Native Consolidation Checklist

- [ ] CONTRACTS.md reviewed - no unintended contract changes
- [ ] Layer 1 bridge contract tests pass (`cd app && yarn jest:run` / `yarn workspace @selfxyz/rn-sdk-test-app test`)
- [ ] Layer 3 builds pass (app iOS, RN test app iOS, RN test app Android)
- [ ] Layer 4 manual smoke test signed off (if consolidation PR)
- [ ] No new native business logic added (logic belongs in TypeScript)

🤖 Generated with [Claude Code](https://claude.com/claude-code)