### PR TITLE
disable support ID sharing by default and rename from "diagnostic"

### DIFF
--- a/app/src/components/support/SupportUuidRow.tsx
+++ b/app/src/components/support/SupportUuidRow.tsx
@@ -23,15 +23,15 @@ interface SupportUuidRowProps {
 
 const SupportUuidRow: React.FC<SupportUuidRowProps> = ({
   collapsedByDefault = true,
-  title = 'Diagnostic ID',
+  title = 'Support ID',
 }) => {
   const [expanded, setExpanded] = useState(!collapsedByDefault);
   const { isEnabled, supportUuid, copy } = useSupportUuid();
-  const diagnosticIdText = supportUuid ?? 'Loading diagnostic ID...';
+  const supportIdText = supportUuid ?? 'Loading support ID...';
 
   const handleCopy = useCallback(() => {
     copy();
-    Alert.alert('Copied', 'Diagnostic ID copied to clipboard.');
+    Alert.alert('Copied', 'Support ID copied to clipboard.');
   }, [copy]);
 
   const toggle = useCallback(() => setExpanded(prev => !prev), []);
@@ -51,7 +51,7 @@ const SupportUuidRow: React.FC<SupportUuidRowProps> = ({
         paddingVertical={10}
         paddingHorizontal={12}
       >
-        <BodyText style={{ color: slate500 }}>Show diagnostic ID</BodyText>
+        <BodyText style={{ color: slate500 }}>Show support ID</BodyText>
       </Button>
     );
   }
@@ -69,7 +69,7 @@ const SupportUuidRow: React.FC<SupportUuidRowProps> = ({
         <BodyText style={{ color: black, fontSize: 14 }}>{title}</BodyText>
       </Button>
       <BodyText style={{ color: slate500, fontSize: 13 }}>
-        {diagnosticIdText}
+        {supportIdText}
       </BodyText>
       <XStack justifyContent="flex-end" alignItems="center">
         <Button unstyled onPress={handleCopy}>

--- a/app/src/screens/account/settings/SupportScreen.tsx
+++ b/app/src/screens/account/settings/SupportScreen.tsx
@@ -24,16 +24,16 @@ const SupportScreen: React.FC = () => {
   const { isEnabled, supportUuid, copy, regenerate, setEnabled } =
     useSupportUuid();
   const openSupportForm = useOpenSupportForm();
-  const diagnosticIdText = supportUuid ?? 'Loading diagnostic ID...';
+  const supportIdText = supportUuid ?? 'Loading support ID...';
 
   const handleCopy = useCallback(() => {
     copy();
-    Alert.alert('Copied', 'Diagnostic ID copied to clipboard.');
+    Alert.alert('Copied', 'Support ID copied to clipboard.');
   }, [copy]);
 
   const handleRegenerate = useCallback(() => {
     Alert.alert(
-      'Regenerate diagnostic ID?',
+      'Regenerate support ID?',
       "Use this if you've shared your ID publicly or want a fresh one for a new issue. Future support requests will use the new ID.",
       [
         { text: 'Cancel', style: 'cancel' },
@@ -42,7 +42,7 @@ const SupportScreen: React.FC = () => {
           style: 'destructive',
           onPress: () => {
             regenerate();
-            Alert.alert('Updated', 'Your diagnostic ID has been replaced.');
+            Alert.alert('Updated', 'Your support ID has been replaced.');
           },
         },
       ],
@@ -69,19 +69,18 @@ const SupportScreen: React.FC = () => {
 
         <YStack gap={8}>
           <BodyText style={{ color: slate500, fontSize: 13 }}>
-            A diagnostic ID helps our team find the activity related to your
-            report. It's not tied to your identity.
+            Only turn this on if a Self support agent asks for it. A support ID
+            helps our team find the activity related to your report. It's not
+            tied to your identity.
           </BodyText>
 
           <View style={styles.settingRow}>
             <View style={styles.settingTextContainer}>
-              <BodyText style={styles.settingLabel}>
-                Share diagnostic ID
-              </BodyText>
+              <BodyText style={styles.settingLabel}>Share support ID</BodyText>
               <BodyText style={styles.settingDescription}>
                 {isEnabled
-                  ? 'Share the diagnostic ID below with support so we can find the activity related to your report. Turn this off to keep it out of support requests and error screens.'
-                  : 'Diagnostic ID is off. Turn it on to include it in future support requests.'}
+                  ? 'Share the support ID below with support so we can find the activity related to your report. Turn this off to keep it out of support requests and error screens.'
+                  : 'Support ID is off. Only turn it on if a Self support agent asks for it.'}
               </BodyText>
             </View>
             <Switch
@@ -104,10 +103,10 @@ const SupportScreen: React.FC = () => {
                 gap={8}
               >
                 <BodyText style={{ color: black, fontSize: 16 }}>
-                  Diagnostic ID
+                  Support ID
                 </BodyText>
                 <BodyText style={{ color: slate500, fontSize: 14 }}>
-                  {diagnosticIdText}
+                  {supportIdText}
                 </BodyText>
               </YStack>
 
@@ -118,7 +117,7 @@ const SupportScreen: React.FC = () => {
                 borderRadius={12}
                 onPress={handleCopy}
               >
-                <BodyText style={{ color: black }}>Copy diagnostic ID</BodyText>
+                <BodyText style={{ color: black }}>Copy support ID</BodyText>
               </Button>
 
               <Button

--- a/app/src/screens/documents/scanning/DocumentNFCTroubleScreen.tsx
+++ b/app/src/screens/documents/scanning/DocumentNFCTroubleScreen.tsx
@@ -89,7 +89,7 @@ const DocumentNFCTroubleScreen: React.FC = () => {
       onSecondaryButtonPress={goToNFCMethodSelection}
       footer={
         <YStack gap="$3">
-          <SupportUuidRow title="Support diagnostic ID" />
+          <SupportUuidRow />
 
           <SecondaryButton
             onPress={openSupportForm}

--- a/app/src/screens/shared/ComingSoonScreen.tsx
+++ b/app/src/screens/shared/ComingSoonScreen.tsx
@@ -158,7 +158,7 @@ const ComingSoonScreen: React.FC<ComingSoonScreenProps> = ({ route }) => {
         paddingTop={20}
         paddingBottom={20}
       >
-        <SupportUuidRow title="Support diagnostic ID" />
+        <SupportUuidRow />
         <PrimaryButton
           onPress={onNotifyMe}
           trackEvent={PassportEvents.NOTIFY_COMING_SOON}

--- a/app/src/screens/verification/QRCodeTroubleScreen.tsx
+++ b/app/src/screens/verification/QRCodeTroubleScreen.tsx
@@ -65,7 +65,7 @@ const QRCodeTrouble: React.FC = () => {
       onDismiss={go}
       footer={
         <View gap={12}>
-          <SupportUuidRow title="Support diagnostic ID" />
+          <SupportUuidRow />
           <SecondaryButton onPress={openSupportForm}>
             {SUPPORT_FORM_BUTTON_TEXT}
           </SecondaryButton>

--- a/app/src/stores/settingStore.ts
+++ b/app/src/stores/settingStore.ts
@@ -56,6 +56,23 @@ interface NonPersistedSettingsState {
 
 type SettingsState = PersistedSettingsState & NonPersistedSettingsState;
 
+export const SETTING_STORE_VERSION = 1;
+
+// v1: force support ID sharing off for all existing users. It is opt-in
+// from here on — users can re-enable it in settings when a support agent
+// asks for it.
+export const migrateSettingStore = (
+  persistedState: unknown,
+  version: number,
+): SettingsState => {
+  const state = (persistedState ?? {}) as Partial<SettingsState>;
+  if (version < 1) {
+    state.supportUuidEnabled = false;
+    state.supportUuid = null;
+  }
+  return state as SettingsState;
+};
+
 /*
  * This store is used to store the settings of the app. Dont store anything sensative here
  */
@@ -143,7 +160,7 @@ export const useSettingStore = create<SettingsState>()(
       setPointsAddress: (address: string | null) =>
         set({ pointsAddress: address }),
 
-      supportUuidEnabled: true,
+      supportUuidEnabled: false,
       setSupportUuidEnabled: (supportUuidEnabled: boolean) =>
         set({ supportUuidEnabled }),
       supportUuid: null,
@@ -174,6 +191,8 @@ export const useSettingStore = create<SettingsState>()(
         delete (persistedState as Partial<SettingsState>).setHideNetworkModal;
         return persistedState;
       },
+      version: SETTING_STORE_VERSION,
+      migrate: migrateSettingStore,
     },
   ),
 );

--- a/app/tests/src/components/support/SupportUuidRow.test.tsx
+++ b/app/tests/src/components/support/SupportUuidRow.test.tsx
@@ -50,6 +50,6 @@ describe('SupportUuidRow', () => {
 
     const { toJSON } = render(<SupportUuidRow />);
 
-    expect(JSON.stringify(toJSON())).toContain('Show diagnostic ID');
+    expect(JSON.stringify(toJSON())).toContain('Show support ID');
   });
 });

--- a/app/tests/src/hooks/useOpenSupportForm.test.ts
+++ b/app/tests/src/hooks/useOpenSupportForm.test.ts
@@ -8,6 +8,7 @@ import { supportFormUrl } from '@/consts/links';
 import useOpenSupportForm from '@/hooks/useOpenSupportForm';
 import { impactLight } from '@/integrations/haptics';
 import { navigationRef } from '@/navigation';
+import { useSettingStore } from '@/stores/settingStore';
 
 jest.mock('@/integrations/haptics', () => ({
   impactLight: jest.fn(),
@@ -24,9 +25,13 @@ describe('useOpenSupportForm', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (navigationRef.isReady as jest.Mock).mockReturnValue(true);
+    useSettingStore.setState({
+      supportUuidEnabled: false,
+      supportUuid: null,
+    });
   });
 
-  it('triggers haptic feedback and navigates to the support form WebView', () => {
+  it('navigates to the support form WebView with haptic feedback', () => {
     const { result } = renderHook(() => useOpenSupportForm());
 
     act(() => {
@@ -43,6 +48,34 @@ describe('useOpenSupportForm', () => {
 
     const [, params] = (navigationRef.navigate as jest.Mock).mock.calls[0];
     expect(params.url).toContain(supportFormUrl);
-    expect(params.url).toContain('support_uuid=');
+  });
+
+  it('omits support_uuid when support ID sharing is disabled (default)', () => {
+    const { result } = renderHook(() => useOpenSupportForm());
+
+    act(() => {
+      result.current();
+    });
+
+    const [, params] = (navigationRef.navigate as jest.Mock).mock.calls[0];
+    expect(params.url).not.toContain('support_uuid=');
+  });
+
+  it('appends support_uuid when the user has enabled sharing', () => {
+    useSettingStore.setState({
+      supportUuidEnabled: true,
+      supportUuid: '11111111-1111-1111-1111-111111111111',
+    });
+
+    const { result } = renderHook(() => useOpenSupportForm());
+
+    act(() => {
+      result.current();
+    });
+
+    const [, params] = (navigationRef.navigate as jest.Mock).mock.calls[0];
+    expect(params.url).toContain(
+      'support_uuid=11111111-1111-1111-1111-111111111111',
+    );
   });
 });

--- a/app/tests/src/screens/account/settings/SupportScreen.test.tsx
+++ b/app/tests/src/screens/account/settings/SupportScreen.test.tsx
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+import { useSupportUuid } from '@/hooks/useSupportUuid';
+import SupportScreen from '@/screens/account/settings/SupportScreen';
+
+jest.mock('react-native', () => {
+  const MockView = ({ children, ...props }: any) => (
+    <mock-view {...props}>{children}</mock-view>
+  );
+  const MockSwitch = ({ value, testID, ...props }: any) => (
+    <mock-switch {...props} value={String(value)} testID={testID} />
+  );
+  return {
+    __esModule: true,
+    Alert: { alert: jest.fn() },
+    StyleSheet: {
+      create: (styles: any) => styles,
+      flatten: (style: any) => style,
+    },
+    Switch: MockSwitch,
+    View: MockView,
+  };
+});
+
+jest.mock('tamagui', () => {
+  const passthrough = (name: string) => {
+    const Component = ({ children, ...props }: any) => (
+      <mock-view {...props} testID={props.testID ?? name}>
+        {children}
+      </mock-view>
+    );
+    Component.displayName = name;
+    return Component;
+  };
+  return {
+    __esModule: true,
+    Button: passthrough('Button'),
+    ScrollView: passthrough('ScrollView'),
+    YStack: passthrough('YStack'),
+  };
+});
+
+jest.mock('@selfxyz/mobile-sdk-alpha/components', () => ({
+  BodyText: ({ children, ...props }: any) => (
+    <mock-text {...props}>{children}</mock-text>
+  ),
+}));
+
+jest.mock('@selfxyz/mobile-sdk-alpha/constants/colors', () => ({
+  black: '#000',
+  blue600: '#00f',
+  slate100: '#eee',
+  slate200: '#ddd',
+  slate500: '#555',
+  white: '#fff',
+}));
+
+jest.mock('@selfxyz/mobile-sdk-alpha/constants/fonts', () => ({
+  dinot: 'dinot',
+}));
+
+jest.mock('@/hooks/useOpenSupportForm', () => ({
+  __esModule: true,
+  default: () => jest.fn(),
+}));
+
+jest.mock('@/hooks/useSupportUuid', () => ({
+  useSupportUuid: jest.fn(),
+}));
+
+const mockUseSupportUuid = useSupportUuid as jest.Mock;
+
+const baseHookValue = {
+  supportUuid: null,
+  copy: jest.fn(),
+  regenerate: jest.fn(),
+  setEnabled: jest.fn(),
+  isReady: true,
+};
+
+describe('SupportScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses the renamed "Support ID" copy and off-state guidance when disabled', () => {
+    mockUseSupportUuid.mockReturnValue({ ...baseHookValue, isEnabled: false });
+
+    const { toJSON } = render(<SupportScreen />);
+    const tree = JSON.stringify(toJSON());
+
+    expect(tree).toContain('Share support ID');
+    expect(tree).toContain('Only turn it on if a Self support agent asks');
+    // The UUID panel and copy/regenerate buttons should be hidden when off.
+    expect(tree).not.toContain('Copy support ID');
+    // No lingering legacy wording.
+    expect(tree.toLowerCase()).not.toContain('diagnostic');
+  });
+
+  it('shows the support ID value and actions when enabled', () => {
+    mockUseSupportUuid.mockReturnValue({
+      ...baseHookValue,
+      isEnabled: true,
+      supportUuid: '11111111-1111-1111-1111-111111111111',
+    });
+
+    const { toJSON } = render(<SupportScreen />);
+    const tree = JSON.stringify(toJSON());
+
+    expect(tree).toContain('Share support ID');
+    expect(tree).toContain('Copy support ID');
+    expect(tree).toContain('11111111-1111-1111-1111-111111111111');
+    expect(tree.toLowerCase()).not.toContain('diagnostic');
+  });
+});

--- a/app/tests/src/stores/settingStore.test.ts
+++ b/app/tests/src/stores/settingStore.test.ts
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import {
+  migrateSettingStore,
+  SETTING_STORE_VERSION,
+} from '@/stores/settingStore';
+
+describe('migrateSettingStore', () => {
+  it('forces supportUuidEnabled off and clears supportUuid when upgrading from v0', () => {
+    const migrated = migrateSettingStore(
+      {
+        supportUuidEnabled: true,
+        supportUuid: '11111111-1111-1111-1111-111111111111',
+        cloudBackupEnabled: true,
+      },
+      0,
+    );
+
+    expect(migrated.supportUuidEnabled).toBe(false);
+    expect(migrated.supportUuid).toBeNull();
+    // Unrelated fields are preserved.
+    expect(migrated.cloudBackupEnabled).toBe(true);
+  });
+
+  it('forces supportUuidEnabled off even if previously disabled (idempotent)', () => {
+    const migrated = migrateSettingStore(
+      { supportUuidEnabled: false, supportUuid: null },
+      0,
+    );
+
+    expect(migrated.supportUuidEnabled).toBe(false);
+    expect(migrated.supportUuid).toBeNull();
+  });
+
+  it('leaves state untouched when already at the current version', () => {
+    const migrated = migrateSettingStore(
+      {
+        supportUuidEnabled: true,
+        supportUuid: '22222222-2222-2222-2222-222222222222',
+      },
+      SETTING_STORE_VERSION,
+    );
+
+    expect(migrated.supportUuidEnabled).toBe(true);
+    expect(migrated.supportUuid).toBe('22222222-2222-2222-2222-222222222222');
+  });
+
+  it('handles missing persisted state', () => {
+    const migrated = migrateSettingStore(undefined, 0);
+
+    expect(migrated.supportUuidEnabled).toBe(false);
+    expect(migrated.supportUuid).toBeNull();
+  });
+});

--- a/specs/projects/sdk/INDEX.md
+++ b/specs/projects/sdk/INDEX.md
@@ -12,13 +12,13 @@ Status: Active (WebView-first, current pass is mock-first UI migration)
 
 ## Active Workstreams
 
-| Workstream           | Entry                                                               | Focus                                                 |
-| -------------------- | ------------------------------------------------------------------- | ----------------------------------------------------- |
-| WebView UI           | [WebView Index](./workstreams/webview/INDEX.md)                     | Euclid screen migration, mocked flows, route coverage |
-| SDK Core             | [SDK Core Spec](./workstreams/sdk-core/SPEC.md)                     | Browser-portable engine                               |
-| Native Shells (Lite) | [Native Shells Lite Spec](./workstreams/native-shells-lite/SPEC.md) | Future Kotlin + Swift shell follow-up                 |
-| Build Pipeline       | [Build Pipeline Spec](./workstreams/build-pipeline/SPEC.md)         | Bundle webview-app into native shells                 |
-| SDK Distribution     | [SDK Distribution Spec](./workstreams/sdk-distribution/SPEC.md)     | Hosted URL loading + native shell publishing          |
+| Workstream           | Entry                                                               | Focus                                                   |
+| -------------------- | ------------------------------------------------------------------- | ------------------------------------------------------- |
+| WebView UI           | [WebView Index](./workstreams/webview/INDEX.md)                     | Euclid screen migration, mocked flows, route coverage   |
+| SDK Core             | [SDK Core Spec](./workstreams/sdk-core/SPEC.md)                     | Browser-portable engine                                 |
+| Native Shells (Lite) | [Native Shells Lite Spec](./workstreams/native-shells-lite/SPEC.md) | Future Kotlin + Swift shell follow-up                   |
+| Build Pipeline       | [Build Pipeline Spec](./workstreams/build-pipeline/SPEC.md)         | Bundle webview-app into native shells                   |
+| SDK Distribution     | [SDK Distribution Spec](./workstreams/sdk-distribution/SPEC.md)     | Hosted URL loading + native shell publishing            |
 | Analytics            | [Analytics Spec](./workstreams/analytics/SPEC.md)                   | Canonical onboarding funnel events + Mixpanel dashboard |
 
 ## Paused Workstreams

--- a/specs/projects/sdk/workstreams/analytics/SPEC.md
+++ b/specs/projects/sdk/workstreams/analytics/SPEC.md
@@ -59,14 +59,14 @@ The caller-facing API still accepts a `branch` property on `trackOnboardingStep(
 
 ### Dashboard queries this enables
 
-| Question                                                                        | Filter                                                                        |
-| ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| Users who *started* biometric                                                   | `initial_branch = biometric_passport` (or `biometric_id`)                     |
-| Users who *completed* via biometric                                             | `event = COMPLETED AND current_branch = biometric_passport`                   |
-| Users who fell back from biometric to KYC                                       | `initial_branch starts_with biometric_ AND current_branch = kyc`              |
-| Biometric starters' conversion regardless of path                               | `initial_branch starts_with biometric_ AND event = COMPLETED`                 |
-| Pure KYC users (never intended biometric)                                       | `initial_branch = kyc AND current_branch = kyc`                               |
-| Cohort of users who used any fallback                                           | `event = COMPLETED AND used_fallback = true`                                  |
+| Question                                          | Filter                                                           |
+| ------------------------------------------------- | ---------------------------------------------------------------- |
+| Users who _started_ biometric                     | `initial_branch = biometric_passport` (or `biometric_id`)        |
+| Users who _completed_ via biometric               | `event = COMPLETED AND current_branch = biometric_passport`      |
+| Users who fell back from biometric to KYC         | `initial_branch starts_with biometric_ AND current_branch = kyc` |
+| Biometric starters' conversion regardless of path | `initial_branch starts_with biometric_ AND event = COMPLETED`    |
+| Pure KYC users (never intended biometric)         | `initial_branch = kyc AND current_branch = kyc`                  |
+| Cohort of users who used any fallback             | `event = COMPLETED AND used_fallback = true`                     |
 
 ### What this does NOT cover (deferred to ANA-05)
 
@@ -74,7 +74,7 @@ The current split tells you **what happened** — initial intent vs final outcom
 
 - When the fallback screen appears, what % accept, decline, or silently abandon?
 - Which failure stage triggers fallback most (NFC vs MRZ vs parse error)?
-- Does *offering* fallback save or destroy biometric conversions overall?
+- Does _offering_ fallback save or destroy biometric conversions overall?
 - At which retry count do users typically switch branches?
 - Fallback-offer → fallback-completion sub-funnel, with attrition per step
 
@@ -84,33 +84,33 @@ Layer 2 is filed as ANA-05 and should be the first follow-up after ANA-01 ships.
 
 Every Layer 1 event carries `attempt_id`, `initial_branch`, and `current_branch` (see Cross-branch flows). Additional per-event properties below.
 
-| Event                     | Fires when                                                                                                  | Additional properties                                          |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| `onboarding_started`      | User dismisses the privacy disclaimer and enters the onboarding flow                                        | — (both branches `pending` at this point)                      |
-| `country_selected`        | User confirms a country in `CountryPickerScreen`                                                            | `country_code`                                                 |
-| `document_type_selected`  | User confirms a document type in `IDSelectionScreen`                                                        | `document_type`, `country_code` (locks `initial_branch`)        |
-| `document_scan_started`   | User opens camera (biometric branches), launches the KYC web SDK, or opens the Aadhaar file picker          | —                                                              |
-| `document_scan_succeeded` | MRZ+NFC committed (biometric), KYC provider returns success, Aadhaar upload accepted                        | `duration_seconds`, `attempt_count`                            |
-| `proof_generation_started`| Proving machine enters `proving` state                                                                      | —                                                              |
-| `proof_generation_succeeded` | Proving machine enters `completed` state with `circuitType === 'register'` (true new registration)       | `duration_seconds`                                             |
-| `onboarding_completed`    | Post-proof wrap-up done (terminal success state for the registration path)                                  | `duration_seconds` (total onboarding), `used_fallback`         |
+| Event                        | Fires when                                                                                         | Additional properties                                    |
+| ---------------------------- | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| `onboarding_started`         | User dismisses the privacy disclaimer and enters the onboarding flow                               | — (both branches `pending` at this point)                |
+| `country_selected`           | User confirms a country in `CountryPickerScreen`                                                   | `country_code`                                           |
+| `document_type_selected`     | User confirms a document type in `IDSelectionScreen`                                               | `document_type`, `country_code` (locks `initial_branch`) |
+| `document_scan_started`      | User opens camera (biometric branches), launches the KYC web SDK, or opens the Aadhaar file picker | —                                                        |
+| `document_scan_succeeded`    | MRZ+NFC committed (biometric), KYC provider returns success, Aadhaar upload accepted               | `duration_seconds`, `attempt_count`                      |
+| `proof_generation_started`   | Proving machine enters `proving` state                                                             | —                                                        |
+| `proof_generation_succeeded` | Proving machine enters `completed` state with `circuitType === 'register'` (true new registration) | `duration_seconds`                                       |
+| `onboarding_completed`       | Post-proof wrap-up done (terminal success state for the registration path)                         | `duration_seconds` (total onboarding), `used_fallback`   |
 
 Supporting events (outside the main funnel but on the same event stream):
 
-| Event                     | Purpose                                                                                                     |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `onboarding_failed`       | Terminal failure. Carries `{stage, reason, recoverable, used_fallback}`. One event replaces 10+ named failure events for dashboard purposes — the detailed events still fire too. |
-| `funnel_step_retried`     | User retried a step (e.g., NFC scan after a failure). Carries `{stage, reason, attempt_count}`. Distinct from drop-off signal. |
-| `disclosure_completed`    | Disclosure proof reached `completed` state. Outside the onboarding funnel. Kept for disclosure analytics.   |
+| Event                  | Purpose                                                                                                                                                                           |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `onboarding_failed`    | Terminal failure. Carries `{stage, reason, recoverable, used_fallback}`. One event replaces 10+ named failure events for dashboard purposes — the detailed events still fire too. |
+| `funnel_step_retried`  | User retried a step (e.g., NFC scan after a failure). Carries `{stage, reason, attempt_count}`. Distinct from drop-off signal.                                                    |
+| `disclosure_completed` | Disclosure proof reached `completed` state. Outside the onboarding funnel. Kept for disclosure analytics.                                                                         |
 
 ## Branch Model
 
-| `branch` value        | Flow                                                                                       | Canonical steps that apply           |
-| --------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------ |
-| `biometric_passport`  | Passport with chip; MRZ + NFC + proof                                                      | All 8 canonical steps                |
-| `biometric_id`        | eID card with chip; same mechanism as passport, different chip-scan animation and UX       | All 8 canonical steps                |
-| `kyc`                 | Embedded KYC provider web SDK (Didit) — used for non-biometric docs and as NFC/MRZ fallback | 5 steps: `onboarding_started` → `country_selected` → `document_type_selected` → `document_scan_started` → `document_scan_succeeded` → proof steps → `onboarding_completed` (no NFC visibility; interior selfie/liveness steps are opaque) |
-| `aadhaar`             | India-specific QR/PDF upload                                                                | Same 8 steps conceptually; `document_scan_*` maps to file pick + upload accept |
+| `branch` value       | Flow                                                                                        | Canonical steps that apply                                                                                                                                                                                                                |
+| -------------------- | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `biometric_passport` | Passport with chip; MRZ + NFC + proof                                                       | All 8 canonical steps                                                                                                                                                                                                                     |
+| `biometric_id`       | eID card with chip; same mechanism as passport, different chip-scan animation and UX        | All 8 canonical steps                                                                                                                                                                                                                     |
+| `kyc`                | Embedded KYC provider web SDK (Didit) — used for non-biometric docs and as NFC/MRZ fallback | 5 steps: `onboarding_started` → `country_selected` → `document_type_selected` → `document_scan_started` → `document_scan_succeeded` → proof steps → `onboarding_completed` (no NFC visibility; interior selfie/liveness steps are opaque) |
+| `aadhaar`            | India-specific QR/PDF upload                                                                | Same 8 steps conceptually; `document_scan_*` maps to file pick + upload accept                                                                                                                                                            |
 
 Biometric passport and biometric ID are treated as distinct branches (different chip animations, different UX) but are rolled up into a `biometric_combined` dashboard view.
 
@@ -126,13 +126,13 @@ Built after event layer lands. One Mixpanel board:
 
 ## What This Doesn't Measure Yet
 
-ANA-01 gets the app from "the funnel is unmeasurable" to "the funnel is measurable." It is *not* the Revolut-grade end-state. The following gaps are known, scoped as followup issues, and worth surfacing up front so nobody mistakes ANA-01's scope for "the final funnel":
+ANA-01 gets the app from "the funnel is unmeasurable" to "the funnel is measurable." It is _not_ the Revolut-grade end-state. The following gaps are known, scoped as followup issues, and worth surfacing up front so nobody mistakes ANA-01's scope for "the final funnel":
 
 - **User-centric vs session-centric metrics** — `duration_seconds` measures within-session time. A user who starts Monday, abandons, finishes Wednesday is invisible in duration tracking. Needs: longer Mixpanel conversion windows, stable `distinct_id` across sessions, and clarity that "attempt" is an engineering convenience, not the analytical unit. Mixpanel's Uniques counting handles user-level dedup in the funnel itself, so this is mostly a dashboard-configuration concern once ANA-02 ships the build/user properties.
 - **Segmentation fidelity** — only `country_code`, `document_type`, and the branch properties are attached today. A PM slicing drop-off wants device, OS, app_version, acquisition channel, experiment variant, build channel, time-of-day. Most of these belong as **super properties** set once per session. See ANA-02 (build + internal), ANA-06 (device/OS/version enrichment).
 - **Step-view vs step-commit mini-funnels** — canonical events are commitment events. Users who view a screen but don't commit are invisible at the canonical layer; they show up only in the preserved `Viewed X` diagnostic events. See ANA-07.
 - **Explicit abandonment modeling** — no event fires on app-background-with-incomplete-attempt. Silent drops look identical to "still thinking." See ANA-08.
-- **Fallback decision visibility** — we know *that* fallback happened via `used_fallback`, but not the decision path that led there (see Cross-branch flows, ANA-05).
+- **Fallback decision visibility** — we know _that_ fallback happened via `used_fallback`, but not the decision path that led there (see Cross-branch flows, ANA-05).
 - **A/B test tagging** — no `experiment_id` / `variant` on events. Blocks running experiments against the funnel. See ANA-09.
 - **PM-roll-up metrics** — D1/D7/D30 completion, median time-to-verified, top-3 drop-off reasons are not pre-built. The raw events support them; the dashboard work is not yet specced. See ANA-10.
 - **KYC provider interior** — selfie / liveness / doc-capture steps inside the provider web SDK are opaque. Requires provider-side instrumentation contract work.
@@ -160,29 +160,29 @@ The conversion window for the Mixpanel funnel should be set to a value matching 
 
 ## Backlog
 
-| ID      | Title                                                                            | Status   | Priority | Depends On | Plan                                                                           | Notes                                                                                                                                      |
-| ------- | -------------------------------------------------------------------------------- | -------- | -------- | ---------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| ANA-01  | Canonical onboarding funnel events + dead-zone and AbstractButton fixes          | Ready    | High     | -          | [plans/ANA-01-canonical-onboarding-funnel.md](./plans/ANA-01-canonical-onboarding-funnel.md) | The full "do now" scope: canonical events, state-machine guards, terminal event invariant, dead-zone fixes, `Click:` prefix fix.          |
-| ANA-02  | Filter TestFlight and internal-build traffic from onboarding funnel              | Deferred | Medium   | ANA-01     | —                                                                              | Add `build_channel` super property and `is_internal` user property with a debug-menu toggle. Optionally separate Mixpanel project per env. |
-| ANA-03  | Convert raw-string analytics events to typed constants across onboarding        | Deferred | Low      | ANA-01     | —                                                                              | `REGISTRATION_FALLBACK_*`, `DEVICE_TOKEN_REG_*`, and similar get moved into the existing event-constant enums. Cosmetic for the funnel, prevents future drift. |
-| ANA-04  | Consolidate Mixpanel NFC native channel with Segment (if feasible)               | Deferred | Low      | ANA-01     | —                                                                              | Investigate whether native NFC events can be routed through Segment. Expected outcome: not feasible for native-module origin, keep as-is with a doc comment. |
-| ANA-05  | Fallback decision events and fallback-offer mini-funnel                          | Ready    | High     | ANA-01     | —                                                                              | Layer 2 canonical events: `Onboarding: Fallback Offered / Accepted / Declined` at the fallback screens (MRZ, NFC, LogoConfirmation "No"). Carries `from_stage` and `reason`. Enables fallback-offer → fallback-completion sub-funnel and answers "does offering fallback save or lose conversions." Should be the next work after ANA-01 ships. |
-| ANA-06  | Super-property enrichment for segmentation                                        | Deferred | High     | ANA-01     | —                                                                              | Attach device model, OS, OS version, app_version, acquisition_channel as super properties on every event. Blocks most Revolut-grade cohort analysis. |
-| ANA-07  | Step-view canonical events for commit-vs-view mini-funnel                         | Deferred | Medium   | ANA-01     | —                                                                              | Add `*_viewed` events to the canonical layer for each screen with a decision (country_picker_viewed, id_selection_viewed, etc.) so drop-off between view and commit is measurable. |
-| ANA-08  | Explicit abandonment events on app background                                     | Deferred | Medium   | ANA-01     | —                                                                              | Fire `Onboarding: Abandoned` with `{stage, reason}` when the app is backgrounded with an incomplete attempt, and/or when an attempt is overwritten by a new one. Turns silent drops into categorized ones. |
-| ANA-09  | A/B test tagging at the super-property layer                                      | Deferred | High     | ANA-06     | —                                                                              | Attach `experiment_id` and `variant` from a config source as super properties. Required for running any onboarding experiment. |
-| ANA-10  | PM-dashboard roll-ups (D1/D7/D30 conversion, TTV, top drop-off reasons)           | Deferred | Medium   | ANA-01, ANA-02, ANA-06 | —                                                                     | Dashboard work, not instrumentation. Build the small set of "headline" metrics a PM watches weekly. |
+| ID     | Title                                                                    | Status   | Priority | Depends On             | Plan                                                                                         | Notes                                                                                                                                                                                                                                                                                                                                           |
+| ------ | ------------------------------------------------------------------------ | -------- | -------- | ---------------------- | -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ANA-01 | Canonical onboarding funnel events + dead-zone and AbstractButton fixes  | Ready    | High     | -                      | [plans/ANA-01-canonical-onboarding-funnel.md](./plans/ANA-01-canonical-onboarding-funnel.md) | The full "do now" scope: canonical events, state-machine guards, terminal event invariant, dead-zone fixes, `Click:` prefix fix.                                                                                                                                                                                                                |
+| ANA-02 | Filter TestFlight and internal-build traffic from onboarding funnel      | Deferred | Medium   | ANA-01                 | —                                                                                            | Add `build_channel` super property and `is_internal` user property with a debug-menu toggle. Optionally separate Mixpanel project per env.                                                                                                                                                                                                      |
+| ANA-03 | Convert raw-string analytics events to typed constants across onboarding | Deferred | Low      | ANA-01                 | —                                                                                            | `REGISTRATION_FALLBACK_*`, `DEVICE_TOKEN_REG_*`, and similar get moved into the existing event-constant enums. Cosmetic for the funnel, prevents future drift.                                                                                                                                                                                  |
+| ANA-04 | Consolidate Mixpanel NFC native channel with Segment (if feasible)       | Deferred | Low      | ANA-01                 | —                                                                                            | Investigate whether native NFC events can be routed through Segment. Expected outcome: not feasible for native-module origin, keep as-is with a doc comment.                                                                                                                                                                                    |
+| ANA-05 | Fallback decision events and fallback-offer mini-funnel                  | Ready    | High     | ANA-01                 | —                                                                                            | Layer 2 canonical events: `Onboarding: Fallback Offered / Accepted / Declined` at the fallback screens (MRZ, NFC, LogoConfirmation "No"). Carries `from_stage` and `reason`. Enables fallback-offer → fallback-completion sub-funnel and answers "does offering fallback save or lose conversions." Should be the next work after ANA-01 ships. |
+| ANA-06 | Super-property enrichment for segmentation                               | Deferred | High     | ANA-01                 | —                                                                                            | Attach device model, OS, OS version, app_version, acquisition_channel as super properties on every event. Blocks most Revolut-grade cohort analysis.                                                                                                                                                                                            |
+| ANA-07 | Step-view canonical events for commit-vs-view mini-funnel                | Deferred | Medium   | ANA-01                 | —                                                                                            | Add `*_viewed` events to the canonical layer for each screen with a decision (country_picker_viewed, id_selection_viewed, etc.) so drop-off between view and commit is measurable.                                                                                                                                                              |
+| ANA-08 | Explicit abandonment events on app background                            | Deferred | Medium   | ANA-01                 | —                                                                                            | Fire `Onboarding: Abandoned` with `{stage, reason}` when the app is backgrounded with an incomplete attempt, and/or when an attempt is overwritten by a new one. Turns silent drops into categorized ones.                                                                                                                                      |
+| ANA-09 | A/B test tagging at the super-property layer                             | Deferred | High     | ANA-06                 | —                                                                                            | Attach `experiment_id` and `variant` from a config source as super properties. Required for running any onboarding experiment.                                                                                                                                                                                                                  |
+| ANA-10 | PM-dashboard roll-ups (D1/D7/D30 conversion, TTV, top drop-off reasons)  | Deferred | Medium   | ANA-01, ANA-02, ANA-06 | —                                                                                            | Dashboard work, not instrumentation. Build the small set of "headline" metrics a PM watches weekly.                                                                                                                                                                                                                                             |
 
 Allowed statuses: `Ready`, `In Progress`, `Blocked`, `Deferred`, `Done`
 
 ## Active Plans
 
-| Plan                                                                                    | IDs    | Status |
-| --------------------------------------------------------------------------------------- | ------ | ------ |
+| Plan                                                                                         | IDs    | Status |
+| -------------------------------------------------------------------------------------------- | ------ | ------ |
 | [plans/ANA-01-canonical-onboarding-funnel.md](./plans/ANA-01-canonical-onboarding-funnel.md) | ANA-01 | Ready  |
 
 ## References
 
 - Mixpanel funnels: [funnels-advanced](https://docs.mixpanel.com/docs/reports/funnels/funnels-advanced) — Uniques vs Totals counting, conversion windows, Optimized Re-entry, specific vs any-order modes.
-- Mixpanel identity: [identifying-users](https://docs.mixpanel.com/docs/tracking-methods/id-management/identifying-users) — ID merge requires an event *after* `identify()` carrying both `$device_id` and `$user_id`.
+- Mixpanel identity: [identifying-users](https://docs.mixpanel.com/docs/tracking-methods/id-management/identifying-users) — ID merge requires an event _after_ `identify()` carrying both `$device_id` and `$user_id`.
 - Mixpanel retention: [retention](https://docs.mixpanel.com/docs/reports/retention) — retention is for "came back days later," not multi-step completion. Use funnels for onboarding drop-off.

--- a/specs/projects/sdk/workstreams/analytics/plans/ANA-01-canonical-onboarding-funnel.md
+++ b/specs/projects/sdk/workstreams/analytics/plans/ANA-01-canonical-onboarding-funnel.md
@@ -53,23 +53,23 @@ Implemented as typed constants in `packages/mobile-sdk-alpha/src/constants/analy
 
 Every event below is stamped by the helper with `attempt_id`, `initial_branch`, `current_branch` in addition to the listed per-event properties. See SPEC.md § Cross-branch flows for semantics.
 
-| Constant                             | Event name                     | Fire location                                                                                                                                                  | Additional properties                                                                          |
-| ------------------------------------ | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `OnboardingEvents.STARTED`           | `Onboarding: Started`          | `app/src/screens/onboarding/DisclaimerScreen.tsx` — on `DISMISS_PRIVACY_DISCLAIMER` button press, before navigation                                            | — (both branches `pending`)                                                                    |
-| `OnboardingEvents.COUNTRY_SELECTED`  | `Onboarding: Country Selected` | `packages/mobile-sdk-alpha/src/flows/onboarding/country-picker-screen.tsx` — inside `onCountrySelect`, after country is committed to the store                  | `country_code`                                                                                 |
-| `OnboardingEvents.DOCUMENT_TYPE_SELECTED` | `Onboarding: Document Type Selected` | `packages/mobile-sdk-alpha/src/flows/onboarding/id-selection-screen.tsx` — inside `onSelectDocumentType`, after doc type committed. **Locks `initial_branch`.** | `document_type`, `country_code`                                                                |
-| `OnboardingEvents.SCAN_STARTED`      | `Onboarding: Document Scan Started` | Biometric: `app/src/screens/documents/scanning/DocumentCameraScreen.tsx` on camera open. KYC: `LogoConfirmationScreen` "No" fallback path. Aadhaar: `AadhaarUploadScreen.tsx` on mount.  | —                                                                                              |
-| `OnboardingEvents.SCAN_SUCCEEDED`    | `Onboarding: Document Scan Succeeded` | Biometric: `DocumentNFCScanScreen.tsx` on NFC success. KYC: on provider result `success`. Aadhaar: after `processAadhaarQRCode` succeeds.                         | `duration_seconds`                                                                             |
-| `OnboardingEvents.PROOF_STARTED`     | `Onboarding: Proof Generation Started` | `packages/mobile-sdk-alpha/src/proving/provingMachine.ts` — when state enters `proving`                                                                        | —                                                                                              |
-| `OnboardingEvents.PROOF_SUCCEEDED`   | `Onboarding: Proof Generation Succeeded` | `provingMachine.ts` — inside `completed` state, gated on terminal invariant (below)                                                                             | —                                                                                              |
-| `OnboardingEvents.COMPLETED`         | `Onboarding: Completed`        | Helper-driven from `provingMachine.ts` `completed` state on the register path                                                                                  | `duration_seconds` (total onboarding), `country_code`, `document_type`, `used_fallback`        |
-| `OnboardingEvents.FAILED`            | `Onboarding: Failed`           | `provingMachine.ts` `failure` and `error` terminal states on the register path; plus KYC / Aadhaar failure paths (future)                                      | `stage`, `reason`, `recoverable`, `duration_seconds`, `used_fallback`                          |
-| `OnboardingEvents.STEP_RETRIED`      | `Onboarding: Step Retried`     | `RegistrationFallbackMRZScreen.tsx` and `RegistrationFallbackNFCScreen.tsx` "Retry" buttons                                                                    | `stage`, `reason`, `attempt_count`                                                             |
-| `OnboardingEvents.DISCLOSURE_COMPLETED` | `Onboarding: Disclosure Completed` | `provingMachine.ts` — inside `completed` state, when `circuitType === 'disclose'`                                                                             | —                                                                                              |
+| Constant                                  | Event name                               | Fire location                                                                                                                                                                           | Additional properties                                                                   |
+| ----------------------------------------- | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `OnboardingEvents.STARTED`                | `Onboarding: Started`                    | `app/src/screens/onboarding/DisclaimerScreen.tsx` — on `DISMISS_PRIVACY_DISCLAIMER` button press, before navigation                                                                     | — (both branches `pending`)                                                             |
+| `OnboardingEvents.COUNTRY_SELECTED`       | `Onboarding: Country Selected`           | `packages/mobile-sdk-alpha/src/flows/onboarding/country-picker-screen.tsx` — inside `onCountrySelect`, after country is committed to the store                                          | `country_code`                                                                          |
+| `OnboardingEvents.DOCUMENT_TYPE_SELECTED` | `Onboarding: Document Type Selected`     | `packages/mobile-sdk-alpha/src/flows/onboarding/id-selection-screen.tsx` — inside `onSelectDocumentType`, after doc type committed. **Locks `initial_branch`.**                         | `document_type`, `country_code`                                                         |
+| `OnboardingEvents.SCAN_STARTED`           | `Onboarding: Document Scan Started`      | Biometric: `app/src/screens/documents/scanning/DocumentCameraScreen.tsx` on camera open. KYC: `LogoConfirmationScreen` "No" fallback path. Aadhaar: `AadhaarUploadScreen.tsx` on mount. | —                                                                                       |
+| `OnboardingEvents.SCAN_SUCCEEDED`         | `Onboarding: Document Scan Succeeded`    | Biometric: `DocumentNFCScanScreen.tsx` on NFC success. KYC: on provider result `success`. Aadhaar: after `processAadhaarQRCode` succeeds.                                               | `duration_seconds`                                                                      |
+| `OnboardingEvents.PROOF_STARTED`          | `Onboarding: Proof Generation Started`   | `packages/mobile-sdk-alpha/src/proving/provingMachine.ts` — when state enters `proving`                                                                                                 | —                                                                                       |
+| `OnboardingEvents.PROOF_SUCCEEDED`        | `Onboarding: Proof Generation Succeeded` | `provingMachine.ts` — inside `completed` state, gated on terminal invariant (below)                                                                                                     | —                                                                                       |
+| `OnboardingEvents.COMPLETED`              | `Onboarding: Completed`                  | Helper-driven from `provingMachine.ts` `completed` state on the register path                                                                                                           | `duration_seconds` (total onboarding), `country_code`, `document_type`, `used_fallback` |
+| `OnboardingEvents.FAILED`                 | `Onboarding: Failed`                     | `provingMachine.ts` `failure` and `error` terminal states on the register path; plus KYC / Aadhaar failure paths (future)                                                               | `stage`, `reason`, `recoverable`, `duration_seconds`, `used_fallback`                   |
+| `OnboardingEvents.STEP_RETRIED`           | `Onboarding: Step Retried`               | `RegistrationFallbackMRZScreen.tsx` and `RegistrationFallbackNFCScreen.tsx` "Retry" buttons                                                                                             | `stage`, `reason`, `attempt_count`                                                      |
+| `OnboardingEvents.DISCLOSURE_COMPLETED`   | `Onboarding: Disclosure Completed`       | `provingMachine.ts` — inside `completed` state, when `circuitType === 'disclose'`                                                                                                       | —                                                                                       |
 
 ### Branch property contract (cross-branch flows)
 
-Callers pass `{ branch: 'biometric_passport' | 'biometric_id' | 'kyc' | 'aadhaar' }` as *input sugar* to `trackOnboardingStep`. The helper translates this into:
+Callers pass `{ branch: 'biometric_passport' | 'biometric_id' | 'kyc' | 'aadhaar' }` as _input sugar_ to `trackOnboardingStep`. The helper translates this into:
 
 - First non-`pending` value → locks `initial_branch` (immutable for the attempt)
 - Every call → updates `current_branch`
@@ -87,12 +87,20 @@ Currently, `provingMachine.ts:1332` sets `circuitType = 'register'` as a side-ef
 You will add a boolean in the proving store: `enteredAsRegistration`, set at `init()` to `circuitType === 'register'` (the type the session was started with, captured before any mid-flow flipping). The terminal gate is:
 
 ```ts
-if (state.value === 'completed'
-    && get().circuitType === 'register'
-    && get().enteredAsRegistration === true) {
-  selfClient.trackEvent(OnboardingEvents.PROOF_SUCCEEDED, { branch, duration_seconds });
+if (
+  state.value === 'completed' &&
+  get().circuitType === 'register' &&
+  get().enteredAsRegistration === true
+) {
+  selfClient.trackEvent(OnboardingEvents.PROOF_SUCCEEDED, {
+    branch,
+    duration_seconds,
+  });
   // later, after _handleAccountVerifiedSuccess:
-  selfClient.trackEvent(OnboardingEvents.COMPLETED, { branch, duration_seconds });
+  selfClient.trackEvent(OnboardingEvents.COMPLETED, {
+    branch,
+    duration_seconds,
+  });
 }
 ```
 
@@ -121,7 +129,10 @@ interface OnboardingAnalyticsState {
 Helper:
 
 ```ts
-function trackStepOnce(step: OnboardingStepName, properties: Record<string, unknown>) {
+function trackStepOnce(
+  step: OnboardingStepName,
+  properties: Record<string, unknown>,
+) {
   if (state.firedSteps.has(step)) return;
   state.firedSteps.add(step);
   selfClient.trackEvent(step, { ...properties, attempt_id: state.attemptId });
@@ -137,18 +148,19 @@ Back-navigation must not re-fire: a user going from doc-type-selected back to co
 
 ## Dead-Zone Fixes
 
-| Screen                                                                                            | Current behavior                                          | Change                                                                                                           |
-| ------------------------------------------------------------------------------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `app/src/screens/documents/selection/LogoConfirmationScreen.tsx`                                  | No button tracking                                        | Fire a diagnostic `logo_confirmation_answered` event with `{answer: 'yes' | 'no'}` on each button. This is not a canonical step — it's diagnostic context.  |
-| `packages/mobile-sdk-alpha/src/flows/onboarding/country-picker-screen.tsx` (line ~37)             | Emits SDK internal event only                             | Also call `trackStepOnce(OnboardingEvents.COUNTRY_SELECTED, { country_code })`                                    |
-| `packages/mobile-sdk-alpha/src/flows/onboarding/id-selection-screen.tsx` (line ~142)              | Emits SDK internal event only                             | Also call `trackStepOnce(OnboardingEvents.DOCUMENT_TYPE_SELECTED, { document_type, country_code, branch })` — `branch` is resolved here for the first time |
-| `app/src/screens/documents/selection/ConfirmBelongingScreen.tsx` (wraps `ConfirmIdentificationScreen`) | Fires errors only                                        | Add a diagnostic `confirm_belonging_confirmed` event on success path                                             |
+| Screen                                                                                                 | Current behavior              | Change                                                                                                                                                     |
+| ------------------------------------------------------------------------------------------------------ | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `app/src/screens/documents/selection/LogoConfirmationScreen.tsx`                                       | No button tracking            | Fire a diagnostic `logo_confirmation_answered` event with `{answer: 'yes'                                                                                  | 'no'}` on each button. This is not a canonical step — it's diagnostic context. |
+| `packages/mobile-sdk-alpha/src/flows/onboarding/country-picker-screen.tsx` (line ~37)                  | Emits SDK internal event only | Also call `trackStepOnce(OnboardingEvents.COUNTRY_SELECTED, { country_code })`                                                                             |
+| `packages/mobile-sdk-alpha/src/flows/onboarding/id-selection-screen.tsx` (line ~142)                   | Emits SDK internal event only | Also call `trackStepOnce(OnboardingEvents.DOCUMENT_TYPE_SELECTED, { document_type, country_code, branch })` — `branch` is resolved here for the first time |
+| `app/src/screens/documents/selection/ConfirmBelongingScreen.tsx` (wraps `ConfirmIdentificationScreen`) | Fires errors only             | Add a diagnostic `confirm_belonging_confirmed` event on success path                                                                                       |
 
 ## AbstractButton Fix
 
 File: `packages/mobile-sdk-alpha/src/components/buttons/AbstractButton.tsx` (line 82-94).
 
 Current behavior:
+
 ```ts
 if (trackEvent) {
   const parsedEvent = trackEvent?.split(':')?.[1]?.trim();


### PR DESCRIPTION
## Summary

- Flip `supportUuidEnabled` default to `false` so support ID sharing is opt-in. Users will only have a support UUID attached to their support form URLs, Sentry context, analytics, and Loki logs if they explicitly turn it on after a Self support agent asks.
- Add a zustand persist `version: 1` migration that forces sharing off (and clears any existing UUID) once per install, so users who had it enabled on the previous build get it disabled on next launch.
- Rename all user-facing copy from "Diagnostic ID" to "Support ID" across the Support settings screen and the `SupportUuidRow` component used on trouble screens. Internal names (`supportUuid`, `support_uuid` query param, store keys) are unchanged to preserve backend/analytics correlation.
- Update Support screen guidance to tell users to only enable sharing when a support agent asks for it.

## Changes

### React Native app

- `app/src/stores/settingStore.ts` — default `supportUuidEnabled` → `false`; export `SETTING_STORE_VERSION` and `migrateSettingStore`; wire persist version + migrate that force the flag off and clear the stored UUID on v0 → v1 upgrade.
- `app/src/screens/account/settings/SupportScreen.tsx` — rename all "Diagnostic ID" copy to "Support ID"; rewrite intro and off-state descriptions to direct users to only enable sharing when a support agent asks.
- `app/src/components/support/SupportUuidRow.tsx` — default title now "Support ID"; update placeholder, expand button ("Show support ID"), and copy-confirmation alert.
- `ComingSoonScreen.tsx`, `QRCodeTroubleScreen.tsx`, `DocumentNFCTroubleScreen.tsx` — drop the `title="Support diagnostic ID"` prop so they pick up the new default.

### Tests

- `app/tests/src/stores/settingStore.test.ts` (new) — covers the v0 → v1 migration: forces `supportUuidEnabled` off, clears `supportUuid`, preserves unrelated fields, is idempotent, and is a no-op at the current version.
- `app/tests/src/screens/account/settings/SupportScreen.test.tsx` (new) — renders the screen in both disabled and enabled states; asserts the new "Share support ID" / "Copy support ID" copy, off-state guidance, and guards against any "diagnostic" wording reappearing.
- `app/tests/src/hooks/useOpenSupportForm.test.ts` — replace the unconditional `support_uuid=` assertion with a disabled-by-default case (param absent) and an enabled case that seeds the store and asserts the UUID is appended.
- `app/tests/src/components/support/SupportUuidRow.test.tsx` — update assertion from "Show diagnostic ID" to "Show support ID".

## Test Plan

- [ ] `cd app && yarn jest tests/src/stores/settingStore.test.ts tests/src/screens/account/settings/SupportScreen.test.tsx tests/src/components/support/SupportUuidRow.test.tsx tests/src/hooks/useOpenSupportForm.test.ts tests/src/services/supportUuid.test.ts tests/src/services/logging/lokiTransport.test.ts`
- [ ] `yarn lint && yarn types` passes
- [ ] Fresh install: open the app → Settings → Get support. Verify the toggle is off by default, the intro says "Only turn this on if a Self support agent asks for it", and no UUID / Copy / Regenerate controls are visible.
- [ ] Upgrade install: on a build that had support UUID sharing enabled, update to this build. Verify on next launch the toggle is off and no `support_uuid` query param is attached to the support form URL or Sentry/analytics context.
- [ ] Toggle on: flip the switch, confirm a Support ID appears, Copy/Regenerate work, and opening "Send feedback" navigates to a URL containing `support_uuid=<id>`.
- [ ] Trouble screens (QR code, NFC, coming soon): with sharing enabled, confirm the `SupportUuidRow` now renders as "Support ID" / "Show support ID".

### Native Consolidation Checklist

- [ ] CONTRACTS.md reviewed - no unintended contract changes
- [ ] Layer 1 bridge contract tests pass (`cd app && yarn jest:run` / `yarn workspace @selfxyz/rn-sdk-test-app test`)
- [ ] Layer 3 builds pass (app iOS, RN test app iOS, RN test app Android)
- [ ] Layer 4 manual smoke test signed off (if consolidation PR)
- [ ] No new native business logic added (logic belongs in TypeScript)

🤖 Generated with [Claude Code](https://claude.com/claude-code)