### PR TITLE
add Linear initiative status update skill

### DIFF
--- a/.claude/skills/linear-initiative-update/SKILL.md
+++ b/.claude/skills/linear-initiative-update/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: linear-initiative-update
+description: Draft and post a status update for a Linear initiative you own. Pulls the last status update plus recent issue activity across the initiative's projects, drafts a brief informative update, and posts it after confirmation.
+disable-model-invocation: false
+user-invocable: true
+argument-hint: '[initiative name or ID]'
+---
+
+# Post a Linear Initiative Status Update
+
+You help the user post a status update for a Linear initiative they own. The output should be informative but brief, focused on what changed since the last update.
+
+## Input
+
+`$ARGUMENTS` — Optional initiative name or ID. If omitted, list the user's owned initiatives and ask which one.
+
+## Workflow
+
+### Step 1: Pick the Initiative
+
+If `$ARGUMENTS` is provided, resolve it via `mcp__linear-server__get_initiative` (pass `includeProjects: true`).
+
+If omitted, call `mcp__linear-server__list_initiatives` with `owner: "me"`. Filter to `status: "Active"` initiatives. If more than one, list them with current health and ask which to update. If exactly one, use it directly.
+
+### Step 2: Gather Context
+
+Do this in two passes — fetch the last updates first, then size the issue-activity window from them.
+
+**Pass A — Last status updates.** Call `mcp__linear-server__get_status_updates` with `type: "initiative"`, the initiative ID, and `limit: 3`. The most recent update's `createdAt` is the cutoff for "what's new."
+
+**Pass B — Recent issue activity per project.** Compute the window from the most recent update's `createdAt`:
+
+- Take `(today - createdAt)` rounded up to the next whole day, then add a 2-day buffer to catch issues that were in flight at the time of the previous update.
+- Format as an ISO-8601 duration: `-P<N>D` for days, `-P<N>W` for whole weeks. Example: last update 13 days ago → use `-P15D`.
+- If there is no previous update, default to `-P4W`.
+
+For each project on the initiative, call `mcp__linear-server__list_issues` with `project: <id>` and `updatedAt: <computed window>`. Filter results to issues whose `completedAt`, `canceledAt`, or `startedAt` falls strictly after the previous update's `createdAt` — earlier activity is already covered by that update.
+
+If the initiative has no projects or no recent activity, ask the user whether to post a "nothing to report" update or skip.
+
+**Closed PRs (optional).** If the user asks about PRs, or if the issues found reference PR numbers, run `gh pr list --state merged --search "merged:>=<YYYY-MM-DD>" --limit 50 --json number,title,mergedAt,url` using the previous update's date. Cross-reference with the issues to enrich the draft (e.g., "shipped: account transfer prototype, Belgian ID fix"). Do not include PR numbers in the draft body.
+
+### Step 3: Draft the Update
+
+Compose a short body (2–4 sentences typical, up to ~6 for big events). Rules:
+
+- **No ticket numbers** in the body unless the user explicitly asks. Reference work by what it accomplished, not by ID.
+- **Lead with the most important event** since the last update (incident response, milestone hit, blocker, scope change).
+- **Group small wins** rather than listing each issue.
+- **Mention follow-ups still in progress** so the reader knows what's next.
+- **Reference prior context** ("since the January follow-ups", "since last update") instead of repeating it.
+- Avoid back-patting or filler. Signal over praise.
+
+Pick a health value:
+
+- `onTrack` — work is progressing as expected
+- `atRisk` — meaningful blocker, slipping target, or unresolved issue
+- `offTrack` — target missed or major issue unresolved
+
+If the user has not given a signal, default to the previous update's health and ask in Step 4 whether to change it.
+
+### Step 4: Confirm
+
+Show the user:
+
+- The drafted body
+- The proposed health
+- Note when the previous update was posted
+
+Ask if they want to post as-is, tweak, or change the health. Iterate until they approve.
+
+### Step 5: Post
+
+Call `mcp__linear-server__save_status_update` with:
+
+- `type: "initiative"`
+- `initiative: <id>`
+- `health: <chosen>`
+- `body: <approved draft>`
+
+Return the URL of the posted update.
+
+## Multi-Initiative Mode
+
+If the user asks to update multiple initiatives in one session, do them **one at a time** — draft, confirm, post for each before moving to the next. Do not batch-draft all of them up front; context from one update can shift the framing of the next.
+
+## Important Notes
+
+- Never post without explicit confirmation.
+- Initiative summaries and descriptions are durable context, not status — do not edit them as part of an update.
+- If the initiative has no recent activity and no external news, ask the user what to write rather than inventing content.
+- Convert relative dates ("last week") to absolute dates when referencing them in the update body.

