### PR TITLE
feat(dev): split registration bypass into document and DSC flags

### DIFF
--- a/app/src/providers/selfClientProvider.tsx
+++ b/app/src/providers/selfClientProvider.tsx
@@ -84,8 +84,10 @@ export const SelfClientProvider = ({ children }: PropsWithChildren) => {
                 .getState()
                 .shouldTrigger(errorType as InjectedErrorType);
             },
-            shouldBypassRegistrationCheck: () =>
+            shouldBypassDocumentRegistrationCheck: () =>
               useSettingStore.getState().consumeTestRegistrationCircuit(),
+            shouldBypassDscRegistrationCheck: () =>
+              useSettingStore.getState().consumeTestDscCircuit(),
           }
         : undefined,
     }),

--- a/app/src/screens/dev/sections/DebugShortcutsSection.tsx
+++ b/app/src/screens/dev/sections/DebugShortcutsSection.tsx
@@ -57,17 +57,35 @@ export const DebugShortcutsSection: React.FC<DebugShortcutsSectionProps> = ({
   const armTestRegistrationCircuit = useSettingStore(
     state => state.armTestRegistrationCircuit,
   );
+  const armTestDscCircuit = useSettingStore(state => state.armTestDscCircuit);
 
   const handleStartTestRegistrationCircuit = () => {
     Alert.alert(
       'Test Registration Circuit',
-      'The next document scan will skip the on-chain "already registered / nullified" checks and force the register circuit to run. The relayer will still reject duplicate registrations. Dev only.',
+      'The next document scan will skip the on-chain "already registered / nullified" checks and force the register circuit to run. The DSC tree check still runs, so the test cert\'s DSC must already be on-chain. The relayer will still reject duplicate registrations. Dev only.',
       [
         { text: 'Cancel', style: 'cancel' },
         {
           text: 'Start',
           onPress: () => {
             armTestRegistrationCircuit();
+            navigation.navigate('DocumentOnboarding');
+          },
+        },
+      ],
+    );
+  };
+
+  const handleStartTestDscCircuit = () => {
+    Alert.alert(
+      'Test DSC Circuit',
+      'The next document scan will skip the on-chain DSC tree check and force the DSC circuit to run, even if the DSC is already registered. Use this to QA the DSC proof path. Dev only.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Start',
+          onPress: () => {
+            armTestDscCircuit();
             navigation.navigate('DocumentOnboarding');
           },
         },
@@ -95,6 +113,12 @@ export const DebugShortcutsSection: React.FC<DebugShortcutsSectionProps> = ({
           <ShortcutRow
             label="Test Registration Circuit"
             onPress={handleStartTestRegistrationCircuit}
+          />
+        )}
+        {IS_DEV_MODE && (
+          <ShortcutRow
+            label="Test DSC Circuit"
+            onPress={handleStartTestDscCircuit}
           />
         )}
       </YStack>

--- a/app/src/screens/documents/selection/DocumentOnboardingScreen.tsx
+++ b/app/src/screens/documents/selection/DocumentOnboardingScreen.tsx
@@ -54,6 +54,9 @@ const DocumentOnboardingScreen: React.FC = () => {
   const testRegistrationCircuitArmed = useSettingStore(
     state => state.testRegistrationCircuitArmed,
   );
+  const testDscCircuitArmed = useSettingStore(
+    state => state.testDscCircuitArmed,
+  );
   const handleCameraPress = useCallback(async () => {
     impactLight();
     const ok = await ensureCameraForPassportScan({
@@ -116,8 +119,29 @@ const DocumentOnboardingScreen: React.FC = () => {
                 Test registration circuit armed
               </Text>
               <Text color={amber700} fontFamily={dinot} fontSize="$3">
-                This scan will bypass the on-chain pre-checks and force the
-                register circuit path.
+                This scan will bypass the document already-registered /
+                nullifier checks and force the register circuit path. The DSC
+                tree check still runs.
+              </Text>
+            </YStack>
+          )}
+          {testDscCircuitArmed && (
+            <YStack
+              backgroundColor={amber50}
+              borderColor={amber200}
+              borderRadius="$4"
+              borderWidth={1}
+              gap="$1"
+              marginBottom="$4"
+              padding="$4"
+              testID="test-dsc-circuit-banner"
+            >
+              <Text color={amber700} fontFamily={dinot} fontSize="$5">
+                Test DSC circuit armed
+              </Text>
+              <Text color={amber700} fontFamily={dinot} fontSize="$3">
+                This scan will bypass the on-chain DSC tree check and force the
+                DSC circuit path.
               </Text>
             </YStack>
           )}

--- a/app/src/screens/home/HomeScreen.tsx
+++ b/app/src/screens/home/HomeScreen.tsx
@@ -93,6 +93,9 @@ const HomeScreen: React.FC = () => {
   const testRegistrationCircuitArmed = useSettingStore(
     state => state.testRegistrationCircuitArmed,
   );
+  const testDscCircuitArmed = useSettingStore(
+    state => state.testDscCircuitArmed,
+  );
 
   useEffect(() => {
     removeExpiredVerifications();
@@ -278,7 +281,27 @@ const HomeScreen: React.FC = () => {
             </Text>
             <Text color={amber700} fontFamily={dinot} fontSize="$3">
               The next document registration attempt in this app session will
-              skip the on-chain pre-checks and force the register circuit path.
+              skip the document already-registered / nullifier checks and force
+              the register circuit path. The DSC tree check still runs.
+            </Text>
+          </YStack>
+        )}
+        {testDscCircuitArmed && (
+          <YStack
+            backgroundColor={amber50}
+            borderColor={amber200}
+            borderRadius="$4"
+            borderWidth={1}
+            gap="$1"
+            padding="$4"
+            testID="test-dsc-circuit-banner"
+          >
+            <Text color={amber700} fontFamily={dinot} fontSize="$5">
+              Test DSC circuit armed
+            </Text>
+            <Text color={amber700} fontFamily={dinot} fontSize="$3">
+              The next document registration attempt in this app session will
+              bypass the on-chain DSC tree check and force the DSC circuit path.
             </Text>
           </YStack>
         )}

--- a/app/src/stores/settingStore.ts
+++ b/app/src/stores/settingStore.ts
@@ -52,12 +52,19 @@ interface PersistedSettingsState {
 interface NonPersistedSettingsState {
   hideNetworkModal: boolean;
   setHideNetworkModal: (hideNetworkModal: boolean) => void;
-  // Dev-only one-shot flag, armed by the "Test registration circuit" debug
-  // shortcut and consumed (cleared) by the proving machine on the next
-  // registration attempt. Not persisted so it never survives an app launch.
+  // Dev-only one-shot flag armed by the "Test registration circuit" debug
+  // shortcut. Bypasses only the document "already registered / nullifier"
+  // checks so the register circuit runs even when the document is on-chain.
+  // The DSC tree check still runs (use testDscCircuitArmed to bypass that).
   testRegistrationCircuitArmed: boolean;
   armTestRegistrationCircuit: () => void;
   consumeTestRegistrationCircuit: () => boolean;
+  // Dev-only one-shot flag armed by the "Test DSC circuit" debug shortcut.
+  // Bypasses only the DSC tree membership check so the DSC circuit runs even
+  // when the DSC is already on-chain.
+  testDscCircuitArmed: boolean;
+  armTestDscCircuit: () => void;
+  consumeTestDscCircuit: () => boolean;
 }
 
 type SettingsState = PersistedSettingsState & NonPersistedSettingsState;
@@ -197,6 +204,16 @@ export const useSettingStore = create<SettingsState>()(
         }
         return armed;
       },
+
+      testDscCircuitArmed: false,
+      armTestDscCircuit: () => set({ testDscCircuitArmed: true }),
+      consumeTestDscCircuit: () => {
+        const armed = get().testDscCircuitArmed;
+        if (armed) {
+          set({ testDscCircuitArmed: false });
+        }
+        return armed;
+      },
     }),
     {
       name: 'setting-storage',
@@ -212,6 +229,9 @@ export const useSettingStore = create<SettingsState>()(
           .armTestRegistrationCircuit;
         delete (persistedState as Partial<SettingsState>)
           .consumeTestRegistrationCircuit;
+        delete (persistedState as Partial<SettingsState>).testDscCircuitArmed;
+        delete (persistedState as Partial<SettingsState>).armTestDscCircuit;
+        delete (persistedState as Partial<SettingsState>).consumeTestDscCircuit;
         return persistedState;
       },
       version: SETTING_STORE_VERSION,

--- a/app/tests/src/providers/selfClientProvider.test.tsx
+++ b/app/tests/src/providers/selfClientProvider.test.tsx
@@ -155,7 +155,7 @@ describe('SelfClientProvider', () => {
     }
   });
 
-  it('consumes shouldBypassRegistrationCheck as a one-shot flag', () => {
+  it('consumes shouldBypassDocumentRegistrationCheck as a one-shot flag', () => {
     act(() => {
       useSettingStore.getState().armTestRegistrationCircuit();
     });
@@ -168,13 +168,68 @@ describe('SelfClientProvider', () => {
     const config = mockSdkProviderProps?.config as
       | {
           devConfig?: {
-            shouldBypassRegistrationCheck?: () => boolean;
+            shouldBypassDocumentRegistrationCheck?: () => boolean;
+            shouldBypassDscRegistrationCheck?: () => boolean;
           };
         }
       | undefined;
 
-    expect(config?.devConfig?.shouldBypassRegistrationCheck?.()).toBe(true);
-    expect(config?.devConfig?.shouldBypassRegistrationCheck?.()).toBe(false);
+    expect(config?.devConfig?.shouldBypassDocumentRegistrationCheck?.()).toBe(
+      true,
+    );
+    expect(config?.devConfig?.shouldBypassDocumentRegistrationCheck?.()).toBe(
+      false,
+    );
     expect(useSettingStore.getState().testRegistrationCircuitArmed).toBe(false);
+  });
+
+  it('consumes shouldBypassDscRegistrationCheck as a one-shot flag', () => {
+    act(() => {
+      useSettingStore.getState().armTestDscCircuit();
+    });
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <SelfClientProvider>{children}</SelfClientProvider>
+    );
+    renderHook(() => useSelfClient(), { wrapper });
+
+    const config = mockSdkProviderProps?.config as
+      | {
+          devConfig?: {
+            shouldBypassDocumentRegistrationCheck?: () => boolean;
+            shouldBypassDscRegistrationCheck?: () => boolean;
+          };
+        }
+      | undefined;
+
+    expect(config?.devConfig?.shouldBypassDscRegistrationCheck?.()).toBe(true);
+    expect(config?.devConfig?.shouldBypassDscRegistrationCheck?.()).toBe(false);
+    expect(useSettingStore.getState().testDscCircuitArmed).toBe(false);
+  });
+
+  it('keeps document and DSC bypasses independent', () => {
+    act(() => {
+      useSettingStore.getState().armTestRegistrationCircuit();
+    });
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <SelfClientProvider>{children}</SelfClientProvider>
+    );
+    renderHook(() => useSelfClient(), { wrapper });
+
+    const config = mockSdkProviderProps?.config as
+      | {
+          devConfig?: {
+            shouldBypassDocumentRegistrationCheck?: () => boolean;
+            shouldBypassDscRegistrationCheck?: () => boolean;
+          };
+        }
+      | undefined;
+
+    // DSC bypass is not armed even though the document bypass is.
+    expect(config?.devConfig?.shouldBypassDscRegistrationCheck?.()).toBe(false);
+    expect(config?.devConfig?.shouldBypassDocumentRegistrationCheck?.()).toBe(
+      true,
+    );
   });
 });

--- a/app/tests/src/stores/settingStore.test.ts
+++ b/app/tests/src/stores/settingStore.test.ts
@@ -88,3 +88,44 @@ describe('useSettingStore test registration circuit flag', () => {
     expect(persistedState).not.toHaveProperty('consumeTestRegistrationCircuit');
   });
 });
+
+describe('useSettingStore test DSC circuit flag', () => {
+  afterEach(() => {
+    useSettingStore.setState(useSettingStore.getInitialState(), true);
+  });
+
+  it('arms once and clears on first consume', () => {
+    expect(useSettingStore.getState().testDscCircuitArmed).toBe(false);
+
+    useSettingStore.getState().armTestDscCircuit();
+
+    expect(useSettingStore.getState().testDscCircuitArmed).toBe(true);
+    expect(useSettingStore.getState().consumeTestDscCircuit()).toBe(true);
+    expect(useSettingStore.getState().testDscCircuitArmed).toBe(false);
+    expect(useSettingStore.getState().consumeTestDscCircuit()).toBe(false);
+  });
+
+  it('is independent of the test registration circuit flag', () => {
+    useSettingStore.getState().armTestDscCircuit();
+
+    expect(useSettingStore.getState().testDscCircuitArmed).toBe(true);
+    expect(useSettingStore.getState().testRegistrationCircuitArmed).toBe(false);
+    expect(useSettingStore.getState().consumeTestRegistrationCircuit()).toBe(
+      false,
+    );
+    // Consuming the registration flag must not clear the DSC arm.
+    expect(useSettingStore.getState().testDscCircuitArmed).toBe(true);
+  });
+
+  it('excludes the test DSC circuit flag from persisted state', () => {
+    useSettingStore.getState().armTestDscCircuit();
+
+    const partialize = useSettingStore.persist.getOptions().partialize;
+    const persistedState = partialize?.(useSettingStore.getState());
+
+    expect(persistedState).toBeDefined();
+    expect(persistedState).not.toHaveProperty('testDscCircuitArmed');
+    expect(persistedState).not.toHaveProperty('armTestDscCircuit');
+    expect(persistedState).not.toHaveProperty('consumeTestDscCircuit');
+  });
+});

--- a/packages/mobile-sdk-alpha/src/proving/provingMachine.ts
+++ b/packages/mobile-sdk-alpha/src/proving/provingMachine.ts
@@ -1389,17 +1389,12 @@ export const useProvingStore = create<ProvingState>((set, get) => {
         else {
           const bypassDocumentRegistrationCheck =
             selfClient.config?.devConfig?.shouldBypassDocumentRegistrationCheck?.() ?? false;
-          const bypassDscRegistrationCheck =
-            selfClient.config?.devConfig?.shouldBypassDscRegistrationCheck?.() ?? false;
           if (bypassDocumentRegistrationCheck) {
             selfClient.logProofEvent(
               'warn',
               'Dev bypass active: skipping document registration / nullifier checks',
               context,
             );
-          }
-          if (bypassDscRegistrationCheck) {
-            selfClient.logProofEvent('warn', 'Dev bypass active: skipping DSC tree check', context);
           }
           const { isRegistered, csca } = bypassDocumentRegistrationCheck
             ? { isRegistered: false, csca: undefined }
@@ -1454,12 +1449,16 @@ export const useProvingStore = create<ProvingState>((set, get) => {
           }
           const document: DocumentCategory = passportData.documentCategory;
           if (document === 'passport' || document === 'id_card') {
+            // Consume the DSC bypass only here so arming it on a session that
+            // ends up scanning aadhaar/kyc does not silently waste the one-shot.
+            const bypassDscRegistrationCheck =
+              selfClient.config?.devConfig?.shouldBypassDscRegistrationCheck?.() ?? false;
+            if (bypassDscRegistrationCheck) {
+              selfClient.logProofEvent('warn', 'Dev bypass active: skipping DSC tree check', context);
+            }
             const isDscRegistered = bypassDscRegistrationCheck
               ? false
-              : await checkIfPassportDscIsInTree(
-                  passportData,
-                  selfClient.getProtocolState()[document].dsc_tree,
-                );
+              : await checkIfPassportDscIsInTree(passportData, selfClient.getProtocolState()[document].dsc_tree);
             selfClient.logProofEvent('info', 'DSC tree check', context, {
               dsc_registered: isDscRegistered,
             });

--- a/packages/mobile-sdk-alpha/src/proving/provingMachine.ts
+++ b/packages/mobile-sdk-alpha/src/proving/provingMachine.ts
@@ -1387,11 +1387,21 @@ export const useProvingStore = create<ProvingState>((set, get) => {
 
         /// registration
         else {
-          const bypassRegistrationCheck = selfClient.config?.devConfig?.shouldBypassRegistrationCheck?.() ?? false;
-          if (bypassRegistrationCheck) {
-            selfClient.logProofEvent('warn', 'Dev bypass active: skipping on-chain registration checks', context);
+          const bypassDocumentRegistrationCheck =
+            selfClient.config?.devConfig?.shouldBypassDocumentRegistrationCheck?.() ?? false;
+          const bypassDscRegistrationCheck =
+            selfClient.config?.devConfig?.shouldBypassDscRegistrationCheck?.() ?? false;
+          if (bypassDocumentRegistrationCheck) {
+            selfClient.logProofEvent(
+              'warn',
+              'Dev bypass active: skipping document registration / nullifier checks',
+              context,
+            );
           }
-          const { isRegistered, csca } = bypassRegistrationCheck
+          if (bypassDscRegistrationCheck) {
+            selfClient.logProofEvent('warn', 'Dev bypass active: skipping DSC tree check', context);
+          }
+          const { isRegistered, csca } = bypassDocumentRegistrationCheck
             ? { isRegistered: false, csca: undefined }
             : await isUserRegisteredWithAlternativeCSCA(passportData, secret as string, {
                 getCommitmentTree: (docCategory: DocumentCategory) => getCommitmentTree(selfClient, docCategory),
@@ -1426,7 +1436,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
             actor!.send({ type: 'ALREADY_REGISTERED' });
             return;
           }
-          const isNullifierOnchain = bypassRegistrationCheck ? false : await isDocumentNullified(passportData);
+          const isNullifierOnchain = bypassDocumentRegistrationCheck ? false : await isDocumentNullified(passportData);
           selfClient.logProofEvent('info', 'Nullifier check', context, {
             nullified: isNullifierOnchain,
           });
@@ -1444,10 +1454,12 @@ export const useProvingStore = create<ProvingState>((set, get) => {
           }
           const document: DocumentCategory = passportData.documentCategory;
           if (document === 'passport' || document === 'id_card') {
-            const isDscRegistered = await checkIfPassportDscIsInTree(
-              passportData,
-              selfClient.getProtocolState()[document].dsc_tree,
-            );
+            const isDscRegistered = bypassDscRegistrationCheck
+              ? false
+              : await checkIfPassportDscIsInTree(
+                  passportData,
+                  selfClient.getProtocolState()[document].dsc_tree,
+                );
             selfClient.logProofEvent('info', 'DSC tree check', context, {
               dsc_registered: isDscRegistered,
             });

--- a/packages/mobile-sdk-alpha/src/types/public.ts
+++ b/packages/mobile-sdk-alpha/src/types/public.ts
@@ -71,8 +71,19 @@ export interface Config {
      * generate a register proof regardless of chain state. Intended for QA of
      * the register circuit path; the relayer/contract will still reject a
      * duplicate registration at submission time.
+     *
+     * Independent of `shouldBypassDscRegistrationCheck`: the DSC tree check
+     * still runs and is honored, so a test cert whose DSC is already on-chain
+     * skips the DSC proof and reaches the register circuit directly.
      */
-    shouldBypassRegistrationCheck?: () => boolean;
+    shouldBypassDocumentRegistrationCheck?: () => boolean;
+    /**
+     * Dev-only bypass for the on-chain DSC tree membership check that runs
+     * before registration proving. When this returns true, the proving machine
+     * treats the DSC as not yet in the tree and forces the DSC circuit to run
+     * before the register circuit. Intended for QA of the DSC circuit path.
+     */
+    shouldBypassDscRegistrationCheck?: () => boolean;
   };
   /**
    * Platform identifier used for structured logging and observability.

--- a/packages/mobile-sdk-alpha/tests/proving/provingMachine.documentProcessor.test.ts
+++ b/packages/mobile-sdk-alpha/tests/proving/provingMachine.documentProcessor.test.ts
@@ -843,7 +843,7 @@ describe('validatingDocument', () => {
     }
   });
 
-  it('skips on-chain registration checks when devConfig.shouldBypassRegistrationCheck returns true', async () => {
+  it('skips document registration checks when devConfig.shouldBypassDocumentRegistrationCheck returns true', async () => {
     const passportData = buildPassportFixture();
     const secret = '123456789';
     const commitment = generateCommitment(secret, AttestationIdHex.passport, passportData);
@@ -868,7 +868,7 @@ describe('validatingDocument', () => {
     const selfClient = createSelfClient(protocolState);
     (selfClient as unknown as { config: unknown }).config = {
       devConfig: {
-        shouldBypassRegistrationCheck: () => true,
+        shouldBypassDocumentRegistrationCheck: () => true,
       },
     };
 
@@ -902,7 +902,7 @@ describe('validatingDocument', () => {
     }
   });
 
-  it('still switches to register circuit from DSC-in-tree when registration checks are bypassed', async () => {
+  it('still switches to register circuit from DSC-in-tree when document registration checks are bypassed', async () => {
     const passportData = buildPassportFixture();
     const secret = '123456789';
     const commitment = generateCommitment(secret, AttestationIdHex.passport, passportData);
@@ -928,7 +928,7 @@ describe('validatingDocument', () => {
     const selfClient = createSelfClient(protocolState);
     (selfClient as unknown as { config: unknown }).config = {
       devConfig: {
-        shouldBypassRegistrationCheck: () => true,
+        shouldBypassDocumentRegistrationCheck: () => true,
       },
     };
 
@@ -952,6 +952,126 @@ describe('validatingDocument', () => {
 
       expect(useProvingStore.getState().circuitType).toBe('register');
       expect(actorMock.send).toHaveBeenCalledWith({ type: 'VALIDATION_SUCCESS' });
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('forces DSC circuit path when devConfig.shouldBypassDscRegistrationCheck returns true', async () => {
+    const passportData = buildPassportFixture();
+    const secret = '123456789';
+    const registerCircuit = getCircuitNameFromPassportData(passportData, 'register');
+    const dscCircuit = getCircuitNameFromPassportData(passportData, 'dsc');
+    const deployedCircuits = {
+      REGISTER: [registerCircuit],
+      REGISTER_ID: [],
+      REGISTER_AADHAAR: ['register_aadhaar'],
+      DSC: [dscCircuit],
+      DSC_ID: [],
+    };
+    // DSC IS in the on-chain tree — without the bypass, the proving machine
+    // would skip the DSC circuit and go straight to the register circuit.
+    const dscLeaf = getLeafDscTree(passportData.dsc_parsed!, passportData.csca_parsed!);
+    const dscTree = createDscTree([dscLeaf]);
+
+    const protocolState = buildProtocolState({
+      commitmentTree: createCommitmentTree([]),
+      dscTree,
+      deployedCircuits,
+      alternativeCsca: {},
+    });
+    const selfClient = createSelfClient(protocolState);
+    (selfClient as unknown as { config: unknown }).config = {
+      devConfig: {
+        shouldBypassDscRegistrationCheck: () => true,
+      },
+    };
+
+    loadSelectedDocumentMock.mockResolvedValue({ data: passportData } as any);
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ data: false }),
+      } as Response),
+    );
+
+    try {
+      await useProvingStore.getState().init(selfClient, 'register');
+      actorMock.send.mockClear();
+      vi.mocked(selfClient.trackEvent).mockClear();
+
+      useProvingStore.setState({ passportData, secret, circuitType: 'dsc' });
+
+      await useProvingStore.getState().validatingDocument(selfClient);
+
+      // circuitType must remain 'dsc' — DSC tree check was bypassed so the
+      // DSC-in-tree shortcut to 'register' did NOT fire.
+      expect(useProvingStore.getState().circuitType).toBe('dsc');
+      expect(actorMock.send).toHaveBeenCalledWith({ type: 'VALIDATION_SUCCESS' });
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('keeps document and DSC bypasses independent', async () => {
+    const passportData = buildPassportFixture();
+    const secret = '123456789';
+    const commitment = generateCommitment(secret, AttestationIdHex.passport, passportData);
+    // Document IS registered on-chain, but document bypass is ON.
+    const commitmentTree = createCommitmentTree([commitment]);
+    const registerCircuit = getCircuitNameFromPassportData(passportData, 'register');
+    const dscCircuit = getCircuitNameFromPassportData(passportData, 'dsc');
+    const deployedCircuits = {
+      REGISTER: [registerCircuit],
+      REGISTER_ID: [],
+      REGISTER_AADHAAR: ['register_aadhaar'],
+      DSC: [dscCircuit],
+      DSC_ID: [],
+    };
+    // DSC is also in the tree — DSC bypass is OFF, so the DSC-in-tree
+    // shortcut should fire and switch circuitType to 'register'.
+    const dscLeaf = getLeafDscTree(passportData.dsc_parsed!, passportData.csca_parsed!);
+    const dscTree = createDscTree([dscLeaf]);
+
+    const protocolState = buildProtocolState({
+      commitmentTree,
+      dscTree,
+      deployedCircuits,
+      alternativeCsca: {},
+    });
+    const selfClient = createSelfClient(protocolState);
+    (selfClient as unknown as { config: unknown }).config = {
+      devConfig: {
+        shouldBypassDocumentRegistrationCheck: () => true,
+        shouldBypassDscRegistrationCheck: () => false,
+      },
+    };
+
+    loadSelectedDocumentMock.mockResolvedValue({ data: passportData } as any);
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ data: true }),
+      } as Response),
+    );
+
+    try {
+      await useProvingStore.getState().init(selfClient, 'register');
+      actorMock.send.mockClear();
+      vi.mocked(selfClient.trackEvent).mockClear();
+
+      useProvingStore.setState({ passportData, secret, circuitType: 'dsc' });
+
+      await useProvingStore.getState().validatingDocument(selfClient);
+
+      // Document bypass skipped the "already registered" path, DSC tree
+      // check ran normally and switched to 'register'.
+      expect(useProvingStore.getState().circuitType).toBe('register');
+      expect(actorMock.send).toHaveBeenCalledWith({ type: 'VALIDATION_SUCCESS' });
+      expect(actorMock.send).not.toHaveBeenCalledWith({ type: 'ALREADY_REGISTERED' });
       expect(fetchSpy).not.toHaveBeenCalled();
     } finally {
       fetchSpy.mockRestore();


### PR DESCRIPTION
The single shouldBypassRegistrationCheck forced isDscRegistered=false, which meant enabling the bypass to test the register circuit always routed through a DSC proof first — and that proof fails when the test cert's DSC is already on-chain, so the register circuit was never reached.

Split into two independent dev flags:
- shouldBypassDocumentRegistrationCheck: bypass isRegistered + nullifier
- shouldBypassDscRegistrationCheck: bypass DSC tree membership

Wire each to its own one-shot armed flag in settingStore and surface as two debug shortcuts ("Test Registration Circuit" / "Test DSC Circuit"), each with its own banner on Home and DocumentOnboarding.

## Summary

<!-- Brief description of changes -->

## Test plan

<!-- How was this tested? -->

---

### Native Consolidation Checklist

<!-- Check items that apply to this PR. Delete section if not touching native code. -->

- [ ] CONTRACTS.md reviewed - no unintended contract changes
- [ ] Layer 1 bridge contract tests pass (`cd app && yarn jest:run` / `yarn workspace @selfxyz/rn-sdk-test-app test`)
- [ ] Layer 3 builds pass (app iOS, RN test app iOS, RN test app Android)
- [ ] Layer 4 manual smoke test signed off (if consolidation PR)
- [ ] No new native business logic added (logic belongs in TypeScript)
