### PR TITLE
chore: update xUrl to point to selfxyz

### DIFF
--- a/app/src/consts/links.ts
+++ b/app/src/consts/links.ts
@@ -40,4 +40,4 @@ export const telegramUrl = 'https://t.me/selfxyz';
 export const termsUrl = 'https://self.xyz/terms';
 export const turnkeyOAuthRedirectAndroidUri = 'https://redirect.self.xyz';
 export const turnkeyOAuthRedirectIosUri = 'https://oauth-redirect.turnkey.com';
-export const xUrl = 'https://x.com/selfprotocol';
+export const xUrl = 'https://x.com/selfxyz';

--- a/app/tests/src/consts/links.test.ts
+++ b/app/tests/src/consts/links.test.ts
@@ -41,7 +41,7 @@ describe('links', () => {
     });
 
     it('should have correct X (Twitter) URL', () => {
-      expect(links.xUrl).toBe('https://x.com/selfprotocol');
+      expect(links.xUrl).toBe('https://x.com/selfxyz');
     });
 
     it('should have correct Self main URL', () => {


### PR DESCRIPTION
Linear: [SELF-2751](https://linear.app/selfprotocol/issue/SELF-2751/chore-update-xtwitter-url-in-settings-to-selfxyz)

## Summary

Updates xUrl to point to [selfxyz](https://x.com/selfxyz).

## Test plan

The X logo in the settings should point to a valid URL.