### PR TITLE
fix(onboarding): close dangling KYC attempts and hide test-only exports

### DIFF
--- a/app/src/screens/documents/selection/LogoConfirmationScreen.tsx
+++ b/app/src/screens/documents/selection/LogoConfirmationScreen.tsx
@@ -71,11 +71,13 @@ const LogoConfirmationScreen: React.FC = () => {
         "To complete registration of a document without a biometric chip, you'll be redirected to our third party verification partner.",
       buttonText: 'Proceed with an external verifier',
       onButtonPress: async () => {
+        let scanStarted = false;
         try {
           const session = await createKycSession();
           trackOnboardingStep(selfClient, OnboardingEvents.SCAN_STARTED, {
             branch: 'kyc',
           });
+          scanStarted = true;
           const result = await launchKycVerification(session.sessionToken);
 
           // User cancelled/dismissed without completing verification
@@ -109,7 +111,11 @@ const LogoConfirmationScreen: React.FC = () => {
           navigation.navigate('KycSuccess', { sessionId: session.sessionId });
         } catch {
           console.error('Error launching KYC verification');
-          failOnboardingAttempt(selfClient, 'scan_started', 'kyc_launch_error');
+          failOnboardingAttempt(
+            selfClient,
+            scanStarted ? 'scan_started' : 'pre_start',
+            scanStarted ? 'kyc_launch_error' : 'kyc_session_error',
+          );
           showModal({
             titleText: 'Error',
             bodyText: 'Unable to start verification. Please try again.',

--- a/app/src/screens/documents/selection/LogoConfirmationScreen.tsx
+++ b/app/src/screens/documents/selection/LogoConfirmationScreen.tsx
@@ -9,6 +9,7 @@ import { useNavigation, useRoute } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import {
+  failOnboardingAttempt,
   setOnboardingBranch,
   trackOnboardingStep,
   useSelfClient,
@@ -79,6 +80,7 @@ const LogoConfirmationScreen: React.FC = () => {
 
           // User cancelled/dismissed without completing verification
           if (result.type === 'cancelled') {
+            failOnboardingAttempt(selfClient, 'scan_started', 'kyc_cancelled');
             return;
           }
 
@@ -87,6 +89,11 @@ const LogoConfirmationScreen: React.FC = () => {
             console.error(
               'KYC verification failed:',
               result.error?.type ?? 'unknown',
+            );
+            failOnboardingAttempt(
+              selfClient,
+              'scan_started',
+              `kyc_failed:${result.error?.type ?? 'unknown'}`,
             );
             navigation.navigate('KycFailure', {
               countryCode,
@@ -102,6 +109,7 @@ const LogoConfirmationScreen: React.FC = () => {
           navigation.navigate('KycSuccess', { sessionId: session.sessionId });
         } catch {
           console.error('Error launching KYC verification');
+          failOnboardingAttempt(selfClient, 'scan_started', 'kyc_launch_error');
           showModal({
             titleText: 'Error',
             bodyText: 'Unable to start verification. Please try again.',

--- a/packages/mobile-sdk-alpha/src/index.ts
+++ b/packages/mobile-sdk-alpha/src/index.ts
@@ -90,17 +90,6 @@ export { SdkEvents } from './types/events';
 
 export { SelfClientContext, SelfClientProvider, useSelfClient } from './context';
 
-export {
-  _getCurrentOnboardingAttempt,
-  _resetOnboardingFunnelForTests,
-  completeOnboardingAttempt,
-  failOnboardingAttempt,
-  resolveOnboardingBranch,
-  setOnboardingBranch,
-  trackOnboardingRetry,
-  trackOnboardingStep,
-} from './analytics/onboardingFunnel';
-
 export { advercase, dinot, dinotBold, plexMono } from './constants/fonts';
 
 export {
@@ -136,6 +125,15 @@ export {
   reStorePassportDataWithRightCSCA,
   storePassportData,
 } from './documents/utils';
+
+export {
+  completeOnboardingAttempt,
+  failOnboardingAttempt,
+  resolveOnboardingBranch,
+  setOnboardingBranch,
+  trackOnboardingRetry,
+  trackOnboardingStep,
+} from './analytics/onboardingFunnel';
 
 export { createAuthAdapter } from './adapters/react-native/auth';
 


### PR DESCRIPTION
## Summary

- Address greptile-bot P2 feedback from #2021 (weekly staging release review).
- Call `failOnboardingAttempt` on the KYC cancel, failed, and catch paths in `LogoConfirmationScreen` so the active attempt is cleared; without this, a retry silently dedupes `STARTED` / `DOCUMENT_TYPE_SELECTED` / `SCAN_STARTED` and the funnel loses retry attribution.
- Stop re-exporting `_getCurrentOnboardingAttempt` and `_resetOnboardingFunnelForTests` from the package entry. They're `@internal` and the only consumer (the funnel test) imports them directly from `src/analytics/onboardingFunnel`.

## Changes

### React Native app

- `app/src/screens/documents/selection/LogoConfirmationScreen.tsx` — fail the active onboarding attempt on KYC `cancelled`, `failed`, and thrown-error paths with stage `scan_started` and a reason tag (`kyc_cancelled`, `kyc_failed:<type>`, `kyc_launch_error`).

### SDK core

- `packages/mobile-sdk-alpha/src/index.ts` — drop `_getCurrentOnboardingAttempt` and `_resetOnboardingFunnelForTests` from the public export surface.

## Test Plan

- [x] `yarn --cwd packages/mobile-sdk-alpha types` passes
- [x] `yarn --cwd packages/mobile-sdk-alpha test tests/analytics/onboardingFunnel.test.ts` — 27/27 pass
- [x] `yarn --cwd app types` passes
- [ ] Manual: tap "No" on LogoConfirmation → cancel the KYC modal → retry the flow and verify funnel events re-fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)