### PR TITLE
gate KYC completion on Didit session status to enable liveness

### DIFF
--- a/app/src/hooks/useKycLauncher.ts
+++ b/app/src/hooks/useKycLauncher.ts
@@ -111,6 +111,25 @@ export const useKycLauncher = (options: UseKycLauncherOptions) => {
         return;
       }
 
+      // Provider returned a completed session, but the decision is not Approved
+      // (e.g. liveness Declined, In Review). Treat as failure.
+      const sessionStatus = result.session?.status;
+      if (sessionStatus !== 'Approved') {
+        const safeError = sanitizeErrorMessage(
+          `kyc_status_not_approved:${sessionStatus ?? 'unknown'}`,
+        );
+        console.error('KYC verification not approved:', safeError);
+        if (onError) {
+          await onError(safeError, result);
+        } else {
+          navigation.navigate('KycFailure', {
+            countryCode,
+            canRetry: true,
+          });
+        }
+        return;
+      }
+
       // Handle success - navigate to KycSuccess by default
       if (onSuccess) {
         await onSuccess(result, session.sessionId);

--- a/app/src/integrations/kyc/kycService.ts
+++ b/app/src/integrations/kyc/kycService.ts
@@ -66,6 +66,8 @@ export const launchKycVerification = async (
   sessionToken: string,
   config?: KycLaunchConfig,
 ): Promise<KycVerificationResult> => {
+  // Liveness and other verification steps are workflow-controlled on the Didit
+  // Console, not configurable here. Do not add SDK-level liveness flags.
   const result = await startVerification(sessionToken, {
     languageCode: config?.locale ?? 'en',
     loggingEnabled: config?.debug ?? __DEV__,

--- a/app/src/providers/selfClientProvider.tsx
+++ b/app/src/providers/selfClientProvider.tsx
@@ -403,12 +403,25 @@ export const SelfClientProvider = ({ children }: PropsWithChildren) => {
                     return;
                   }
 
-                  // User completed verification
-                  // Navigate to KYC success screen
+                  // Provider returned a completed session — only Approved
+                  // proceeds. Liveness Declined / In Review must not advance
+                  // the proving flow.
+                  const sessionStatus = result.session?.status;
                   console.log(
                     '[KYC] Verification submitted, status:',
-                    result.session?.status,
+                    sessionStatus,
                   );
+                  if (sessionStatus !== 'Approved') {
+                    if (navigationRef.isReady()) {
+                      navigationRef.navigate('KycFailure', {
+                        countryCode,
+                        canRetry: true,
+                      });
+                    }
+                    return;
+                  }
+
+                  // User completed verification with Approved status
                   if (navigationRef.isReady()) {
                     navigationRef.navigate('KycSuccess', {
                       sessionId: session.sessionId,

--- a/app/src/screens/documents/selection/LogoConfirmationScreen.tsx
+++ b/app/src/screens/documents/selection/LogoConfirmationScreen.tsx
@@ -104,6 +104,22 @@ const LogoConfirmationScreen: React.FC = () => {
             return;
           }
 
+          // Provider returned a completed session — only Approved counts as
+          // success. Liveness Declined / In Review must route to KycFailure.
+          const sessionStatus = result.session?.status;
+          if (sessionStatus !== 'Approved') {
+            failOnboardingAttempt(
+              selfClient,
+              'scan_started',
+              `kyc_declined:${sessionStatus ?? 'unknown'}`,
+            );
+            navigation.navigate('KycFailure', {
+              countryCode,
+              canRetry: true,
+            });
+            return;
+          }
+
           // Verification succeeded - navigate to KycSuccessScreen
           trackOnboardingStep(selfClient, OnboardingEvents.SCAN_SUCCEEDED, {
             branch: 'kyc',

--- a/app/tests/src/hooks/useKycLauncher.test.ts
+++ b/app/tests/src/hooks/useKycLauncher.test.ts
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { useNavigation } from '@react-navigation/native';
+import { act, renderHook } from '@testing-library/react-native';
+
+import { useKycLauncher } from '@/hooks/useKycLauncher';
+import { createKycSession, launchKycVerification } from '@/integrations/kyc';
+import { useFeedback } from '@/providers/feedbackProvider';
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: jest.fn(),
+}));
+
+jest.mock('@/integrations/kyc', () => ({
+  createKycSession: jest.fn(),
+  launchKycVerification: jest.fn(),
+}));
+
+jest.mock('@/providers/feedbackProvider', () => ({
+  useFeedback: jest.fn(),
+}));
+
+jest.mock('@selfxyz/mobile-sdk-alpha', () => ({
+  sanitizeErrorMessage: (msg: string) => msg,
+}));
+
+const MockUseNavigation = useNavigation as jest.MockedFunction<
+  typeof useNavigation
+>;
+const MockCreateKycSession = createKycSession as jest.MockedFunction<
+  typeof createKycSession
+>;
+const MockLaunchKycVerification = launchKycVerification as jest.MockedFunction<
+  typeof launchKycVerification
+>;
+const MockUseFeedback = useFeedback as jest.MockedFunction<typeof useFeedback>;
+
+const mockNavigate = jest.fn();
+const mockShowModal = jest.fn();
+
+describe('useKycLauncher', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    MockUseNavigation.mockReturnValue({ navigate: mockNavigate } as any);
+    MockUseFeedback.mockReturnValue({ showModal: mockShowModal } as any);
+    MockCreateKycSession.mockResolvedValue({
+      sessionId: 'sess-1',
+      sessionToken: 'tok-1',
+    });
+  });
+
+  const renderLauncher = (options: { onError?: jest.Mock } = {}) =>
+    renderHook(() =>
+      useKycLauncher({
+        countryCode: 'US',
+        onError: options.onError,
+      }),
+    );
+
+  it('navigates to KycSuccess when status is Approved', async () => {
+    MockLaunchKycVerification.mockResolvedValue({
+      type: 'completed',
+      session: { status: 'Approved', sessionId: 'sess-1' },
+    });
+
+    const { result } = renderLauncher();
+    await act(async () => {
+      await result.current.launchKycVerification();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('KycSuccess', {
+      sessionId: 'sess-1',
+    });
+  });
+
+  it('navigates to KycFailure (not KycSuccess) when status is Declined', async () => {
+    MockLaunchKycVerification.mockResolvedValue({
+      type: 'completed',
+      session: { status: 'Declined', sessionId: 'sess-1' },
+    });
+
+    const { result } = renderLauncher();
+    await act(async () => {
+      await result.current.launchKycVerification();
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalledWith(
+      'KycSuccess',
+      expect.anything(),
+    );
+    expect(mockNavigate).toHaveBeenCalledWith('KycFailure', {
+      countryCode: 'US',
+      canRetry: true,
+    });
+  });
+
+  it('navigates to KycFailure when status is In Review', async () => {
+    MockLaunchKycVerification.mockResolvedValue({
+      type: 'completed',
+      session: { status: 'In Review', sessionId: 'sess-1' },
+    });
+
+    const { result } = renderLauncher();
+    await act(async () => {
+      await result.current.launchKycVerification();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('KycFailure', {
+      countryCode: 'US',
+      canRetry: true,
+    });
+  });
+
+  it('navigates to KycFailure when session is missing', async () => {
+    MockLaunchKycVerification.mockResolvedValue({ type: 'completed' });
+
+    const { result } = renderLauncher();
+    await act(async () => {
+      await result.current.launchKycVerification();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('KycFailure', {
+      countryCode: 'US',
+      canRetry: true,
+    });
+  });
+
+  it('forwards Declined to a custom onError when provided', async () => {
+    MockLaunchKycVerification.mockResolvedValue({
+      type: 'completed',
+      session: { status: 'Declined', sessionId: 'sess-1' },
+    });
+    const onError = jest.fn();
+
+    const { result } = renderLauncher({ onError });
+    await act(async () => {
+      await result.current.launchKycVerification();
+    });
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('routes type:failed to KycFailure', async () => {
+    MockLaunchKycVerification.mockResolvedValue({
+      type: 'failed',
+      error: { type: 'provider_error', message: 'oops' },
+    });
+
+    const { result } = renderLauncher();
+    await act(async () => {
+      await result.current.launchKycVerification();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('KycFailure', {
+      countryCode: 'US',
+      canRetry: true,
+    });
+  });
+});

--- a/app/tests/src/providers/selfClientProvider.test.tsx
+++ b/app/tests/src/providers/selfClientProvider.test.tsx
@@ -6,6 +6,7 @@
 import type { ReactNode } from 'react';
 import { act, renderHook } from '@testing-library/react-native';
 
+import { createKycSession, launchKycVerification } from '@/integrations/kyc';
 import { useSettingStore } from '@/stores/settingStore';
 
 let mockSdkProviderProps: Record<string, unknown> | undefined;
@@ -46,6 +47,11 @@ jest.mock('@/navigation', () => {
   };
 });
 
+jest.mock('@/integrations/kyc', () => ({
+  createKycSession: jest.fn(),
+  launchKycVerification: jest.fn(),
+}));
+
 jest.mock(
   '@selfxyz/mobile-sdk-alpha/onboarding/confirm-identification',
   () => ({
@@ -80,6 +86,18 @@ jest.mock('@selfxyz/mobile-sdk-alpha', () => {
     PROVING_REGISTER_ERROR_OR_FAILURE: 'PROVING_REGISTER_ERROR_OR_FAILURE',
     PROVING_ACCOUNT_VERIFIED_PENDING: 'PROVING_ACCOUNT_VERIFIED_PENDING',
     PROVING_ACCOUNT_VERIFIED_FAILURE: 'PROVING_ACCOUNT_VERIFIED_FAILURE',
+    PROVING_PASSPORT_NOT_SUPPORTED: 'PROVING_PASSPORT_NOT_SUPPORTED',
+    PROVING_ACCOUNT_RECOVERY_REQUIRED: 'PROVING_ACCOUNT_RECOVERY_REQUIRED',
+    PROVING_BEGIN_GENERATION: 'PROVING_BEGIN_GENERATION',
+    PROOF_EVENT: 'PROOF_EVENT',
+    NFC_EVENT: 'NFC_EVENT',
+    DOCUMENT_MRZ_READ_SUCCESS: 'DOCUMENT_MRZ_READ_SUCCESS',
+    DOCUMENT_MRZ_READ_FAILURE: 'DOCUMENT_MRZ_READ_FAILURE',
+    PROVING_AADHAAR_UPLOAD_SUCCESS: 'PROVING_AADHAAR_UPLOAD_SUCCESS',
+    PROVING_AADHAAR_UPLOAD_FAILURE: 'PROVING_AADHAAR_UPLOAD_FAILURE',
+    DOCUMENT_COUNTRY_SELECTED: 'DOCUMENT_COUNTRY_SELECTED',
+    DOCUMENT_TYPE_SELECTED: 'DOCUMENT_TYPE_SELECTED',
+    DOCUMENT_OWNERSHIP_CONFIRMED: 'DOCUMENT_OWNERSHIP_CONFIRMED',
   };
 
   return {
@@ -96,15 +114,31 @@ jest.mock('@selfxyz/mobile-sdk-alpha', () => {
 
 let useSelfClient: () => unknown;
 let SelfClientProvider: ({ children }: { children: ReactNode }) => JSX.Element;
+let SdkEvents: Record<string, string>;
+let navigationRef: {
+  isReady: jest.Mock<boolean, []>;
+  navigate: jest.Mock;
+};
+
+const MockCreateKycSession = createKycSession as jest.MockedFunction<
+  typeof createKycSession
+>;
+const MockLaunchKycVerification = launchKycVerification as jest.MockedFunction<
+  typeof launchKycVerification
+>;
 
 beforeAll(() => {
   ({ useSelfClient } = require('@selfxyz/mobile-sdk-alpha'));
+  ({ SdkEvents } = require('@selfxyz/mobile-sdk-alpha'));
   ({ SelfClientProvider } = require('@/providers/selfClientProvider'));
+  ({ navigationRef } = require('@/navigation'));
 });
 
 describe('SelfClientProvider', () => {
   beforeEach(() => {
     mockSdkProviderProps = undefined;
+    jest.clearAllMocks();
+    navigationRef.isReady.mockReturnValue(false);
     useSettingStore.setState(useSettingStore.getInitialState(), true);
   });
 
@@ -231,5 +265,48 @@ describe('SelfClientProvider', () => {
     expect(config?.devConfig?.shouldBypassDocumentRegistrationCheck?.()).toBe(
       true,
     );
+  });
+
+  it('routes declined KYC provider results to KycFailure without advancing', async () => {
+    navigationRef.isReady.mockReturnValue(true);
+    MockCreateKycSession.mockResolvedValue({
+      sessionId: 'sess-1',
+      sessionToken: 'tok-1',
+    });
+    MockLaunchKycVerification.mockResolvedValue({
+      type: 'completed',
+      session: {
+        status: 'Declined',
+        sessionId: 'didit-session-1',
+      },
+    });
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <SelfClientProvider>{children}</SelfClientProvider>
+    );
+    renderHook(() => useSelfClient(), { wrapper });
+
+    const listeners = mockSdkProviderProps?.listeners as
+      | Map<string, (payload: unknown) => void>
+      | undefined;
+    const onDocumentTypeSelected = listeners?.get(
+      SdkEvents.DOCUMENT_TYPE_SELECTED,
+    );
+
+    expect(onDocumentTypeSelected).toBeDefined();
+
+    await act(async () => {
+      onDocumentTypeSelected?.({ documentType: 'kyc', countryCode: 'US' });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(navigationRef.navigate).toHaveBeenCalledWith('KycFailure', {
+      countryCode: 'US',
+      canRetry: true,
+    });
+    expect(navigationRef.navigate).not.toHaveBeenCalledWith('KycSuccess', {
+      sessionId: 'sess-1',
+    });
   });
 });

--- a/app/tests/src/screens/documents/selection/LogoConfirmationScreen.test.tsx
+++ b/app/tests/src/screens/documents/selection/LogoConfirmationScreen.test.tsx
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import React from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+import { act, fireEvent, render, screen } from '@testing-library/react-native';
+
+import { createKycSession, launchKycVerification } from '@/integrations/kyc';
+import { useFeedback } from '@/providers/feedbackProvider';
+import LogoConfirmationScreen from '@/screens/documents/selection/LogoConfirmationScreen';
+
+const MockText = Text;
+const MockTouchableOpacity = TouchableOpacity;
+const MockView = View;
+
+const mockNavigate = jest.fn();
+const mockTrackEvent = jest.fn();
+const mockShowModal = jest.fn();
+let mockSetOnboardingBranch = jest.fn();
+let mockTrackOnboardingStep = jest.fn();
+let mockFailOnboardingAttempt = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({
+    navigate: mockNavigate,
+  }),
+  useRoute: () => ({
+    params: {
+      countryCode: 'US',
+      documentType: 'p',
+    },
+  }),
+}));
+
+jest.mock('@/providers/feedbackProvider', () => ({
+  useFeedback: jest.fn(),
+}));
+
+jest.mock('@/hooks/useHapticNavigation', () => jest.fn(() => jest.fn()));
+
+jest.mock('@/integrations/haptics', () => ({
+  buttonTap: jest.fn(),
+}));
+
+jest.mock('@/integrations/kyc', () => ({
+  createKycSession: jest.fn(),
+  launchKycVerification: jest.fn(),
+}));
+
+jest.mock('@selfxyz/mobile-sdk-alpha', () => ({
+  failOnboardingAttempt: jest.fn(),
+  setOnboardingBranch: jest.fn(),
+  trackOnboardingStep: jest.fn(),
+  useSelfClient: jest.fn(() => ({
+    trackEvent: mockTrackEvent,
+  })),
+}));
+
+jest.mock('@selfxyz/mobile-sdk-alpha/constants/analytics', () => ({
+  OnboardingEvents: {
+    SCAN_STARTED: 'SCAN_STARTED',
+    SCAN_SUCCEEDED: 'SCAN_SUCCEEDED',
+  },
+}));
+
+jest.mock('@selfxyz/mobile-sdk-alpha/components', () => ({
+  BodyText: ({ children }: { children: React.ReactNode }) => (
+    <MockText>{children}</MockText>
+  ),
+  ButtonsContainer: ({ children }: { children: React.ReactNode }) => (
+    <MockView>{children}</MockView>
+  ),
+  PrimaryButton: ({
+    children,
+    onPress,
+  }: {
+    children: React.ReactNode;
+    onPress?: () => void;
+  }) => (
+    <MockTouchableOpacity onPress={onPress}>
+      <MockText>{children}</MockText>
+    </MockTouchableOpacity>
+  ),
+  SecondaryButton: ({
+    children,
+    onPress,
+  }: {
+    children: React.ReactNode;
+    onPress?: () => void;
+  }) => (
+    <MockTouchableOpacity onPress={onPress}>
+      <MockText>{children}</MockText>
+    </MockTouchableOpacity>
+  ),
+}));
+
+jest.mock('@selfxyz/mobile-sdk-alpha/constants/colors', () => ({
+  black: '#000',
+  slate100: '#eee',
+  slate400: '#999',
+  white: '#fff',
+}));
+
+jest.mock('@selfxyz/mobile-sdk-alpha/constants/fonts', () => ({
+  advercase: 'advercase',
+  dinot: 'dinot',
+}));
+
+jest.mock('@/components/navbar/DocumentFlowNavBar', () => ({
+  DocumentFlowNavBar: ({ title }: { title: string }) => (
+    <MockText>{title}</MockText>
+  ),
+}));
+
+jest.mock('@/layouts/ExpandableBottomLayout', () => ({
+  ExpandableBottomLayout: {
+    Layout: ({ children }: { children: React.ReactNode }) => (
+      <MockView>{children}</MockView>
+    ),
+    TopSection: ({ children }: { children: React.ReactNode }) => (
+      <MockView>{children}</MockView>
+    ),
+    BottomSection: ({ children }: { children: React.ReactNode }) => (
+      <MockView>{children}</MockView>
+    ),
+  },
+}));
+
+jest.mock('@/assets/icons/epassport_logo.svg', () => 'EPassportLogo');
+
+const MockCreateKycSession = createKycSession as jest.MockedFunction<
+  typeof createKycSession
+>;
+const MockLaunchKycVerification = launchKycVerification as jest.MockedFunction<
+  typeof launchKycVerification
+>;
+const MockUseFeedback = useFeedback as jest.MockedFunction<typeof useFeedback>;
+
+beforeAll(() => {
+  ({
+    setOnboardingBranch: mockSetOnboardingBranch,
+  } = require('@selfxyz/mobile-sdk-alpha'));
+  ({
+    trackOnboardingStep: mockTrackOnboardingStep,
+  } = require('@selfxyz/mobile-sdk-alpha'));
+  ({
+    failOnboardingAttempt: mockFailOnboardingAttempt,
+  } = require('@selfxyz/mobile-sdk-alpha'));
+});
+
+describe('LogoConfirmationScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    MockUseFeedback.mockReturnValue({ showModal: mockShowModal } as any);
+    MockCreateKycSession.mockResolvedValue({
+      sessionId: 'sess-1',
+      sessionToken: 'tok-1',
+    });
+  });
+
+  it('routes declined completed KYC results to KycFailure and tracks decline telemetry', async () => {
+    MockLaunchKycVerification.mockResolvedValue({
+      type: 'completed',
+      session: { status: 'Declined', sessionId: 'didit-1' },
+    });
+
+    render(<LogoConfirmationScreen />);
+
+    fireEvent.press(screen.getByText('No'));
+
+    expect(mockShowModal).toHaveBeenCalledTimes(1);
+    const modalConfig = mockShowModal.mock.calls[0]?.[0] as {
+      onButtonPress: () => Promise<void>;
+    };
+
+    await act(async () => {
+      await modalConfig.onButtonPress();
+    });
+
+    expect(mockSetOnboardingBranch).toHaveBeenCalledWith('kyc');
+    expect(mockTrackOnboardingStep).toHaveBeenCalledWith(
+      expect.objectContaining({ trackEvent: mockTrackEvent }),
+      'SCAN_STARTED',
+      { branch: 'kyc' },
+    );
+    expect(mockFailOnboardingAttempt).toHaveBeenCalledWith(
+      expect.objectContaining({ trackEvent: mockTrackEvent }),
+      'scan_started',
+      'kyc_declined:Declined',
+    );
+    expect(mockNavigate).toHaveBeenCalledWith('KycFailure', {
+      countryCode: 'US',
+      canRetry: true,
+    });
+    expect(mockNavigate).not.toHaveBeenCalledWith('KycSuccess', {
+      sessionId: 'sess-1',
+    });
+  });
+});

--- a/specs/README.md
+++ b/specs/README.md
@@ -18,7 +18,6 @@
 - **[React Native Upgrade Plan (Mobile App)](./topics/RN-UPGRADE-PLAN.md)** — staged migration plan from RN 0.77 to supported versions.
 - **[RN Upgrade Checklist](./topics/RN-UPGRADE-CHECKLIST.md)** — shared owner/status tracker for coordinating the upgrade across developers.
 
-
 ## Framework
 
 - [Templates](./framework/TEMPLATES.md) — copy-paste templates for all three tiers

--- a/specs/projects/sdk/workstreams/webview/SPEC.md
+++ b/specs/projects/sdk/workstreams/webview/SPEC.md
@@ -86,6 +86,7 @@ webview backlog.
 | WV-15 | Recovery and backup surfaces                                                                    | In Progress | Low      | WV-14               | [plans/SELF-2504-onboarding-recovery-phrase.md](./plans/SELF-2504-onboarding-recovery-phrase.md) | Active slice: add onboarding recovery phrase route after registration success, before notifications. Remaining recovery/backup surfaces still need follow-up planning.                                                                                                                                            |
 | WV-16 | Settings follow-through and support routes                                                      | Done        | Low      | WV-14               | —                                                                                                | Delivered: haptic wiring on all menu items, dev-mode mock generation fixed, Manage Documents description fixed, DevRouteMenu Settings + Tunnel groups added, settings screen tests. Deferred: notification toggle and backup-enabled persistence (requires storage design decision, not blocking UI completeness) |
 | WV-17 | Recovery phrase restore flow for WebView and tunnel account recovery                            | In Progress | High     | WV-07, WV-08        | [plans/WV-17-recovery-phrase-restore-flow.md](./plans/WV-17-recovery-phrase-restore-flow.md)     | Existing recovery screens are UI-only in webview today. This spec wires phrase-based restore, selected-document validation, and tunnel resume without importing app-only providers.                                                                                                                               |
+| WV-18 | Enable Didit liveness for Self Wallet (iOS + Android)                                           | Ready       | High     | WV-02               | [plans/WV-18-didit-liveness.md](./plans/WV-18-didit-liveness.md)                                 | Server-side enforced liveness via 3D Flash workflow + TEE. Implementation files live in `app/` (KYC launcher status branching). Attested liveness in the KYC byte layout is a separate follow-up.                                                                                                                 |
 
 Allowed statuses: `Ready`, `In Progress`, `Blocked`, `Deferred`, `Done`
 
@@ -106,6 +107,7 @@ Allowed statuses: `Ready`, `In Progress`, `Blocked`, `Deferred`, `Done`
 | [plans/WV-11-disclose-core.md](./plans/WV-11-disclose-core.md)                                   | WV-11 | Ready                                     |
 | [plans/WV-12-registration-prompts.md](./plans/WV-12-registration-prompts.md)                     | WV-12 | Ready                                     |
 | [plans/WV-17-recovery-phrase-restore-flow.md](./plans/WV-17-recovery-phrase-restore-flow.md)     | WV-17 | In Progress                               |
+| [plans/WV-18-didit-liveness.md](./plans/WV-18-didit-liveness.md)                                 | WV-18 | Ready                                     |
 
 ## Completion Checklist
 

--- a/specs/projects/sdk/workstreams/webview/plans/WV-18-didit-liveness.md
+++ b/specs/projects/sdk/workstreams/webview/plans/WV-18-didit-liveness.md
@@ -1,0 +1,129 @@
+# Didit Liveness Enablement (Self Wallet, iOS + Android)
+
+> Last updated: 2026-04-30
+> Status: Ready
+
+- Workstream: webview (KYC-provider-contract follow-up; implementation lives in `app/`)
+- Backlog IDs: WV-18
+- Owner: Mobile / KYC
+- Branch: TBD
+- PR: TBD
+
+## Why
+
+- Didit liveness is an available anti-spoofing layer (3D flash, passive, etc.) configurable per workflow at the Didit Business Console. The Self Wallet currently launches Didit verification through a workflow that does not require liveness, so spoof attempts (printed photo, replay) are not gated.
+- The `@didit-protocol/sdk-react-native` SDK has no client-side toggle for liveness — it executes whatever the workflow declares (verified against Didit docs: liveness is a workflow-level setting, not an SDK parameter). Enabling liveness for iOS + Android is therefore primarily a workflow / TEE configuration change, with one mandatory client fix to make the gate effective.
+- The mandatory client fix: `useKycLauncher.ts` does not branch on `session.status` and currently routes a Didit-`Declined` outcome (the status returned when liveness fails) to `KycSuccess`. The web path in `packages/webview-app/src/utils/kycProvider.ts` handles this correctly; the native app does not. Without this fix, turning on liveness would still let users complete registration after a failed liveness check.
+
+## Scope
+
+This spec covers **server-side enforced liveness, gate fix only**: liveness runs as part of the Didit workflow and a failed check produces a `Declined` session that the TEE refuses to attest. The verdict is not added to the KYC byte layout and is not visible to circuits. The client trusts the TEE. Failure copy stays generic — liveness-specific UX is a separate follow-up (see "Follow-ups").
+
+Specifically:
+
+1. Coordinate with the Didit Console + KYC TEE owners so that:
+   - The active workflow used by `${KYC_TEE_URL}/session` has 3D Flash liveness enabled.
+   - The TEE returns a `Declined` session status for sessions where Didit reports a liveness failure and does not produce a signed `serializedApplicantInfo` for those sessions.
+2. Fix the `Declined`-as-success bug across **all three** native call sites of `launchKycVerification` so a liveness-driven decline routes to the existing `KycFailure` screen. The web path (`packages/webview-app/src/utils/kycProvider.ts:96-119`) already handles `Declined` correctly and is not changed.
+3. Mirror the web path's status mapping: `session.status === 'Approved'` → success, `'Declined'` → `KycFailure`, anything else → `KycFailure` with `canRetry: true`.
+4. Manual test: spoof attempt (printed photo / replay video) on iOS simulator and Android emulator/device produces a `KycFailure` route from each entry point. Live attempt completes normally.
+
+## Out of Scope
+
+- **Attested / circuit-visible liveness.** Adding a liveness verdict byte to the 295-byte KYC layout in `common/src/utils/kyc/constants.ts`, threading it through `packages/webview-app/src/utils/buildKycDocument.ts`, and exposing it as a selectable field. Tracked separately as a follow-up.
+- **Liveness-specific failure UX.** The `KycFailure` route accepts only `{ countryCode?, canRetry? }` (`app/src/navigation/types.ts:173`) and `KycFailureScreen.tsx` renders fixed generic copy. Plumbing a liveness-specific message would require new route params, screen branching, copy decisions, and a `declineReason` shape that mirrors whatever Didit's RN SDK actually emits. That is a separate spec.
+- **Tightening `KycVerificationResult.session.status`.** Leaving as `string` for this PR. A discriminated union would require a real `KycKnownStatus | { kind: 'unknown'; raw: string }` shape and consumer updates; not worth the change for a gate-only fix.
+- **Bumping the Didit RN SDK or iOS/Android native pods.** `@didit-protocol/sdk-react-native@3.2.8` and `DiditSDK` 3.2.6 already execute whatever the workflow specifies. 3D Flash predates 3.2.x.
+- **Web (`webview-app`) liveness.** The web path already handles `Declined` correctly. Enabling liveness in the web flow is a Console-only change against the same workflow.
+- **Any change to `KYC_TEE_URL` configuration in `app/env.ts`.** The endpoint stays the same; the workflow it points at is what gains liveness.
+- **Selector / disclosure UX.** Liveness is not a disclosable field in this spec.
+
+## Files to Modify
+
+Three native call sites currently call `launchKycVerification` and only branch on `result.type`. All three must additionally branch on `result.session?.status === 'Declined'` and route to `KycFailure` instead of `KycSuccess`:
+
+- `app/src/hooks/useKycLauncher.ts:88-119` — primary launcher hook used by document scan/NFC trouble screens, Aadhaar, and registration fallback. After the `result.type === 'completed'` branch, route `session.status === 'Declined'` to the existing `onError` / `KycFailure` path with `canRetry: true`. Anything other than `'Approved'` also goes to `KycFailure`.
+- `app/src/providers/selfClientProvider.tsx:362` — second call site, inside the proving flow. Same status branching; the proving machine must not advance when status is not `'Approved'`.
+- `app/src/screens/documents/selection/LogoConfirmationScreen.tsx:81-111` — third call site (non-chip-document branch). Currently routes any `result.type === 'completed'` directly to `KycSuccess`. Add the `Declined` → `KycFailure` branch and call `failOnboardingAttempt(selfClient, 'scan_started', 'kyc_declined:<status>')` for telemetry parity with the existing `kyc_failed:` path.
+
+Other:
+
+- `app/src/integrations/kyc/kycService.ts:69` — no behavior change. Add a one-line code comment noting that liveness is workflow-controlled, not an SDK parameter, so future readers don't try to add a flag here.
+- `app/tests/` — Jest tests covering `useKycLauncher`, `LogoConfirmationScreen`, and the `selfClientProvider` KYC handler. Each test drives a `{ type: 'completed', session: { status: 'Declined' } }` mock and asserts the failure path (no `KycSuccess` navigation, no proving-machine advance). Honor the test-memory rules from `app/AGENTS.md` and `feedback_test_memory_oom.md`: hoisted imports, `Mock*` aliases, no nested `require('react-native')`, tests under `app/tests/`.
+- `specs/projects/sdk/workstreams/webview/SPEC.md` — already updated alongside this spec (backlog row + Active Plans row for WV-18).
+
+## Files Not to Modify
+
+- `common/src/utils/kyc/constants.ts` (byte layout — out of scope; touching this is the attested-liveness follow-up).
+- `packages/webview-app/src/utils/kycProvider.ts` and `buildKycDocument.ts` (web path; already correct for Declined).
+- `app/env.ts` and `.env*` (no new environment variables; workflow ID stays TEE-side).
+- iOS `Podfile` / `Podfile.lock` and Android `build.gradle`. No SDK or pod bump in this PR (per Decisions: 3D Flash predates 3.2.x).
+- Any KYC circuit code in `circuits/`.
+
+## Preconditions
+
+- **Didit Business Console** (out of repo, ops/product owned): the workflow that the KYC TEE creates sessions against has a liveness feature enabled with an agreed threshold.
+- **KYC TEE backend** (separate repo — confirm location with the TEE owner; not present in `selfapp`): does not produce a signed `serializedApplicantInfo` for sessions where Didit reports a failed liveness, and surfaces `Declined` status to the client. If the TEE currently passes through any Didit outcome unmodified, no change is needed beyond pointing it at the liveness-enabled workflow.
+- **Coordination order:** TEE/console change can ship before the client fix without harm (current client would still incorrectly mark a liveness-declined session as success — same as today's behavior for non-liveness declines, so no regression). The client fix can ship before the TEE/console change without harm (just no decline outcomes to handle yet). Either order is safe; recommend client-fix lands first so the gate is wired before liveness is turned on.
+
+## Decisions
+
+- **Liveness method: 3D Flash.** Self's threat model (ZK identity proofs tied to a real human) demands the strongest available anti-spoof; passive single-image is insufficient against video replay. Configured on the Didit Console; no client impact.
+- **Threshold: Didit default.** Tune later from telemetry; do not block this PR on a number.
+- **Fix all three native call sites identically.** Hook + proving provider + LogoConfirmationScreen. Centralizing this in a shared helper is tempting but out of scope — three small symmetric edits is less risky than introducing a new abstraction in this PR.
+- **Generic failure copy.** Do not change `KycFailureScreen` or its route params. Liveness-specific UX is a separate spec.
+- **Do not bump the Didit RN SDK or iOS pod.** 3D Flash predates 3.2.x.
+
+## Implementation Steps
+
+1. Update `app/src/hooks/useKycLauncher.ts` to branch on `result.session?.status` after `result.type === 'completed'`. Mirror `packages/webview-app/src/utils/kycProvider.ts:96-119`: `'Approved'` → success path, anything else → existing failure path (`onError` if provided, otherwise `navigation.navigate('KycFailure', { countryCode, canRetry: true })`).
+2. Apply the same branching in `app/src/providers/selfClientProvider.tsx:362`.
+3. Apply the same branching in `app/src/screens/documents/selection/LogoConfirmationScreen.tsx:107-111`. Add `failOnboardingAttempt(selfClient, 'scan_started', 'kyc_declined:<status>')` on the new non-Approved branch for telemetry symmetry with the existing `kyc_failed:` path.
+4. Add the one-line comment to `app/src/integrations/kyc/kycService.ts:69` noting workflow-controlled liveness.
+5. Add Jest tests per "Files to Modify".
+6. Manual test on iOS simulator + Android emulator against a TEE staging env pointed at a 3D Flash-enabled workflow, exercising **all three entry points**:
+   - Hook entry: e.g. `DocumentCameraTroubleScreen` → "Try Alternative Verification".
+   - Proving entry: registration through `selfClientProvider`.
+   - Logo confirmation entry: non-chip document selection → "Proceed with an external verifier".
+   - For each: spoof (printed photo) → `KycFailure`; live capture → `KycSuccess`; cancellation → existing cancel path.
+7. Coordinate ship order with the TEE/Console owner per "Preconditions".
+
+## Validation
+
+```bash
+# From repo root
+yarn lint && yarn types
+
+# From app/
+cd app && yarn test --testPathPattern='(useKycLauncher|LogoConfirmation|selfClientProvider)'
+node scripts/check-test-requires.cjs
+
+# Build sanity (per app/AGENTS.md Pre-PR Checklist)
+yarn ios     # iOS simulator builds
+yarn android # Android emulator builds
+```
+
+Expected:
+
+- New tests pass; no Declined-as-success regressions in existing tests.
+- iOS and Android builds succeed; no native-pod changes.
+- Manual liveness spoof on staging produces a `KycFailure` route from each of the three entry points on both platforms.
+
+## Definition of Done
+
+- [ ] `useKycLauncher.ts`, `selfClientProvider.tsx:362`, and `LogoConfirmationScreen.tsx` all branch on `session.status` and route non-`Approved` outcomes to the existing `KycFailure` path.
+- [ ] Jest tests cover the `Declined` → failure routing for each of the three call sites.
+- [ ] `webview/SPEC.md` backlog and Active Plans tables include WV-18 (already done alongside this spec).
+- [ ] Manual spoof + live test from each of the three entry points on iOS and Android against a 3D Flash-enabled staging workflow, recorded in the PR description.
+- [ ] PR targets `dev`, well under the 1k–3k LOC target.
+
+## Follow-ups (separate specs, not this PR)
+
+- **Attested liveness in the KYC byte layout.** Add 1–2 bytes for liveness verdict + threshold in `common/src/utils/kyc/constants.ts`, update `KYC_REVEAL_DATA_INDICES`, `KYC_SELECTOR_BITS`, parsers in `webview-app/src/utils/buildKycDocument.ts`, the corresponding KYC circuit, and any selector UI. Coordinate a TEE serializer bump in lockstep. Circuit-visible change; requires a backwards-compatibility plan for already-issued KYC documents.
+- **Liveness-specific failure UX.** Extend `KycFailure` route params with a `declineReason` shape, branch the screen copy, and plumb the reason from the RN SDK callback. Depends on confirming Didit's actual decline payload shape.
+- **Centralized status mapping.** Once the three call sites stabilize, extract the `result.type` + `session.status` mapping to a single helper in `app/src/integrations/kyc/`. Skipped here to keep the PR diff minimal.
+- **Liveness telemetry.** Analytics event from the failure branches if product wants visibility into liveness failure rates.
+
+## Status Log
+
+- 2026-04-30: Created. Decision: server-side enforcement only; attested liveness, liveness-specific UX, and helper extraction all deferred. Identified the `Declined`-as-success bug across three call sites (`useKycLauncher.ts`, `selfClientProvider.tsx:362`, `LogoConfirmationScreen.tsx:81-111`) as the precondition for an effective liveness gate.

--- a/specs/topics/RN-UPGRADE-CHECKLIST.md
+++ b/specs/topics/RN-UPGRADE-CHECKLIST.md
@@ -21,12 +21,12 @@ Use this file as the working state tracker for the React Native upgrade. The nar
 
 ## Track Owners
 
-| Track | Primary | Backup | Scope |
-|---|---|---|---|
+| Track                 | Primary       | Backup        | Scope                                                      |
+| --------------------- | ------------- | ------------- | ---------------------------------------------------------- |
 | JS + package versions | `@unassigned` | `@unassigned` | RN core versions, JS toolchain, Metro/Babel/Jest, lockfile |
-| iOS native | `@unassigned` | `@unassigned` | Pods, Podfile, Xcode settings, iOS build/runtime |
-| Android native | `@unassigned` | `@unassigned` | Gradle, Kotlin/AGP, Android build/runtime |
-| Runtime validation | `@unassigned` | `@unassigned` | Critical flows, smoke tests, rollout decisions |
+| iOS native            | `@unassigned` | `@unassigned` | Pods, Podfile, Xcode settings, iOS build/runtime           |
+| Android native        | `@unassigned` | `@unassigned` | Gradle, Kotlin/AGP, Android build/runtime                  |
+| Runtime validation    | `@unassigned` | `@unassigned` | Critical flows, smoke tests, rollout decisions             |
 
 ## Global Gates
 
@@ -43,53 +43,53 @@ Use this file as the working state tracker for the React Native upgrade. The nar
 
 ### Core RN and companion packages
 
-| Item | Current | Target `0.84.x` | Target `0.85.x` | Owner | Backup | Status | Last Validation | Last Note |
-|---|---|---|---|---|---|---|---|---|
-| `react-native` | `0.77.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Core runtime |
-| `@react-native/babel-preset` | `0.77.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Must stay aligned with RN |
-| `@react-native/eslint-config` | `0.77.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Must stay aligned with RN |
-| `@react-native/gradle-plugin` | `0.77.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Android track dependency |
-| `@react-native/metro-config` | `0.77.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Metro config drift risk |
-| `@react-native/typescript-config` | `0.77.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | TS config alignment |
-| `@react-native-community/cli` | `^16.0.3` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Verify version expectations per RN line |
+| Item                              | Current   | Target `0.84.x` | Target `0.85.x` | Owner         | Backup        | Status        | Last Validation | Last Note                               |
+| --------------------------------- | --------- | --------------- | --------------- | ------------- | ------------- | ------------- | --------------- | --------------------------------------- |
+| `react-native`                    | `0.77.0`  | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Core runtime                            |
+| `@react-native/babel-preset`      | `0.77.0`  | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Must stay aligned with RN               |
+| `@react-native/eslint-config`     | `0.77.0`  | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Must stay aligned with RN               |
+| `@react-native/gradle-plugin`     | `0.77.0`  | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Android track dependency                |
+| `@react-native/metro-config`      | `0.77.0`  | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Metro config drift risk                 |
+| `@react-native/typescript-config` | `0.77.0`  | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | TS config alignment                     |
+| `@react-native-community/cli`     | `^16.0.3` | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Verify version expectations per RN line |
 
 ### Expo alignment
 
-| Item | Current | Target `0.84.x` | Target `0.85.x` | Owner | Backup | Status | Last Validation | Last Note |
-|---|---|---|---|---|---|---|---|---|
-| `expo` | `~52.0.40` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Must follow Expo/RN support matrix |
-| `expo-application` | `~6.0.2` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Keep aligned with Expo SDK |
-| `expo-camera` | `~16.0.18` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Camera is critical flow |
+| Item               | Current    | Target `0.84.x` | Target `0.85.x` | Owner         | Backup        | Status        | Last Validation | Last Note                          |
+| ------------------ | ---------- | --------------- | --------------- | ------------- | ------------- | ------------- | --------------- | ---------------------------------- |
+| `expo`             | `~52.0.40` | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Must follow Expo/RN support matrix |
+| `expo-application` | `~6.0.2`   | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Keep aligned with Expo SDK         |
+| `expo-camera`      | `~16.0.18` | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Camera is critical flow            |
 
 ### Critical native dependencies
 
-| Item | Current | Target `0.84.x` | Target `0.85.x` | Owner | Backup | Status | Last Validation | Last Note |
-|---|---|---|---|---|---|---|---|---|
-| `react-native-webview` | `13.16.1` app / `13.16.0` override | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Resolve override mismatch explicitly |
-| `react-native-gesture-handler` | `~2.22.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Navigation/input critical |
-| `react-native-screens` | `4.15.3` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Navigation stack dependency |
-| `react-native-safe-area-context` | `^5.7.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Common runtime dependency |
-| `react-native-svg` | `15.14.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Rendering dependency |
-| `react-native-permissions` | `^4.1.5` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Critical OS prompt flow |
-| `react-native-keychain` | `^10.0.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Security boundary |
-| `react-native-biometrics` | `^3.0.1` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Auth critical path |
-| `react-native-nfc-manager` | `3.17.2` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Passport scan path |
-| `react-native-passport-reader` | `1.0.3` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Passport scan path |
-| `@react-native-firebase/app` | `^21.14.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Firebase base |
-| `@react-native-firebase/analytics` | `^21.14.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Analytics boot path |
-| `@react-native-firebase/messaging` | `^21.14.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Push init critical |
-| `@react-native-firebase/remote-config` | `^21.14.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Startup/config critical |
-| `@invertase/react-native-apple-authentication` | `^2.5.1` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | iOS auth dependency |
-| `@react-native-google-signin/google-signin` | `^16.1.2` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Auth dependency |
-| `react-native-app-auth` | `^8.1.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Auth dependency |
+| Item                                           | Current                            | Target `0.84.x` | Target `0.85.x` | Owner         | Backup        | Status        | Last Validation | Last Note                            |
+| ---------------------------------------------- | ---------------------------------- | --------------- | --------------- | ------------- | ------------- | ------------- | --------------- | ------------------------------------ |
+| `react-native-webview`                         | `13.16.1` app / `13.16.0` override | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Resolve override mismatch explicitly |
+| `react-native-gesture-handler`                 | `~2.22.0`                          | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Navigation/input critical            |
+| `react-native-screens`                         | `4.15.3`                           | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Navigation stack dependency          |
+| `react-native-safe-area-context`               | `^5.7.0`                           | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Common runtime dependency            |
+| `react-native-svg`                             | `15.14.0`                          | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Rendering dependency                 |
+| `react-native-permissions`                     | `^4.1.5`                           | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Critical OS prompt flow              |
+| `react-native-keychain`                        | `^10.0.0`                          | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Security boundary                    |
+| `react-native-biometrics`                      | `^3.0.1`                           | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Auth critical path                   |
+| `react-native-nfc-manager`                     | `3.17.2`                           | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Passport scan path                   |
+| `react-native-passport-reader`                 | `1.0.3`                            | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Passport scan path                   |
+| `@react-native-firebase/app`                   | `^21.14.0`                         | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Firebase base                        |
+| `@react-native-firebase/analytics`             | `^21.14.0`                         | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Analytics boot path                  |
+| `@react-native-firebase/messaging`             | `^21.14.0`                         | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Push init critical                   |
+| `@react-native-firebase/remote-config`         | `^21.14.0`                         | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Startup/config critical              |
+| `@invertase/react-native-apple-authentication` | `^2.5.1`                           | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | iOS auth dependency                  |
+| `@react-native-google-signin/google-signin`    | `^16.1.2`                          | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Auth dependency                      |
+| `react-native-app-auth`                        | `^8.1.0`                           | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Auth dependency                      |
 
 ### Monorepo alignment checks
 
-| Item | Current | Target `0.84.x` | Target `0.85.x` | Owner | Backup | Status | Last Validation | Last Note |
-|---|---|---|---|---|---|---|---|---|
-| Root `react-native` dependency | `0.76.9` | `TBD / keep or align` | `TBD / keep or align` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Only change if it blocks app build/test integrity |
-| Root `react` resolution | `^18.3.1` | `Verify` | `Verify` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Confirm RN target compatibility |
-| Root `react-native-webview` resolution | `13.16.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Must match app decision |
+| Item                                   | Current   | Target `0.84.x`       | Target `0.85.x`       | Owner         | Backup        | Status        | Last Validation | Last Note                                         |
+| -------------------------------------- | --------- | --------------------- | --------------------- | ------------- | ------------- | ------------- | --------------- | ------------------------------------------------- |
+| Root `react-native` dependency         | `0.76.9`  | `TBD / keep or align` | `TBD / keep or align` | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Only change if it blocks app build/test integrity |
+| Root `react` resolution                | `^18.3.1` | `Verify`              | `Verify`              | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Confirm RN target compatibility                   |
+| Root `react-native-webview` resolution | `13.16.0` | `TBD`                 | `TBD`                 | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Must match app decision                           |
 
 ## Work Breakdown Checklist
 
@@ -133,8 +133,8 @@ Use this file as the working state tracker for the React Native upgrade. The nar
 
 ## Validation Log
 
-| Date | Owner | Command / Check | Result | Notes |
-|---|---|---|---|---|
+| Date         | Owner   | Command / Check                           | Result      | Notes        |
+| ------------ | ------- | ----------------------------------------- | ----------- | ------------ |
 | `YYYY-MM-DD` | `@name` | `yarn workspace @selfxyz/mobile-app test` | `Pass/Fail` | `Short note` |
 
 ## Open Questions


### PR DESCRIPTION
## Summary

- Server-side enabling of Didit liveness (3D Flash) is a workflow change on the Didit Business Console, not a code change. This PR fixes the client-side gap that would otherwise let a `Declined` (e.g. liveness-failed) session route to `KycSuccess`.
- Adds a `session.status === 'Approved'` gate at the three native `launchKycVerification` call sites. Non-Approved outcomes route to `KycFailure` with `canRetry: true`, matching the existing web path in `packages/webview-app/src/utils/kycProvider.ts`.
- Adds Jest coverage for each call site and an execution spec under `specs/projects/sdk/workstreams/webview/`.

## Changes

### React Native app

- `app/src/hooks/useKycLauncher.ts` — branch on `result.session?.status` after `type === 'completed'`; non-Approved goes through `onError` or navigates to `KycFailure`.
- `app/src/providers/selfClientProvider.tsx` — same status branching inside the proving flow so a non-Approved session does not advance.
- `app/src/screens/documents/selection/LogoConfirmationScreen.tsx` — same status branching plus `failOnboardingAttempt('kyc_declined:<status>')` for telemetry parity with the existing `kyc_failed:` path.
- `app/src/integrations/kyc/kycService.ts` — one-line comment noting liveness is workflow-controlled and should not be added as an SDK flag.

### Tests

- `app/tests/src/hooks/useKycLauncher.test.ts` (new) — Approved/Declined/In Review/missing-session cases plus `onError` forwarding and `type:failed` routing.
- `app/tests/src/screens/documents/selection/LogoConfirmationScreen.test.tsx` (new) — Declined → `KycFailure` and telemetry assertions.
- `app/tests/src/providers/selfClientProvider.test.tsx` — adds Declined → `KycFailure`/no-advance test for the proving flow.

### Docs/specs

- `specs/projects/sdk/workstreams/webview/plans/WV-18-didit-liveness.md` (new) — execution spec for this change.
- `specs/projects/sdk/workstreams/webview/SPEC.md` — backlog and Active Plans rows for WV-18.
- `specs/README.md`, `specs/topics/RN-UPGRADE-CHECKLIST.md` — formatting-only touchups carried over from \`eb43745ce\`.

## Linear Issues

- Closes [SELF-2748](https://linear.app/selfprotocol/issue/SELF-2748/switch-to-didit-active-liveliness) — Switch to Didit active liveliness

## Test Plan

- [ ] \`yarn lint && yarn types\` passes
- [ ] \`cd app && yarn test --testPathPattern='(useKycLauncher|LogoConfirmation|selfClientProvider)'\` passes
- [ ] \`node app/scripts/check-test-requires.cjs\` passes
- [ ] iOS simulator and Android emulator builds succeed
- [ ] Manual: spoof attempt (printed photo / replay) on a 3D Flash-enabled staging workflow routes to \`KycFailure\` from each of the three entry points (DocumentCameraTrouble → "Try Alternative Verification", proving flow via \`selfClientProvider\`, LogoConfirmation → "Proceed with an external verifier"). Live capture completes normally.

### Native Consolidation Checklist

- [ ] CONTRACTS.md reviewed - no unintended contract changes
- [ ] Layer 1 bridge contract tests pass (\`cd app && yarn jest:run\` / \`yarn workspace @selfxyz/rn-sdk-test-app test\`)
- [ ] Layer 3 builds pass (app iOS, RN test app iOS, RN test app Android)
- [ ] Layer 4 manual smoke test signed off (if consolidation PR)
- [ ] No new native business logic added (logic belongs in TypeScript)

🤖 Generated with [Claude Code](https://claude.com/claude-code)