### PR TITLE
fix: remove darkmode from QR rendering

### DIFF
--- a/sdk/qrcode/README.md
+++ b/sdk/qrcode/README.md
@@ -62,7 +62,7 @@ function MyComponent() {
         console.log('Verification successful');
         // Perform actions after successful verification
       }}
-      darkMode={false} // Optional: set to true for dark mode
+      darkMode={false} // Optional: set to true for dark-themed wrapper styling
       size={300} // Optional: customize QR code size (default: 300)
     />
   );
@@ -111,7 +111,7 @@ The `SelfQRcodeWrapper` component accepts the following props:
 | `onSuccess`    | () => void      | Yes      | -             | Callback function executed on successful verification |
 | `websocketUrl` | string          | No       | WS_DB_RELAYER | Custom WebSocket URL for verification                 |
 | `size`         | number          | No       | 300           | QR code size in pixels                                |
-| `darkMode`     | boolean         | No       | false         | Enable dark mode styling                              |
+| `darkMode`     | boolean         | No       | false         | Enable dark-themed wrapper styling                    |
 | `children`     | React.ReactNode | No       | -             | Custom children to render                             |
 
 ## Complete Example

--- a/sdk/qrcode/components/DesktopQRcode.tsx
+++ b/sdk/qrcode/components/DesktopQRcode.tsx
@@ -10,22 +10,19 @@ interface DesktopQRcodeProps {
   proofStep: number;
   qrValue: string;
   size: number;
-  darkMode: boolean;
   selfApp: SelfApp;
 }
 
-const DesktopQRcode = memo(
-  ({ proofStep, qrValue, size, darkMode, selfApp }: DesktopQRcodeProps) => (
-    <div style={desktopCardStyle()} role="img" aria-label="Self authentication QR code">
-      <DesktopHeader appName={selfApp.appName} appLogo={selfApp.logoBase64} />
-      <div style={desktopQrSectionStyle()}>
-        <div style={desktopQrWrapperStyle(proofStep)}>
-          <QRCode value={qrValue} size={size} darkMode={darkMode} proofStep={proofStep} />
-        </div>
+const DesktopQRcode = memo(({ proofStep, qrValue, size, selfApp }: DesktopQRcodeProps) => (
+  <div style={desktopCardStyle()} role="img" aria-label="Self authentication QR code">
+    <DesktopHeader appName={selfApp.appName} appLogo={selfApp.logoBase64} />
+    <div style={desktopQrSectionStyle()}>
+      <div style={desktopQrWrapperStyle(proofStep)}>
+        <QRCode value={qrValue} size={size} proofStep={proofStep} />
       </div>
-      <DesktopFooter proofStep={proofStep} />
     </div>
-  )
-);
+    <DesktopFooter proofStep={proofStep} />
+  </div>
+));
 
 export default DesktopQRcode;

--- a/sdk/qrcode/components/QRCode.tsx
+++ b/sdk/qrcode/components/QRCode.tsx
@@ -11,11 +11,10 @@ const QR_IMAGE_SIZE_RATIO = 0.32;
 interface QRCodeProps {
   value: string;
   size: number;
-  darkMode: boolean;
   proofStep: number;
 }
 
-const QRCode = memo(({ value, size, darkMode, proofStep }: QRCodeProps) => {
+const QRCode = memo(({ value, size, proofStep }: QRCodeProps) => {
   const isInitialState =
     proofStep === QRcodeSteps.DISCONNECTED || proofStep === QRcodeSteps.WAITING_FOR_MOBILE;
 
@@ -27,8 +26,11 @@ const QRCode = memo(({ value, size, darkMode, proofStep }: QRCodeProps) => {
   const showAnimation = !isInitialState;
 
   const statusIcon = getStatusIcon(proofStep);
-  const bgColor = darkMode ? '#000000' : '#ffffff';
-  const fgColor = darkMode ? '#ffffff' : '#000000';
+  // Keep the QR itself in the standard high-contrast black-on-white format.
+  // The surrounding wrapper handles dark mode styling, but the QR pattern
+  // stays scan-friendly across readers that struggle with inverted codes.
+  const bgColor = '#ffffff';
+  const fgColor = '#000000';
   const imageSize = size * QR_IMAGE_SIZE_RATIO;
 
   return (

--- a/sdk/qrcode/components/SelfQRcode.tsx
+++ b/sdk/qrcode/components/SelfQRcode.tsx
@@ -122,11 +122,11 @@ const SelfQRcode = ({
 
   return (
     <div
-      style={qrWrapperStyle(proofStep, showBorder)}
+      style={qrWrapperStyle(proofStep, showBorder, darkMode)}
       role="img"
       aria-label="Self authentication QR code"
     >
-      <QRCode value={qrValue} size={size} darkMode={darkMode} proofStep={proofStep} />
+      <QRCode value={qrValue} size={size} proofStep={proofStep} />
       {showStatusText && <StatusBanner proofStep={proofStep} qrSize={size} />}
     </div>
   );

--- a/sdk/qrcode/components/SelfQRcode.tsx
+++ b/sdk/qrcode/components/SelfQRcode.tsx
@@ -114,7 +114,6 @@ const SelfQRcode = ({
         proofStep={proofStep}
         qrValue={qrValue}
         size={size}
-        darkMode={darkMode}
         selfApp={selfAppRef.current}
       />
     );

--- a/sdk/qrcode/utils/styles.ts
+++ b/sdk/qrcode/utils/styles.ts
@@ -312,7 +312,11 @@ export const qrContainerStyle = (size: number): React.CSSProperties => ({
   height: size,
 });
 
-export const qrWrapperStyle = (step: number, showBorder: boolean = true): React.CSSProperties => ({
+export const qrWrapperStyle = (
+  step: number,
+  showBorder: boolean = true,
+  darkMode: boolean = false
+): React.CSSProperties => ({
   display: 'inline-flex',
   flexDirection: 'column',
   alignItems: 'center',
@@ -320,7 +324,7 @@ export const qrWrapperStyle = (step: number, showBorder: boolean = true): React.
   padding: '3px',
   borderRadius: '10px',
   border: showBorder ? `6px solid ${getBorderColor(step)}` : 'none',
-  backgroundColor: '#FFF',
+  backgroundColor: darkMode ? '#0F172A' : '#FFF',
   transition: 'border-color 0.3s ease',
 });
 


### PR DESCRIPTION
## Summary
- Keep the QR code itself black-on-white for scan reliability
- Move dark-themed styling to the wrapper only
- Update the SDK README wording to match the behavior

## Verification
- `yarn workspace @selfxyz/qrcode nice:check` ✅
- `yarn workspace @selfxyz/qrcode types` ⚠️ blocked locally: missing Node type definitions in this environment
- `yarn workspace @selfxyz/qrcode build` ⚠️ not completed after the typecheck failure
