### PR TITLE
fix: gracefully gate passport OCR camera permission

### DIFF
--- a/app/ios/Podfile
+++ b/app/ios/Podfile
@@ -12,6 +12,13 @@ require Pod::Executable.execute_command("node", ["-p",
 
 require File.join(File.dirname(`node --print "require.resolve('expo/package.json', {paths: ['#{__dir__}/..']})"`.strip), "scripts/autolinking")
 
+# react-native-permissions: only the Camera handler is used (passport OCR gate).
+permissions_pkg = Pod::Executable.execute_command("node", ["-p",
+  'require.resolve("react-native-permissions/package.json", {paths: [process.argv[1]]})',
+  __dir__]).strip
+require File.join(File.dirname(permissions_pkg), "scripts/setup")
+setup_permissions(["Camera"])
+
 project "Self.xcodeproj"
 
 # Define consistent iOS deployment target

--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -2053,6 +2053,27 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
+  - RNPermissions (4.1.5):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - RNReactNativeHapticFeedback (2.3.3):
     - DoubleConversion
     - glog
@@ -2336,13 +2357,14 @@ DEPENDENCIES:
   - RNInAppBrowser (from `../node_modules/react-native-inappbrowser-reborn`)
   - RNKeychain (from `../node_modules/react-native-keychain`)
   - RNLocalize (from `../node_modules/react-native-localize`)
+  - RNPermissions (from `../node_modules/react-native-permissions`)
   - RNReactNativeHapticFeedback (from `../node_modules/react-native-haptic-feedback`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - "RNSentry (from `../node_modules/@sentry/react-native`)"
   - RNSVG (from `../node_modules/react-native-svg`)
   - "SdkReactNative (from `../node_modules/@didit-protocol/sdk-react-native`)"
   - "segment-analytics-react-native (from `../node_modules/@segment/analytics-react-native`)"
-  - SelfNFCPassportReader (from `https://github.com/selfxyz/NFCPassportReader.git`, commit `b478e1f1320e86f72c5755bc5adf156fff950585`)
+  - "SelfNFCPassportReader (from `git@github.com:selfxyz/NFCPassportReader.git`, commit `b478e1f1320e86f72c5755bc5adf156fff950585`)"
   - "sovran-react-native (from `../node_modules/@segment/sovran-react-native`)"
   - SwiftQRScanner (from `https://github.com/vinodiOS/SwiftQRScanner`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
@@ -2588,6 +2610,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-keychain"
   RNLocalize:
     :path: "../node_modules/react-native-localize"
+  RNPermissions:
+    :path: "../node_modules/react-native-permissions"
   RNReactNativeHapticFeedback:
     :path: "../node_modules/react-native-haptic-feedback"
   RNScreens:
@@ -2602,7 +2626,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@segment/analytics-react-native"
   SelfNFCPassportReader:
     :commit: b478e1f1320e86f72c5755bc5adf156fff950585
-    :git: https://github.com/selfxyz/NFCPassportReader.git
+    :git: "git@github.com:selfxyz/NFCPassportReader.git"
   sovran-react-native:
     :path: "../node_modules/@segment/sovran-react-native"
   SwiftQRScanner:
@@ -2613,7 +2637,7 @@ EXTERNAL SOURCES:
 CHECKOUT OPTIONS:
   SelfNFCPassportReader:
     :commit: b478e1f1320e86f72c5755bc5adf156fff950585
-    :git: https://github.com/selfxyz/NFCPassportReader.git
+    :git: "git@github.com:selfxyz/NFCPassportReader.git"
   SwiftQRScanner:
     :commit: c71ff91297640a944de4bca61434155c3f9b0979
     :git: https://github.com/vinodiOS/SwiftQRScanner
@@ -2748,6 +2772,7 @@ SPEC CHECKSUMS:
   RNInAppBrowser: 904d24dc75e8e6c6c98a3160329192608946f9df
   RNKeychain: 35beaa17938f7d8e4990d8a38fad5f8a748fc47c
   RNLocalize: aa57bee9fcd545b98ce773a8e2404f9a36115b4a
+  RNPermissions: c32bbfa8a665692acb9681c47abca019b97c9f1e
   RNReactNativeHapticFeedback: 7c895b81434f045ddc330972816f844e3c0c2f35
   RNScreens: b0811b109e1a0b8b579f3348018e177bee374840
   RNSentry: 98ab9f6a16c9596e36565ccf1a5871323f334766
@@ -2763,6 +2788,6 @@ SPEC CHECKSUMS:
   Yoga: c34725819ab0a5962e85455b9e56679b306910ee
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
-PODFILE CHECKSUM: 747d8e64a0829e1e63e259a223e02b99ef7bcb53
+PODFILE CHECKSUM: ded06f411c13516d51a97838c92095beafb1fc25
 
 COCOAPODS: 1.16.2

--- a/app/jest.config.cjs
+++ b/app/jest.config.cjs
@@ -16,7 +16,7 @@ module.exports = {
     'node',
   ],
   transformIgnorePatterns: [
-    'node_modules/(?!(react-native|@react-native|@react-navigation|@react-native-community|@segment/analytics-react-native|@openpassport|react-native-keychain|react-native-check-version|react-native-nfc-manager|react-native-passport-reader|react-native-gesture-handler|uuid|@stablelib|@react-native-google-signin|react-native-cloud-storage|@react-native-clipboard|@react-native-firebase|@selfxyz|@sentry|@anon-aadhaar|react-native-svg|react-native-svg-circle-country-flags|react-native-blur-effect|@didit-protocol)/)',
+    'node_modules/(?!(react-native|@react-native|@react-navigation|@react-native-community|@segment/analytics-react-native|@openpassport|react-native-keychain|react-native-check-version|react-native-nfc-manager|react-native-passport-reader|react-native-gesture-handler|uuid|@stablelib|@react-native-google-signin|react-native-cloud-storage|@react-native-clipboard|@react-native-firebase|@selfxyz|@sentry|@anon-aadhaar|react-native-svg|react-native-svg-circle-country-flags|react-native-blur-effect|react-native-permissions|@didit-protocol)/)',
   ],
   setupFiles: ['<rootDir>/jest.setup.js'],
   testMatch: [

--- a/app/jest.setup.js
+++ b/app/jest.setup.js
@@ -1284,6 +1284,12 @@ jest.mock('react-native/Libraries/AppState/AppState', () => {
   };
 });
 
+// Mock react-native-permissions — use the library's bundled mock so every test
+// can import it transitively without hitting the native module.
+jest.mock('react-native-permissions', () =>
+  require('react-native-permissions/mock'),
+);
+
 // Mock @didit-protocol/sdk-react-native
 jest.mock('@didit-protocol/sdk-react-native', () => ({
   __esModule: true,

--- a/app/package.json
+++ b/app/package.json
@@ -159,6 +159,7 @@
     "react-native-nfc-manager": "3.17.2",
     "react-native-passkey": "^3.3.3",
     "react-native-passport-reader": "1.0.3",
+    "react-native-permissions": "^4.1.5",
     "react-native-safe-area-context": "^5.7.0",
     "react-native-screens": "4.15.3",
     "react-native-sqlite-storage": "^6.0.1",

--- a/app/src/screens/documents/scanning/DocumentCameraScreen.tsx
+++ b/app/src/screens/documents/scanning/DocumentCameraScreen.tsx
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
-import React, { useEffect, useRef } from 'react';
-import { StyleSheet } from 'react-native';
+import React, { useEffect, useRef, useState } from 'react';
+import { AppState, Platform, StyleSheet } from 'react-native';
+import { check, PERMISSIONS, RESULTS } from 'react-native-permissions';
 import { View, XStack, YStack } from 'tamagui';
 import { useIsFocused, useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -55,6 +56,43 @@ const DocumentCameraScreen: React.FC = () => {
   const scanStartTimeRef = useRef(Date.now());
   const { onPassportRead } = useReadMRZ(scanStartTimeRef);
 
+  // Gate `<PassportCamera>` on an explicit permission check so iOS never shows
+  // the black scanner view and Android never triggers its re-prompt loop.
+  // `null` while the initial check is in flight; `true`/`false` once resolved.
+  const [cameraReady, setCameraReady] = useState<boolean | null>(null);
+  useEffect(() => {
+    const cameraPerm =
+      Platform.OS === 'ios'
+        ? PERMISSIONS.IOS.CAMERA
+        : PERMISSIONS.ANDROID.CAMERA;
+    let active = true;
+    const verify = async () => {
+      try {
+        const status = await check(cameraPerm);
+        const ok = status === RESULTS.GRANTED || status === RESULTS.LIMITED;
+        if (!active) return;
+        setCameraReady(ok);
+        if (!ok) {
+          navigation.goBack();
+        }
+      } catch {
+        if (active) {
+          setCameraReady(false);
+        }
+      }
+    };
+    verify();
+    const sub = AppState.addEventListener('change', state => {
+      if (state === 'active') {
+        verify();
+      }
+    });
+    return () => {
+      active = false;
+      sub.remove();
+    };
+  }, [navigation]);
+
   // Dev-only: Auto-trigger MRZ error after short delay if error injection is enabled
   useEffect(() => {
     if (
@@ -86,7 +124,12 @@ const DocumentCameraScreen: React.FC = () => {
   return (
     <ExpandableBottomLayout.Layout backgroundColor={white}>
       <ExpandableBottomLayout.TopSection roundTop backgroundColor={black}>
-        <PassportCamera onPassportRead={onPassportRead} isMounted={isFocused} />
+        {cameraReady === true && (
+          <PassportCamera
+            onPassportRead={onPassportRead}
+            isMounted={isFocused}
+          />
+        )}
         <DelayedLottieView
           autoPlay
           loop

--- a/app/src/screens/documents/selection/DocumentOnboardingScreen.tsx
+++ b/app/src/screens/documents/selection/DocumentOnboardingScreen.tsx
@@ -3,9 +3,10 @@
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
 import LottieView from 'lottie-react-native';
-import React, { useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { StyleSheet } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import { useSelfClient } from '@selfxyz/mobile-sdk-alpha';
 import {
@@ -25,18 +26,34 @@ import {
 } from '@selfxyz/mobile-sdk-alpha/constants/colors';
 
 import passportOnboardingAnimation from '@/assets/animations/passport_onboarding.json';
-import useHapticNavigation from '@/hooks/useHapticNavigation';
+import { useKycLauncher } from '@/hooks/useKycLauncher';
 import { impactLight } from '@/integrations/haptics';
 import { ExpandableBottomLayout } from '@/layouts/ExpandableBottomLayout';
+import type { RootStackParamList } from '@/navigation';
+import { ensureCameraForPassportScan } from '@/utils/cameraPermission';
 import { getDocumentScanPrompt } from '@/utils/documentAttributes';
 
 const DocumentOnboardingScreen: React.FC = () => {
-  const navigation = useNavigation();
+  const navigation =
+    useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const selfClient = useSelfClient();
   const selectedDocumentType = selfClient.useMRZStore(
     state => state.documentType,
   );
-  const handleCameraPress = useHapticNavigation('DocumentCamera');
+  const countryCode = selfClient.useMRZStore(state => state.countryCode);
+  const { launchKycVerification } = useKycLauncher({
+    countryCode: countryCode ?? '',
+    errorSource: 'mrz_scan_failed',
+  });
+  const handleCameraPress = useCallback(async () => {
+    impactLight();
+    const ok = await ensureCameraForPassportScan({
+      onFallback: launchKycVerification,
+    });
+    if (ok) {
+      navigation.navigate('DocumentCamera');
+    }
+  }, [launchKycVerification, navigation]);
   const animationRef = useRef<LottieView>(null);
 
   const scanPrompt = getDocumentScanPrompt(selectedDocumentType);

--- a/app/src/utils/cameraPermission.ts
+++ b/app/src/utils/cameraPermission.ts
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { Alert, Linking, Platform } from 'react-native';
+import {
+  check,
+  openSettings,
+  PERMISSIONS,
+  request,
+  RESULTS,
+} from 'react-native-permissions';
+
+const CAMERA_PERMISSION =
+  Platform.OS === 'ios' ? PERMISSIONS.IOS.CAMERA : PERMISSIONS.ANDROID.CAMERA;
+
+async function safeCheck(): Promise<string> {
+  try {
+    return await check(CAMERA_PERMISSION);
+  } catch {
+    return RESULTS.UNAVAILABLE;
+  }
+}
+
+async function safeRequest(): Promise<string> {
+  try {
+    return await request(CAMERA_PERMISSION);
+  } catch {
+    return RESULTS.UNAVAILABLE;
+  }
+}
+
+function openAppSettings(): void {
+  openSettings().catch(() => {
+    Linking.openSettings().catch(() => {});
+  });
+}
+
+function showBlockedAlert(onFallback?: () => void): void {
+  const buttons: Array<{
+    text: string;
+    style?: 'cancel';
+    onPress?: () => void;
+  }> = [
+    { text: 'Cancel', style: 'cancel' },
+    { text: 'Open Settings', onPress: openAppSettings },
+  ];
+  if (onFallback) {
+    buttons.splice(1, 0, {
+      text: 'Try Alternative Verification',
+      onPress: onFallback,
+    });
+  }
+  Alert.alert(
+    'Camera access needed',
+    'Self needs camera access to scan your passport. Enable it in Settings to continue.',
+    buttons,
+  );
+}
+
+function showUnavailableAlert(onFallback?: () => void): void {
+  Alert.alert(
+    'Camera not available',
+    "This device doesn't have a camera available. You can still verify your ID with an alternative method.",
+    onFallback
+      ? [
+          { text: 'Cancel', style: 'cancel' },
+          { text: 'Try Alternative Verification', onPress: onFallback },
+        ]
+      : [{ text: 'OK' }],
+  );
+}
+
+/**
+ * Checks camera permission before launching a flow that mounts the camera
+ * (e.g. passport OCR scanning). Prompts the user when the permission is
+ * re-askable. Shows an alert with a Settings deep-link on blocked/unavailable
+ * states. Returns true only when the flow should proceed.
+ */
+export async function ensureCameraForPassportScan(opts?: {
+  onFallback?: () => void;
+}): Promise<boolean> {
+  let status = await safeCheck();
+  if (status === RESULTS.GRANTED || status === RESULTS.LIMITED) {
+    return true;
+  }
+  if (status === RESULTS.DENIED) {
+    status = await safeRequest();
+    if (status === RESULTS.GRANTED || status === RESULTS.LIMITED) {
+      return true;
+    }
+  }
+  if (status === RESULTS.UNAVAILABLE) {
+    showUnavailableAlert(opts?.onFallback);
+  } else {
+    showBlockedAlert(opts?.onFallback);
+  }
+  return false;
+}

--- a/app/tests/src/utils/cameraPermission.test.ts
+++ b/app/tests/src/utils/cameraPermission.test.ts
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { Alert } from 'react-native';
+import { check, openSettings, request } from 'react-native-permissions';
+
+import { ensureCameraForPassportScan } from '@/utils/cameraPermission';
+
+jest.mock('react-native', () => ({
+  __esModule: true,
+  Alert: { alert: jest.fn() },
+  Linking: { openSettings: jest.fn().mockResolvedValue(undefined) },
+  Platform: { OS: 'ios', select: (obj: any) => obj.ios },
+}));
+
+jest.mock('react-native-permissions', () =>
+  require('react-native-permissions/mock'),
+);
+
+const alertMock = Alert.alert as jest.MockedFunction<typeof Alert.alert>;
+const mockedCheck = check as jest.MockedFunction<typeof check>;
+const mockedRequest = request as jest.MockedFunction<typeof request>;
+const mockedOpenSettings = openSettings as jest.MockedFunction<
+  typeof openSettings
+>;
+
+describe('ensureCameraForPassportScan', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns true when permission is already granted', async () => {
+    mockedCheck.mockResolvedValueOnce('granted' as never);
+    await expect(ensureCameraForPassportScan()).resolves.toBe(true);
+    expect(mockedRequest).not.toHaveBeenCalled();
+    expect(alertMock).not.toHaveBeenCalled();
+  });
+
+  it('returns true when permission is limited', async () => {
+    mockedCheck.mockResolvedValueOnce('limited' as never);
+    await expect(ensureCameraForPassportScan()).resolves.toBe(true);
+    expect(alertMock).not.toHaveBeenCalled();
+  });
+
+  it('requests when denied and returns true if granted', async () => {
+    mockedCheck.mockResolvedValueOnce('denied' as never);
+    mockedRequest.mockResolvedValueOnce('granted' as never);
+    await expect(ensureCameraForPassportScan()).resolves.toBe(true);
+    expect(mockedRequest).toHaveBeenCalledTimes(1);
+    expect(alertMock).not.toHaveBeenCalled();
+  });
+
+  it('shows the blocked alert when denied then blocked on request', async () => {
+    mockedCheck.mockResolvedValueOnce('denied' as never);
+    mockedRequest.mockResolvedValueOnce('blocked' as never);
+    await expect(ensureCameraForPassportScan()).resolves.toBe(false);
+    expect(alertMock).toHaveBeenCalledTimes(1);
+    expect(alertMock.mock.calls[0][0]).toBe('Camera access needed');
+  });
+
+  it('shows the blocked alert when the initial check reports blocked', async () => {
+    mockedCheck.mockResolvedValueOnce('blocked' as never);
+    await expect(ensureCameraForPassportScan()).resolves.toBe(false);
+    expect(mockedRequest).not.toHaveBeenCalled();
+    expect(alertMock.mock.calls[0][0]).toBe('Camera access needed');
+  });
+
+  it('shows the unavailable alert when the device lacks a camera', async () => {
+    mockedCheck.mockResolvedValueOnce('unavailable' as never);
+    await expect(ensureCameraForPassportScan()).resolves.toBe(false);
+    expect(alertMock.mock.calls[0][0]).toBe('Camera not available');
+  });
+
+  it('treats thrown check errors as unavailable', async () => {
+    mockedCheck.mockRejectedValueOnce(new Error('native crash'));
+    await expect(ensureCameraForPassportScan()).resolves.toBe(false);
+    expect(alertMock.mock.calls[0][0]).toBe('Camera not available');
+  });
+
+  it('invokes openSettings when the user taps Open Settings', async () => {
+    mockedCheck.mockResolvedValueOnce('blocked' as never);
+    await ensureCameraForPassportScan();
+    const buttons = alertMock.mock.calls[0][2] as Array<{
+      text: string;
+      onPress?: () => void;
+    }>;
+    const openBtn = buttons.find(b => b.text === 'Open Settings');
+    mockedOpenSettings.mockResolvedValueOnce(undefined as never);
+    openBtn?.onPress?.();
+    expect(mockedOpenSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('adds a "Try Alternative Verification" button when a fallback is supplied (blocked)', async () => {
+    mockedCheck.mockResolvedValueOnce('blocked' as never);
+    const onFallback = jest.fn();
+    await ensureCameraForPassportScan({ onFallback });
+    const buttons = alertMock.mock.calls[0][2] as Array<{
+      text: string;
+      onPress?: () => void;
+    }>;
+    const fallbackBtn = buttons.find(
+      b => b.text === 'Try Alternative Verification',
+    );
+    fallbackBtn?.onPress?.();
+    expect(onFallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('adds a fallback button to the unavailable alert', async () => {
+    mockedCheck.mockResolvedValueOnce('unavailable' as never);
+    const onFallback = jest.fn();
+    await ensureCameraForPassportScan({ onFallback });
+    const buttons = alertMock.mock.calls[0][2] as Array<{
+      text: string;
+      onPress?: () => void;
+    }>;
+    const fallbackBtn = buttons.find(
+      b => b.text === 'Try Alternative Verification',
+    );
+    expect(fallbackBtn).toBeDefined();
+    fallbackBtn?.onPress?.();
+    expect(onFallback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/docs/superpowers/plans/2026-04-21-passport-ocr-camera-permission.md
+++ b/docs/superpowers/plans/2026-04-21-passport-ocr-camera-permission.md
@@ -1,0 +1,241 @@
+# Passport OCR Camera Permission Gate (SELF-2645)
+
+**Bug:** When the user denies the system camera prompt on the Android passport OCR scan screen, the prompt re-fires repeatedly (the UI "blinks"). On iOS, the camera silently stays black. No way out without accepting or force-quitting.
+
+**Root cause:** Permission is requested by the native Android fragment (`CameraFragment.onResume` in `app/android/android-passport-nfc-reader/app/src/main/java/example/jllarraz/com/passportreader/ui/fragments/CameraFragment.kt:111`). After denial, the permission dialog dismisses, which triggers `onResume` to fire again — which immediately re-requests. iOS has an analogous issue (`QKMRZScannerViewRepresentable.swift:64`) that falls through to a silent `print()`.
+
+**Fix:** Gate the OCR camera at the TypeScript layer — before `<PassportCamera>` mounts. The native fragment's broken permission path never runs. No changes to Kotlin/Swift required.
+
+**Scope:** OCR passport scanning only. **Does not** touch the Didit KYC flow, QR disclosure, or the Android permission code itself (leave as dead code; follow-up ticket).
+
+---
+
+## Choke-point
+
+`DocumentCameraScreen.tsx:89` mounts `<PassportCamera>`. The only way into this screen is from `DocumentOnboardingScreen.tsx:39` via `useHapticNavigation('DocumentCamera')`. Gating that navigation point covers the flow.
+
+A screen-level safety check in `DocumentCameraScreen` handles the edge case where a user reaches it without the gate (e.g., deep link, dev-drawer jump) or revokes permission while the screen is in the background.
+
+## Tasks
+
+### Task 1 — Add `react-native-permissions`
+
+- `app/package.json`: add `"react-native-permissions": "^4.1.5"` to `dependencies`.
+- `yarn install`, `cd app/ios && pod install`.
+- Add `react-native-permissions` to `app/jest.config.cjs` `transformIgnorePatterns`.
+- Add a global mock in `app/jest.setup.js`:
+  ```js
+  jest.mock('react-native-permissions', () =>
+    require('react-native-permissions/mock'),
+  );
+  ```
+
+### Task 2 — Add `ensureCameraForPassportScan` util
+
+File: `app/src/utils/cameraPermission.ts`
+
+```ts
+import { Alert, Linking, Platform } from 'react-native';
+import {
+  PERMISSIONS,
+  RESULTS,
+  check,
+  openSettings,
+  request,
+} from 'react-native-permissions';
+
+const CAMERA =
+  Platform.OS === 'ios' ? PERMISSIONS.IOS.CAMERA : PERMISSIONS.ANDROID.CAMERA;
+
+async function safeCheck(): Promise<string> {
+  try { return await check(CAMERA); } catch { return RESULTS.UNAVAILABLE; }
+}
+async function safeRequest(): Promise<string> {
+  try { return await request(CAMERA); } catch { return RESULTS.UNAVAILABLE; }
+}
+
+function openAppSettings(): void {
+  openSettings().catch(() => Linking.openSettings().catch(() => {}));
+}
+
+function showBlockedAlert(onFallback?: () => void): void {
+  const buttons: Array<{ text: string; style?: 'cancel'; onPress?: () => void }> = [
+    { text: 'Cancel', style: 'cancel' },
+    { text: 'Open Settings', onPress: openAppSettings },
+  ];
+  if (onFallback) buttons.splice(1, 0, { text: 'Try Alternative Verification', onPress: onFallback });
+  Alert.alert(
+    'Camera access needed',
+    'Self needs camera access to scan your passport. Enable it in Settings to continue.',
+    buttons,
+  );
+}
+
+function showUnavailableAlert(onFallback?: () => void): void {
+  Alert.alert(
+    'Camera not available',
+    "This device doesn't have a camera available. You can still verify your ID with an alternative method.",
+    onFallback
+      ? [{ text: 'Cancel', style: 'cancel' }, { text: 'Try Alternative Verification', onPress: onFallback }]
+      : [{ text: 'OK' }],
+  );
+}
+
+export async function ensureCameraForPassportScan(opts?: {
+  onFallback?: () => void;
+}): Promise<boolean> {
+  let status = await safeCheck();
+  if (status === RESULTS.GRANTED || status === RESULTS.LIMITED) return true;
+  if (status === RESULTS.DENIED) {
+    status = await safeRequest();
+    if (status === RESULTS.GRANTED || status === RESULTS.LIMITED) return true;
+  }
+  if (status === RESULTS.UNAVAILABLE) showUnavailableAlert(opts?.onFallback);
+  else showBlockedAlert(opts?.onFallback);
+  return false;
+}
+```
+
+Tests in `app/tests/src/utils/cameraPermission.test.ts` — same 7 cases as before (granted/limited, denied→granted, denied→blocked, blocked, unavailable, throw, Open Settings callback).
+
+### Task 3 — Gate `DocumentOnboardingScreen`
+
+`app/src/screens/documents/selection/DocumentOnboardingScreen.tsx:39`
+
+Current:
+```tsx
+const handleCameraPress = useHapticNavigation('DocumentCamera');
+```
+
+Replace with:
+```tsx
+const navigateToCamera = useHapticNavigation('DocumentCamera');
+const { launchKycVerification } = useKycLauncher({
+  countryCode: countryCode ?? '',
+  errorSource: 'mrz_scan_failed',
+});
+const handleCameraPress = useCallback(async () => {
+  const ok = await ensureCameraForPassportScan({ onFallback: launchKycVerification });
+  if (ok) navigateToCamera();
+}, [launchKycVerification, navigateToCamera]);
+```
+
+`useKycLauncher` wires the "Try Alternative Verification" fallback through the existing KYC launcher. (The KYC launcher has no camera gate of its own yet; that's a separate ticket if ever needed.)
+
+### Task 4 — Gate `<PassportCamera>` render in `DocumentCameraScreen`
+
+`app/src/screens/documents/scanning/DocumentCameraScreen.tsx`
+
+This is the iOS black-screen fix **and** the fallback safety net for non-guarded navigation paths.
+
+**Why state-driven, not a navigate-back effect:** an async `useEffect` that navigates back on denial still lets `<PassportCamera>` mount for a frame or two before the effect resolves — on iOS that frame IS the black scanner view the user complained about. Tracking permission in component state and skipping the camera render until confirmed granted eliminates the black flash entirely.
+
+Add a `cameraReady` state, initialized to `null`. Render the native camera only when `cameraReady === true`. On mount and on AppState foreground, re-check. On revocation, flip to `false` and navigate back.
+
+```tsx
+import { AppState, Platform } from 'react-native';
+import { check, PERMISSIONS, RESULTS } from 'react-native-permissions';
+
+// Inside the component:
+const [cameraReady, setCameraReady] = useState<boolean | null>(null);
+
+useEffect(() => {
+  const cameraPerm = Platform.OS === 'ios' ? PERMISSIONS.IOS.CAMERA : PERMISSIONS.ANDROID.CAMERA;
+  let active = true;
+  const verify = async () => {
+    try {
+      const status = await check(cameraPerm);
+      const ok = status === RESULTS.GRANTED || status === RESULTS.LIMITED;
+      if (!active) return;
+      setCameraReady(ok);
+      if (!ok) navigation.goBack();
+    } catch {
+      if (active) setCameraReady(false);
+    }
+  };
+  verify();
+  const sub = AppState.addEventListener('change', (s) => {
+    if (s === 'active') verify();
+  });
+  return () => { active = false; sub.remove(); };
+}, [navigation]);
+```
+
+Replace the camera render line:
+
+```tsx
+// before:
+<PassportCamera onPassportRead={onPassportRead} isMounted={isFocused} />
+
+// after:
+{cameraReady === true && (
+  <PassportCamera onPassportRead={onPassportRead} isMounted={isFocused} />
+)}
+```
+
+When `cameraReady` is `null` (initial check in flight) or `false` (denied), the Lottie scanning animation still plays over a plain `black` background via the existing `<ExpandableBottomLayout.TopSection backgroundColor={black}>` — visually identical to the existing scan screen chrome, just without a live camera behind it. The effect's `navigation.goBack()` runs on denial so the user doesn't linger here.
+
+No other changes to `DocumentCameraScreen` — `useReadMRZ`, layout, error-injection effect, copy all untouched.
+
+### Task 5 — iOS usage string (optional, nice-to-have)
+
+`app/ios/Self.xcodeproj/project.pbxproj` (Debug + Release) and `app/ios/OpenPassport/Info.plist`:
+
+```
+"Self uses your camera to scan your passport. Images are not stored."
+```
+
+Current copy ("Needed to scan the passport MRZ.") is technically acceptable; updating is cosmetic.
+
+### Task 6 — Validation gate
+
+```bash
+yarn lint && yarn types
+cd app && yarn test
+cd ios && pod install && xcodebuild -workspace OpenPassport.xcworkspace \
+  -scheme OpenPassport -configuration Debug -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 15' build
+cd ../android && ./gradlew assembleDebug
+```
+
+### Task 7 — Manual smoke
+
+One iOS simulator + one Android emulator (the Android case is the bug's home):
+
+1. Fresh install → DocumentOnboarding → tap Scan Passport → system prompt → **Deny** (without "Don't ask again"). Expect: NO re-prompt loop. Alert appears with "Open Settings".
+2. Tap Open Settings → grant camera → return → retap Scan Passport → camera opens cleanly.
+3. Tap Scan Passport again after Deny → system prompt re-fires once (Android re-askable), Deny again → alert, no loop.
+4. Device without a camera (emulator with camera disabled) → "Camera not available" alert with fallback.
+
+Record a short clip of the Android Deny flow to prove the loop is gone.
+
+### Task 8 — Open PR
+
+Target `main`. Title: `fix(app): gate passport OCR camera in TS to stop Android permission loop (SELF-2645)`.
+
+---
+
+## Files NOT modified
+
+- `app/android/android-passport-nfc-reader/**` — the inverted `hasCameraPermission()` and the `onResume`-request loop are left in place as dead paths. Follow-up ticket can clean them up.
+- `app/ios/QKMRZScannerViewRepresentable.swift` — silent `print()` on denial stays. TS guard prevents the view from mounting without permission.
+- `app/src/integrations/kyc/**` — Didit flow untouched. (Separate ticket already tracked this.)
+- `app/src/components/native/PassportCamera.tsx` — no prop changes.
+- `useReadMRZ`, any MRZ onboarding logic — untouched.
+- QR disclosure flow.
+
+## Out of scope
+
+- Cleaning up the Android inverted-`hasCameraPermission` and `onResume` loop code.
+- Fixing the Android `ErrorDialog.activity!!.finish()` behavior.
+- KYC camera gate (separate ticket).
+- Styling / illustrations in the denial Alert (using native `Alert` for minimum surface).
+
+## Why no iOS black screen under this plan
+
+Every iOS path that could show it is closed:
+
+1. **Primary path** (DocumentOnboarding → DocumentCamera): Task 3's gate requests permission and alerts on denial. User never navigates to DocumentCamera without a grant.
+2. **Non-guarded path** (deep link, dev-drawer, any future screen that navigates directly): Task 4's `cameraReady` state skips `<PassportCamera>` render until permission is confirmed, and navigates back on denial. The native scanner view never mounts.
+3. **Revocation while screen is backgrounded**: Task 4's AppState listener re-checks on foreground → flips `cameraReady` → unmounts `<PassportCamera>` → navigates back.
+4. **Device without a camera (`UNAVAILABLE`)**: Task 2's unavailable alert with KYC fallback; user never reaches DocumentCamera.

--- a/yarn.lock
+++ b/yarn.lock
@@ -11291,6 +11291,7 @@ __metadata:
     react-native-nfc-manager: "npm:3.17.2"
     react-native-passkey: "npm:^3.3.3"
     react-native-passport-reader: "npm:1.0.3"
+    react-native-permissions: "npm:^4.1.5"
     react-native-safe-area-context: "npm:^5.7.0"
     react-native-screens: "npm:4.15.3"
     react-native-sqlite-storage: "npm:^6.0.1"
@@ -34687,6 +34688,20 @@ __metadata:
   version: 1.0.3
   resolution: "react-native-passport-reader@npm:1.0.3"
   checksum: 10c0/bfb7454d4859d40c10a28faacb279e135faec215b29ee7965592651ed205dd298ae5282aba9c403c729d0c8a78cadab46b7d8825c6782e29248f1cadf0a1e794
+  languageName: node
+  linkType: hard
+
+"react-native-permissions@npm:^4.1.5":
+  version: 4.1.5
+  resolution: "react-native-permissions@npm:4.1.5"
+  peerDependencies:
+    react: ">=18.1.0"
+    react-native: ">=0.70.0"
+    react-native-windows: ">=0.70.0"
+  peerDependenciesMeta:
+    react-native-windows:
+      optional: true
+  checksum: 10c0/93dd8ec9c4f5259b959fe0ec560c95c10518e893358b53acf9a380dca7d58e541274bf25cfe83e09c769b260fbce1361fa4497488b6bbcad499d8fb2cdefb5c0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Moves camera permission handling for passport OCR from the native layer into TypeScript, fixing the Android permission re-prompt loop and the iOS black scanner view after denial.
- Adds a pre-navigation gate in `DocumentOnboardingScreen` that routes denials to a KYC fallback via `useKycLauncher`, and a render gate in `DocumentCameraScreen` that re-checks on `AppState` foreground.
- Links the iOS Camera permission handler in the Podfile so `check(PERMISSIONS.IOS.CAMERA)` resolves instead of throwing and falsely reporting "Camera not available".

## Changes

### React Native app

- New `app/src/utils/cameraPermission.ts` (`ensureCameraForPassportScan`) — checks, requests, and surfaces a blocked/unavailable alert with a Settings deep-link and optional "Try Alternative Verification" fallback.
- `DocumentOnboardingScreen.tsx` — runs `ensureCameraForPassportScan` on tap; launches KYC verification on denial instead of navigating into the camera.
- `DocumentCameraScreen.tsx` — gates `<PassportCamera>` on a resolved permission state and re-verifies on `AppState` foreground transitions.
- `ios/Podfile` — adds `setup_permissions(["Camera"])` so the iOS native handler is linked.
- `android/app/build.gradle`, `version.json` — bumps Android versionCode to 151 and deployment timestamps.

### Tests

- `app/tests/src/utils/cameraPermission.test.ts` — covers granted/limited/denied→granted/denied→blocked/initial-blocked/unavailable/thrown paths plus Settings and fallback button wiring.
- `jest.setup.js` — mocks `react-native-permissions` with its bundled mock.
- `jest.config.cjs` — adds `react-native-permissions` to `transformIgnorePatterns`.

### Config

- `package.json` — adds `react-native-permissions@^4.1.5`.

## Linear Issues

- Closes [SELF-2645](https://linear.app/selfprotocol/issue/SELF-2645/graceful-camera-permission-handling) — Graceful camera permission handling

## Test Plan

- [ ] `yarn lint && yarn types` passes
- [ ] `cd app && yarn jest:run` passes (new `cameraPermission.test.ts`)
- [ ] iOS: `cd app/ios && pod install`, deny camera → alert with Settings + KYC fallback; grant → scanner mounts (no black view)
- [ ] Android: deny camera on scan screen → single alert with fallback, no re-prompt loop
- [ ] Revoke permission in Settings while the app is backgrounded → returning to the scan screen dismounts the camera

### Native Consolidation Checklist

- [ ] CONTRACTS.md reviewed - no unintended contract changes
- [ ] Layer 1 bridge contract tests pass (`cd app && yarn jest:run` / `yarn workspace @selfxyz/rn-sdk-test-app test`)
- [ ] Layer 3 builds pass (app iOS, RN test app iOS, RN test app Android)
- [ ] Layer 4 manual smoke test signed off (if consolidation PR)
- [ ] No new native business logic added (logic belongs in TypeScript)

🤖 Generated with [Claude Code](https://claude.com/claude-code)