--- a/specs/README.md
+++ b/specs/README.md
@@ -18,7 +18,6 @@
 - **[React Native Upgrade Plan (Mobile App)](./topics/RN-UPGRADE-PLAN.md)** — staged migration plan from RN 0.77 to supported versions.
 - **[RN Upgrade Checklist](./topics/RN-UPGRADE-CHECKLIST.md)** — shared owner/status tracker for coordinating the upgrade across developers.
 
-
 ## Framework
 
 - [Templates](./framework/TEMPLATES.md) — copy-paste templates for all three tiers

--- a/specs/topics/RN-UPGRADE-CHECKLIST.md
+++ b/specs/topics/RN-UPGRADE-CHECKLIST.md
@@ -21,12 +21,12 @@ Use this file as the working state tracker for the React Native upgrade. The nar
 
 ## Track Owners
 
-| Track | Primary | Backup | Scope |
-|---|---|---|---|
+| Track                 | Primary       | Backup        | Scope                                                      |
+| --------------------- | ------------- | ------------- | ---------------------------------------------------------- |
 | JS + package versions | `@unassigned` | `@unassigned` | RN core versions, JS toolchain, Metro/Babel/Jest, lockfile |
-| iOS native | `@unassigned` | `@unassigned` | Pods, Podfile, Xcode settings, iOS build/runtime |
-| Android native | `@unassigned` | `@unassigned` | Gradle, Kotlin/AGP, Android build/runtime |
-| Runtime validation | `@unassigned` | `@unassigned` | Critical flows, smoke tests, rollout decisions |
+| iOS native            | `@unassigned` | `@unassigned` | Pods, Podfile, Xcode settings, iOS build/runtime           |
+| Android native        | `@unassigned` | `@unassigned` | Gradle, Kotlin/AGP, Android build/runtime                  |
+| Runtime validation    | `@unassigned` | `@unassigned` | Critical flows, smoke tests, rollout decisions             |
 
 ## Global Gates
 
@@ -43,53 +43,53 @@ Use this file as the working state tracker for the React Native upgrade. The nar
 
 ### Core RN and companion packages
 
-| Item | Current | Target `0.84.x` | Target `0.85.x` | Owner | Backup | Status | Last Validation | Last Note |
-|---|---|---|---|---|---|---|---|---|
-| `react-native` | `0.77.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Core runtime |
-| `@react-native/babel-preset` | `0.77.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Must stay aligned with RN |
-| `@react-native/eslint-config` | `0.77.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Must stay aligned with RN |
-| `@react-native/gradle-plugin` | `0.77.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Android track dependency |
-| `@react-native/metro-config` | `0.77.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Metro config drift risk |
-| `@react-native/typescript-config` | `0.77.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | TS config alignment |
-| `@react-native-community/cli` | `^16.0.3` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Verify version expectations per RN line |
+| Item                              | Current   | Target `0.84.x` | Target `0.85.x` | Owner         | Backup        | Status        | Last Validation | Last Note                               |
+| --------------------------------- | --------- | --------------- | --------------- | ------------- | ------------- | ------------- | --------------- | --------------------------------------- |
+| `react-native`                    | `0.77.0`  | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Core runtime                            |
+| `@react-native/babel-preset`      | `0.77.0`  | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Must stay aligned with RN               |
+| `@react-native/eslint-config`     | `0.77.0`  | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Must stay aligned with RN               |
+| `@react-native/gradle-plugin`     | `0.77.0`  | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Android track dependency                |
+| `@react-native/metro-config`      | `0.77.0`  | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Metro config drift risk                 |
+| `@react-native/typescript-config` | `0.77.0`  | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | TS config alignment                     |
+| `@react-native-community/cli`     | `^16.0.3` | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Verify version expectations per RN line |
 
 ### Expo alignment
 
-| Item | Current | Target `0.84.x` | Target `0.85.x` | Owner | Backup | Status | Last Validation | Last Note |
-|---|---|---|---|---|---|---|---|---|
-| `expo` | `~52.0.40` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Must follow Expo/RN support matrix |
-| `expo-application` | `~6.0.2` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Keep aligned with Expo SDK |
-| `expo-camera` | `~16.0.18` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Camera is critical flow |
+| Item               | Current    | Target `0.84.x` | Target `0.85.x` | Owner         | Backup        | Status        | Last Validation | Last Note                          |
+| ------------------ | ---------- | --------------- | --------------- | ------------- | ------------- | ------------- | --------------- | ---------------------------------- |
+| `expo`             | `~52.0.40` | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Must follow Expo/RN support matrix |
+| `expo-application` | `~6.0.2`   | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Keep aligned with Expo SDK         |
+| `expo-camera`      | `~16.0.18` | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Camera is critical flow            |
 
 ### Critical native dependencies
 
-| Item | Current | Target `0.84.x` | Target `0.85.x` | Owner | Backup | Status | Last Validation | Last Note |
-|---|---|---|---|---|---|---|---|---|
-| `react-native-webview` | `13.16.1` app / `13.16.0` override | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Resolve override mismatch explicitly |
-| `react-native-gesture-handler` | `~2.22.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Navigation/input critical |
-| `react-native-screens` | `4.15.3` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Navigation stack dependency |
-| `react-native-safe-area-context` | `^5.7.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Common runtime dependency |
-| `react-native-svg` | `15.14.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Rendering dependency |
-| `react-native-permissions` | `^4.1.5` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Critical OS prompt flow |
-| `react-native-keychain` | `^10.0.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Security boundary |
-| `react-native-biometrics` | `^3.0.1` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Auth critical path |
-| `react-native-nfc-manager` | `3.17.2` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Passport scan path |
-| `react-native-passport-reader` | `1.0.3` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Passport scan path |
-| `@react-native-firebase/app` | `^21.14.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Firebase base |
-| `@react-native-firebase/analytics` | `^21.14.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Analytics boot path |
-| `@react-native-firebase/messaging` | `^21.14.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Push init critical |
-| `@react-native-firebase/remote-config` | `^21.14.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Startup/config critical |
-| `@invertase/react-native-apple-authentication` | `^2.5.1` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | iOS auth dependency |
-| `@react-native-google-signin/google-signin` | `^16.1.2` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Auth dependency |
-| `react-native-app-auth` | `^8.1.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Auth dependency |
+| Item                                           | Current                            | Target `0.84.x` | Target `0.85.x` | Owner         | Backup        | Status        | Last Validation | Last Note                            |
+| ---------------------------------------------- | ---------------------------------- | --------------- | --------------- | ------------- | ------------- | ------------- | --------------- | ------------------------------------ |
+| `react-native-webview`                         | `13.16.1` app / `13.16.0` override | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Resolve override mismatch explicitly |
+| `react-native-gesture-handler`                 | `~2.22.0`                          | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Navigation/input critical            |
+| `react-native-screens`                         | `4.15.3`                           | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Navigation stack dependency          |
+| `react-native-safe-area-context`               | `^5.7.0`                           | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Common runtime dependency            |
+| `react-native-svg`                             | `15.14.0`                          | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Rendering dependency                 |
+| `react-native-permissions`                     | `^4.1.5`                           | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Critical OS prompt flow              |
+| `react-native-keychain`                        | `^10.0.0`                          | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Security boundary                    |
+| `react-native-biometrics`                      | `^3.0.1`                           | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Auth critical path                   |
+| `react-native-nfc-manager`                     | `3.17.2`                           | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Passport scan path                   |
+| `react-native-passport-reader`                 | `1.0.3`                            | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Passport scan path                   |
+| `@react-native-firebase/app`                   | `^21.14.0`                         | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Firebase base                        |
+| `@react-native-firebase/analytics`             | `^21.14.0`                         | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Analytics boot path                  |
+| `@react-native-firebase/messaging`             | `^21.14.0`                         | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Push init critical                   |
+| `@react-native-firebase/remote-config`         | `^21.14.0`                         | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Startup/config critical              |
+| `@invertase/react-native-apple-authentication` | `^2.5.1`                           | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | iOS auth dependency                  |
+| `@react-native-google-signin/google-signin`    | `^16.1.2`                          | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Auth dependency                      |
+| `react-native-app-auth`                        | `^8.1.0`                           | `TBD`           | `TBD`           | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Auth dependency                      |
 
 ### Monorepo alignment checks
 
-| Item | Current | Target `0.84.x` | Target `0.85.x` | Owner | Backup | Status | Last Validation | Last Note |
-|---|---|---|---|---|---|---|---|---|
-| Root `react-native` dependency | `0.76.9` | `TBD / keep or align` | `TBD / keep or align` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Only change if it blocks app build/test integrity |
-| Root `react` resolution | `^18.3.1` | `Verify` | `Verify` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Confirm RN target compatibility |
-| Root `react-native-webview` resolution | `13.16.0` | `TBD` | `TBD` | `@unassigned` | `@unassigned` | `Not Started` | `None` | Must match app decision |
+| Item                                   | Current   | Target `0.84.x`       | Target `0.85.x`       | Owner         | Backup        | Status        | Last Validation | Last Note                                         |
+| -------------------------------------- | --------- | --------------------- | --------------------- | ------------- | ------------- | ------------- | --------------- | ------------------------------------------------- |
+| Root `react-native` dependency         | `0.76.9`  | `TBD / keep or align` | `TBD / keep or align` | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Only change if it blocks app build/test integrity |
+| Root `react` resolution                | `^18.3.1` | `Verify`              | `Verify`              | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Confirm RN target compatibility                   |
+| Root `react-native-webview` resolution | `13.16.0` | `TBD`                 | `TBD`                 | `@unassigned` | `@unassigned` | `Not Started` | `None`          | Must match app decision                           |
 
 ## Work Breakdown Checklist
 
@@ -133,8 +133,8 @@ Use this file as the working state tracker for the React Native upgrade. The nar
 
 ## Validation Log
 
-| Date | Owner | Command / Check | Result | Notes |
-|---|---|---|---|---|
+| Date         | Owner   | Command / Check                           | Result      | Notes        |
+| ------------ | ------- | ----------------------------------------- | ----------- | ------------ |
 | `YYYY-MM-DD` | `@name` | `yarn workspace @selfxyz/mobile-app test` | `Pass/Fail` | `Short note` |
 
 ## Open Questions


### PR DESCRIPTION
## Summary

- Adds a new Claude Code skill at `.claude/skills/linear-initiative-update/` that drafts and posts Linear initiative status updates.
- Skill pulls the last status update + recent issue activity (window sized from the last update's date with a 2-day buffer) and an optional list of merged PRs, then drafts a brief, ticket-number-free body for confirmation before posting.
- Supports a multi-initiative mode that walks through updates one at a time rather than batch-drafting.

## Changes

### Docs/specs

- Add `linear-initiative-update` skill (`SKILL.md`).
- Incidental whitespace-only formatting of `specs/README.md` and `specs/topics/RN-UPGRADE-CHECKLIST.md` (table column padding, no content changes).

## Test Plan

- [ ] Invoke `/linear-initiative-update` with no args and confirm it lists owned active initiatives.
- [ ] Invoke `/linear-initiative-update <name>` and confirm it pulls the right window of issue activity.
- [ ] Confirm draft is shown and update is only posted after explicit confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)