### PR TITLE
ANA-14 fix(analytics): drop all Mixpanel events from mock passport flow

### DIFF
--- a/packages/mobile-sdk-alpha/src/analytics/onboardingFunnel.ts
+++ b/packages/mobile-sdk-alpha/src/analytics/onboardingFunnel.ts
@@ -46,6 +46,7 @@ interface OnboardingAttempt {
   retryCounts: Record<string, number>;
   countryCode?: string;
   documentType?: string;
+  isMock: boolean;
 }
 
 let currentAttempt: OnboardingAttempt | null = null;
@@ -71,6 +72,7 @@ function ensureAttempt(selfClient: Pick<SelfClient, 'trackEvent'>): OnboardingAt
       startedAt: Date.now(),
       firedSteps: new Set([OnboardingEvents.STARTED]),
       retryCounts: {},
+      isMock: false,
     };
     selfClient.trackEvent(OnboardingEvents.STARTED, baseProperties(currentAttempt));
   }
@@ -138,6 +140,11 @@ export function completeOnboardingAttempt(
   if (currentAttempt.firedSteps.has(OnboardingEvents.COMPLETED)) return;
   currentAttempt.firedSteps.add(OnboardingEvents.COMPLETED);
 
+  if (currentAttempt.isMock) {
+    currentAttempt = null;
+    return;
+  }
+
   selfClient.trackEvent(OnboardingEvents.COMPLETED, {
     ...baseProperties(currentAttempt),
     duration_seconds: durationSeconds(currentAttempt.startedAt),
@@ -165,6 +172,8 @@ export function failOnboardingAttempt(
   const attempt = currentAttempt;
   currentAttempt = null;
 
+  if (attempt.isMock) return;
+
   selfClient.trackEvent(OnboardingEvents.FAILED, {
     ...baseProperties(attempt),
     stage,
@@ -173,6 +182,22 @@ export function failOnboardingAttempt(
     used_fallback: attempt.initialBranch !== attempt.currentBranch,
     ...properties,
   });
+}
+
+export function markCurrentAttemptAsMock(_selfClient: Pick<SelfClient, 'trackEvent'>): void {
+  if (currentAttempt) {
+    currentAttempt.isMock = true;
+    return;
+  }
+  currentAttempt = {
+    id: uuid(),
+    initialBranch: 'pending',
+    currentBranch: 'pending',
+    startedAt: Date.now(),
+    firedSteps: new Set([OnboardingEvents.STARTED]),
+    retryCounts: {},
+    isMock: true,
+  };
 }
 
 /**
@@ -227,6 +252,7 @@ export function trackOnboardingRetry(
 ): void {
   const attempt = ensureAttempt(selfClient);
   attempt.retryCounts[stage] = (attempt.retryCounts[stage] ?? 0) + 1;
+  if (attempt.isMock) return;
   selfClient.trackEvent(OnboardingEvents.STEP_RETRIED, {
     ...baseProperties(attempt),
     stage,
@@ -265,6 +291,8 @@ export function trackOnboardingStep(
 
   if (attempt.firedSteps.has(event)) return;
   attempt.firedSteps.add(event);
+
+  if (attempt.isMock) return;
 
   // Strip the caller-supplied `branch` — emitted event uses the richer
   // `initial_branch` / `current_branch` pair from `baseProperties`.

--- a/packages/mobile-sdk-alpha/src/proving/provingMachine.ts
+++ b/packages/mobile-sdk-alpha/src/proving/provingMachine.ts
@@ -41,7 +41,12 @@ import {
 } from '@selfxyz/common/utils/proving';
 import type { IDDocument } from '@selfxyz/common/utils/types';
 
-import { completeOnboardingAttempt, failOnboardingAttempt, trackOnboardingStep } from '../analytics/onboardingFunnel';
+import {
+  completeOnboardingAttempt,
+  failOnboardingAttempt,
+  markCurrentAttemptAsMock,
+  trackOnboardingStep,
+} from '../analytics/onboardingFunnel';
 import { OnboardingEvents, PassportEvents, ProofEvents } from '../constants/analytics';
 import {
   clearPassportData,
@@ -236,6 +241,7 @@ export interface ProvingState {
   // event so it does not fire when `completed` is reached via the
   // `ALREADY_REGISTERED` shortcut from `validating_document`.
   didNewRegistrationProof: boolean;
+  isMock: boolean;
   init: (
     selfClient: SelfClient,
     circuitType: 'dsc' | 'disclose' | 'register',
@@ -397,6 +403,20 @@ export const getPostVerificationRoute = () => {
   // return cloudBackupEnabled ? 'AccountVerifiedSuccess' : 'SaveRecoveryPhrase';
 };
 
+function trackEventIfNotMock(
+  selfClient: SelfClient,
+  isMock: boolean,
+  eventName: string,
+  properties?: Record<string, unknown>,
+): void {
+  if (isMock) return;
+  if (properties === undefined) {
+    selfClient.trackEvent(eventName);
+  } else {
+    selfClient.trackEvent(eventName, properties);
+  }
+}
+
 export const useProvingStore = create<ProvingState>((set, get) => {
   let actor: AnyActorRef | null = null;
 
@@ -416,6 +436,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
       secret: null,
       circuitType: null,
       didNewRegistrationProof: false,
+      isMock: false,
       endpointType: null,
       env: null,
       error_code: null,
@@ -458,7 +479,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
         },
       });
       lastTransition = now;
-      selfClient.trackEvent(ProofEvents.PROVING_STATE_CHANGE, {
+      trackEventIfNotMock(selfClient, get().isMock, ProofEvents.PROVING_STATE_CHANGE, {
         state: state.value,
       });
       set({ currentState: state.value as ProvingStateType });
@@ -497,7 +518,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
       }
 
       if (state.value === 'completed') {
-        selfClient.trackEvent(ProofEvents.PROOF_COMPLETED, {
+        trackEventIfNotMock(selfClient, get().isMock, ProofEvents.PROOF_COMPLETED, {
           circuitType: get().circuitType,
         });
 
@@ -597,6 +618,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
     secret: null,
     circuitType: null,
     didNewRegistrationProof: false,
+    isMock: false,
     env: null,
     error_code: null,
     reason: null,
@@ -794,7 +816,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
         transports: ['websocket'],
       });
       set({ socketConnection: socket });
-      selfClient.trackEvent(ProofEvents.SOCKETIO_CONN_STARTED);
+      trackEventIfNotMock(selfClient, get().isMock, ProofEvents.SOCKETIO_CONN_STARTED);
       const context = createProofContext(selfClient, '_startSocketIOStatusListener');
       selfClient.logProofEvent('info', 'Socket.IO listener started', context, { url });
 
@@ -804,13 +826,13 @@ export const useProvingStore = create<ProvingState>((set, get) => {
 
       socket.on('connect', () => {
         socket?.emit('subscribe', receivedUuid);
-        selfClient.trackEvent(ProofEvents.SOCKETIO_SUBSCRIBED);
+        trackEventIfNotMock(selfClient, get().isMock, ProofEvents.SOCKETIO_SUBSCRIBED);
         selfClient.logProofEvent('info', 'Socket.IO connected', context);
       });
 
       socket.on('connect_error', error => {
         console.error('SocketIO connection error:', error);
-        selfClient.trackEvent(ProofEvents.SOCKETIO_CONNECT_ERROR, {
+        trackEventIfNotMock(selfClient, get().isMock, ProofEvents.SOCKETIO_CONNECT_ERROR, {
           message: error instanceof Error ? error.message : String(error),
         });
         selfClient.logProofEvent('error', 'Socket.IO connection error', context, {
@@ -831,7 +853,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
         }
         if (currentActor && (currentState === 'ready_to_prove' || currentState === 'listening_for_status')) {
           console.error(`SocketIO disconnected unexpectedly during ${currentState}.`);
-          selfClient.trackEvent(ProofEvents.SOCKETIO_DISCONNECT_UNEXPECTED);
+          trackEventIfNotMock(selfClient, get().isMock, ProofEvents.SOCKETIO_DISCONNECT_UNEXPECTED);
           selfClient.logProofEvent('error', 'Socket.IO disconnected unexpectedly', context, {
             failure: 'PROOF_FAILED_CONNECTION',
             state: currentState,
@@ -845,7 +867,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
         try {
           const data = parseStatusMessage(message);
 
-          selfClient.trackEvent(ProofEvents.SOCKETIO_STATUS_RECEIVED, {
+          trackEventIfNotMock(selfClient, get().isMock, ProofEvents.SOCKETIO_STATUS_RECEIVED, {
             status: data.status,
           });
           selfClient.logProofEvent('info', 'Status message received', context, {
@@ -870,7 +892,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
             } else if (event === 'SOCKETIO_PROOF_SUCCESS') {
               selfClient.logProofEvent('info', 'TEE processing succeeded', context);
             }
-            selfClient.trackEvent(event as unknown as keyof typeof ProofEvents, eventData);
+            trackEventIfNotMock(selfClient, get().isMock, event as unknown as keyof typeof ProofEvents, eventData);
           });
 
           // Handle actor events
@@ -908,7 +930,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
       }
       const connectionUuid = v4();
 
-      selfClient.trackEvent(ProofEvents.CONNECTION_UUID_GENERATED, {
+      trackEventIfNotMock(selfClient, get().isMock, ProofEvents.CONNECTION_UUID_GENERATED, {
         connection_uuid: connectionUuid,
       });
       const context = createProofContext(selfClient, '_handleWsOpen', {
@@ -925,7 +947,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
           uuid: connectionUuid,
         },
       };
-      selfClient.trackEvent(ProofEvents.WS_HELLO_SENT);
+      trackEventIfNotMock(selfClient, get().isMock, ProofEvents.WS_HELLO_SENT);
       ws.send(JSON.stringify(helloBody));
       selfClient.logProofEvent('info', 'WS hello sent', context);
     },
@@ -949,7 +971,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
     },
 
     _handleWsClose: (event: CloseEvent, selfClient: SelfClient) => {
-      selfClient.trackEvent(ProofEvents.TEE_WS_CLOSED, {
+      trackEventIfNotMock(selfClient, get().isMock, ProofEvents.TEE_WS_CLOSED, {
         code: event.code,
         reason: event.reason,
       });
@@ -1083,13 +1105,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
       circuitType: 'dsc' | 'disclose' | 'register',
       userConfirmed: boolean = false,
     ) => {
-      selfClient.trackEvent(ProofEvents.PROVING_INIT);
       get()._closeConnections(selfClient);
-
-      // Enable keychain error modal for proving flows
-      // This ensures users are notified if keychain access fails during critical operations
-      selfClient.navigation?.enableKeychainErrorModal?.();
-
       if (actor) {
         try {
           actor.stop();
@@ -1098,20 +1114,31 @@ export const useProvingStore = create<ProvingState>((set, get) => {
         }
         actor = null;
       }
+
+      selfClient.navigation?.enableKeychainErrorModal?.();
+
+      const selectedDocument = await loadSelectedDocument(selfClient);
+      const isMock = selectedDocument?.data.mock === true;
+
       resetProvingState({
         userConfirmed,
         circuitType,
+        isMock,
       });
 
       actor = createActor(provingMachine);
       setupActorSubscriptions(actor, selfClient);
       actor.start();
 
-      selfClient.trackEvent(ProofEvents.DOCUMENT_LOAD_STARTED);
-      const selectedDocument = await loadSelectedDocument(selfClient);
+      if (isMock) {
+        markCurrentAttemptAsMock(selfClient);
+      }
+
+      trackEventIfNotMock(selfClient, isMock, ProofEvents.PROVING_INIT);
+      trackEventIfNotMock(selfClient, isMock, ProofEvents.DOCUMENT_LOAD_STARTED);
       if (!selectedDocument) {
         console.error('No document found for proving');
-        selfClient.trackEvent(PassportEvents.PASSPORT_DATA_NOT_FOUND, {
+        trackEventIfNotMock(selfClient, isMock, PassportEvents.PASSPORT_DATA_NOT_FOUND, {
           stage: 'init',
         });
         console.error('No document found for proving in init');
@@ -1123,7 +1150,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
       const secret = await selfClient.getPrivateKey();
       if (!secret) {
         console.error('Could not load secret');
-        selfClient.trackEvent(ProofEvents.LOAD_SECRET_FAILED);
+        trackEventIfNotMock(selfClient, get().isMock, ProofEvents.LOAD_SECRET_FAILED);
         actor!.send({ type: 'ERROR' });
         return;
       }
@@ -1143,7 +1170,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
 
       if (circuitType === 'dsc' && !needsDscParsing) {
         console.error(`DSC circuit is not supported for ${passportData.documentCategory} documents`);
-        selfClient.trackEvent(ProofEvents.PROOF_FAILED, {
+        trackEventIfNotMock(selfClient, get().isMock, ProofEvents.PROOF_FAILED, {
           message: `DSC circuit not supported for ${passportData.documentCategory}`,
         });
         actor.send({ type: 'ERROR' });
@@ -1154,7 +1181,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
 
       if (shouldParseDocument) {
         actor.send({ type: 'PARSE_ID_DOCUMENT' });
-        selfClient.trackEvent(ProofEvents.PARSE_ID_DOCUMENT_STARTED);
+        trackEventIfNotMock(selfClient, get().isMock, ProofEvents.PARSE_ID_DOCUMENT_STARTED);
       } else {
         actor.send({ type: 'FETCH_DATA' });
       }
@@ -1190,7 +1217,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
           dscObject = {};
         }
 
-        selfClient.trackEvent(PassportEvents.PASSPORT_PARSED, {
+        trackEventIfNotMock(selfClient, get().isMock, PassportEvents.PASSPORT_PARSED, {
           success: true,
           data_groups: passportMetadata.dataGroups,
           dg1_size: passportMetadata.dg1Size,
@@ -1235,7 +1262,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
         });
         console.error('Error parsing ID document:', error);
         const errMsg = error instanceof Error ? error.message : String(error);
-        selfClient.trackEvent(PassportEvents.PASSPORT_PARSE_FAILED, {
+        trackEventIfNotMock(selfClient, get().isMock, PassportEvents.PASSPORT_PARSE_FAILED, {
           error: errMsg,
         });
         actor!.send({ type: 'PARSE_ERROR' });
@@ -1244,7 +1271,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
 
     startFetchingData: async (selfClient: SelfClient) => {
       _checkActorInitialized(actor);
-      selfClient.trackEvent(ProofEvents.FETCH_DATA_STARTED);
+      trackEventIfNotMock(selfClient, get().isMock, ProofEvents.FETCH_DATA_STARTED);
       const startTime = Date.now();
       const context = createProofContext(selfClient, 'startFetchingData');
       // passport and id card
@@ -1266,7 +1293,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
                 duration_ms: Date.now() - startTime,
               });
               console.error(`Missing parsed DSC in ${docType} data`);
-              selfClient.trackEvent(ProofEvents.FETCH_DATA_FAILED, {
+              trackEventIfNotMock(selfClient, get().isMock, ProofEvents.FETCH_DATA_FAILED, {
                 message: `Missing parsed DSC in ${docType} data`,
               });
               actor!.send({ type: 'FETCH_ERROR' });
@@ -1296,7 +1323,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
         selfClient.logProofEvent('info', 'Data fetch succeeded', context, {
           duration_ms: Date.now() - startTime,
         });
-        selfClient.trackEvent(ProofEvents.FETCH_DATA_SUCCESS);
+        trackEventIfNotMock(selfClient, get().isMock, ProofEvents.FETCH_DATA_SUCCESS);
         actor!.send({ type: 'FETCH_SUCCESS' });
       } catch (error) {
         selfClient.logProofEvent('error', 'Data fetch failed', context, {
@@ -1305,7 +1332,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
           duration_ms: Date.now() - startTime,
         });
         console.error('Error fetching data:', error);
-        selfClient.trackEvent(ProofEvents.FETCH_DATA_FAILED, {
+        trackEventIfNotMock(selfClient, get().isMock, ProofEvents.FETCH_DATA_FAILED, {
           message: error instanceof Error ? error.message : String(error),
         });
         actor!.send({ type: 'FETCH_ERROR' });
@@ -1315,7 +1342,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
     validatingDocument: async (selfClient: SelfClient) => {
       _checkActorInitialized(actor);
       // TODO: for the disclosure, we could check that the selfApp is a valid one.
-      selfClient.trackEvent(ProofEvents.VALIDATION_STARTED);
+      trackEventIfNotMock(selfClient, get().isMock, ProofEvents.VALIDATION_STARTED);
       const startTime = Date.now();
       const context = createProofContext(selfClient, 'validatingDocument');
       selfClient.logProofEvent('info', 'Validating document started', context);
@@ -1339,7 +1366,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
             duration_ms: Date.now() - startTime,
           });
           console.error('Passport not supported:', isSupported.status, isSupported.details);
-          selfClient.trackEvent(PassportEvents.COMING_SOON, {
+          trackEventIfNotMock(selfClient, get().isMock, PassportEvents.COMING_SOON, {
             status: isSupported.status,
             details: isSupported.details,
           });
@@ -1364,7 +1391,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
             selfClient.logProofEvent('info', 'Validation succeeded', context, {
               duration_ms: Date.now() - startTime,
             });
-            selfClient.trackEvent(ProofEvents.VALIDATION_SUCCESS);
+            trackEventIfNotMock(selfClient, get().isMock, ProofEvents.VALIDATION_SUCCESS);
             actor!.send({ type: 'VALIDATION_SUCCESS' });
             return;
           } else {
@@ -1416,7 +1443,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
             })();
             set({ circuitType: 'register' }); // Update circuit type to 'register' to reflect full registration completion
 
-            selfClient.trackEvent(ProofEvents.ALREADY_REGISTERED);
+            trackEventIfNotMock(selfClient, get().isMock, ProofEvents.ALREADY_REGISTERED);
             selfClient.logProofEvent('info', 'Document already registered', context, {
               duration_ms: Date.now() - startTime,
             });
@@ -1435,7 +1462,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
             console.warn(
               'Passport is nullified, but not registered with this secret. Navigating to AccountRecoveryChoice',
             );
-            selfClient.trackEvent(ProofEvents.PASSPORT_NULLIFIER_ONCHAIN);
+            trackEventIfNotMock(selfClient, get().isMock, ProofEvents.PASSPORT_NULLIFIER_ONCHAIN);
             actor!.send({ type: 'ACCOUNT_RECOVERY_CHOICE' });
             return;
           }
@@ -1455,14 +1482,14 @@ export const useProvingStore = create<ProvingState>((set, get) => {
               dsc_registered: isDscRegistered,
             });
             if (isDscRegistered) {
-              selfClient.trackEvent(ProofEvents.DSC_IN_TREE);
+              trackEventIfNotMock(selfClient, get().isMock, ProofEvents.DSC_IN_TREE);
               set({ circuitType: 'register' });
             }
           }
           selfClient.logProofEvent('info', 'Validation succeeded', context, {
             duration_ms: Date.now() - startTime,
           });
-          selfClient.trackEvent(ProofEvents.VALIDATION_SUCCESS);
+          trackEventIfNotMock(selfClient, get().isMock, ProofEvents.VALIDATION_SUCCESS);
           actor!.send({ type: 'VALIDATION_SUCCESS' });
         }
       } catch (error) {
@@ -1472,7 +1499,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
           duration_ms: Date.now() - startTime,
         });
         console.error('Error validating passport:', error);
-        selfClient.trackEvent(ProofEvents.VALIDATION_FAILED, {
+        trackEventIfNotMock(selfClient, get().isMock, ProofEvents.VALIDATION_FAILED, {
           message: error instanceof Error ? error.message : String(error),
         });
         actor!.send({ type: 'VALIDATION_ERROR' });
@@ -1528,7 +1555,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
       }
 
       get()._closeConnections(selfClient);
-      selfClient.trackEvent(ProofEvents.TEE_CONN_STARTED);
+      trackEventIfNotMock(selfClient, get().isMock, ProofEvents.TEE_CONN_STARTED);
       selfClient.logProofEvent('info', 'TEE connection attempt', baseContext);
 
       return new Promise(resolve => {
@@ -1538,7 +1565,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
           selfClient.logProofEvent('info', 'TEE connection succeeded', baseContext, {
             duration_ms: Date.now() - startTime,
           });
-          selfClient.trackEvent(ProofEvents.TEE_CONN_SUCCESS);
+          trackEventIfNotMock(selfClient, get().isMock, ProofEvents.TEE_CONN_SUCCESS);
           resolve(true);
         };
         const handleConnectError = (msg: string = 'connect_error') => {
@@ -1547,7 +1574,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
             error: msg,
             duration_ms: Date.now() - startTime,
           });
-          selfClient.trackEvent(ProofEvents.TEE_CONN_FAILED, { message: msg });
+          trackEventIfNotMock(selfClient, get().isMock, ProofEvents.TEE_CONN_FAILED, { message: msg });
           resolve(false);
         };
 
@@ -1642,7 +1669,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
           context,
         });
 
-        selfClient.trackEvent(ProofEvents.PAYLOAD_GEN_STARTED);
+        trackEventIfNotMock(selfClient, get().isMock, ProofEvents.PAYLOAD_GEN_STARTED);
         selfClient.logProofEvent('info', 'Payload generation started', context);
         const submitBody = await get()._generatePayload(selfClient);
 
@@ -1652,8 +1679,8 @@ export const useProvingStore = create<ProvingState>((set, get) => {
         }
         activeWsConnection.send(JSON.stringify(submitBody));
         selfClient.logProofEvent('info', 'Payload sent over WebSocket', context);
-        selfClient.trackEvent(ProofEvents.PAYLOAD_SENT);
-        selfClient.trackEvent(ProofEvents.PROVING_PROCESS_STARTED);
+        trackEventIfNotMock(selfClient, get().isMock, ProofEvents.PAYLOAD_SENT);
+        trackEventIfNotMock(selfClient, get().isMock, ProofEvents.PROVING_PROCESS_STARTED);
         actor!.send({ type: 'START_PROVING' });
         selfClient.logProofEvent('info', 'Proving started', context, {
           duration_ms: Date.now() - startTime,
@@ -1671,7 +1698,7 @@ export const useProvingStore = create<ProvingState>((set, get) => {
 
     setUserConfirmed: (selfClient: SelfClient) => {
       set({ userConfirmed: true });
-      selfClient.trackEvent(ProofEvents.USER_CONFIRMED);
+      trackEventIfNotMock(selfClient, get().isMock, ProofEvents.USER_CONFIRMED);
       if (get().currentState === 'ready_to_prove') {
         get().startProving(selfClient);
       }
@@ -1680,20 +1707,20 @@ export const useProvingStore = create<ProvingState>((set, get) => {
     postProving: (selfClient: SelfClient) => {
       _checkActorInitialized(actor);
       const { circuitType } = get();
-      selfClient.trackEvent(ProofEvents.POST_PROVING_STARTED);
+      trackEventIfNotMock(selfClient, get().isMock, ProofEvents.POST_PROVING_STARTED);
       if (circuitType === 'dsc') {
         setTimeout(() => {
-          selfClient.trackEvent(ProofEvents.POST_PROVING_CHAIN_STEP, {
+          trackEventIfNotMock(selfClient, get().isMock, ProofEvents.POST_PROVING_CHAIN_STEP, {
             from: 'dsc',
             to: 'register',
           });
           get().init(selfClient, 'register', true);
         }, 1500);
       } else if (circuitType === 'register') {
-        selfClient.trackEvent(ProofEvents.POST_PROVING_COMPLETED);
+        trackEventIfNotMock(selfClient, get().isMock, ProofEvents.POST_PROVING_COMPLETED);
         actor!.send({ type: 'COMPLETED' });
       } else if (circuitType === 'disclose') {
-        selfClient.trackEvent(ProofEvents.POST_PROVING_COMPLETED);
+        trackEventIfNotMock(selfClient, get().isMock, ProofEvents.POST_PROVING_COMPLETED);
         actor!.send({ type: 'COMPLETED' });
       }
     },
@@ -1791,8 +1818,8 @@ export const useProvingStore = create<ProvingState>((set, get) => {
           payload_size: payloadSize,
         });
 
-        selfClient.trackEvent(ProofEvents.PAYLOAD_GEN_COMPLETED);
-        selfClient.trackEvent(ProofEvents.PAYLOAD_ENCRYPTED);
+        trackEventIfNotMock(selfClient, get().isMock, ProofEvents.PAYLOAD_GEN_COMPLETED);
+        trackEventIfNotMock(selfClient, get().isMock, ProofEvents.PAYLOAD_ENCRYPTED);
 
         set({ endpointType: endpointType as EndpointType });
 

--- a/packages/mobile-sdk-alpha/tests/proving/provingMachine.documentProcessor.test.ts
+++ b/packages/mobile-sdk-alpha/tests/proving/provingMachine.documentProcessor.test.ts
@@ -26,6 +26,8 @@ import { actorMock } from './actorMock';
 
 import { LeanIMT } from '@openpassport/zk-kit-lean-imt';
 
+const asNonMock = <T extends { mock?: boolean }>(doc: T): T => ({ ...doc, mock: false });
+
 vi.mock('xstate', async () => {
   const actual = await vi.importActual<typeof import('xstate')>('xstate');
   return {
@@ -73,7 +75,7 @@ const buildPassportFixture = (): PassportData =>
     encryptedDigest: [11, 12, 13, 14, 15],
     documentType: 'passport',
     documentCategory: 'passport',
-    mock: true,
+    mock: false,
     passportMetadata: {
       dataGroups: '1,2,3',
       dg1Size: 88,
@@ -232,7 +234,7 @@ describe('parseIDDocument', () => {
   });
 
   it('parses passport data successfully and updates state with parsed result', async () => {
-    const passportData = genMockIdDoc({ idType: 'mock_passport' }) as PassportData;
+    const passportData = asNonMock(genMockIdDoc({ idType: 'mock_passport' })) as PassportData;
     const protocolState = buildProtocolState({
       commitmentTree: null,
       dscTree: null,
@@ -257,7 +259,7 @@ describe('parseIDDocument', () => {
     await useProvingStore.getState().parseIDDocument(selfClient);
 
     const state = useProvingStore.getState();
-    expect(getSKIPEMSpy).toHaveBeenCalledWith('staging');
+    expect(getSKIPEMSpy).toHaveBeenCalledWith('production');
     expect(storePassportDataMock).toHaveBeenCalledWith(selfClient, state.passportData);
     if (state.passportData && isMRZDocument(state.passportData)) {
       expect(state.passportData.passportMetadata).toBeDefined();
@@ -288,7 +290,7 @@ describe('parseIDDocument', () => {
     });
     const selfClient = createSelfClient(protocolState);
 
-    loadSelectedDocumentMock.mockResolvedValue({ data: genMockIdDoc({ idType: 'mock_passport' }) } as any);
+    loadSelectedDocumentMock.mockResolvedValue({ data: asNonMock(genMockIdDoc({ idType: 'mock_passport' })) } as any);
 
     vi.spyOn(commonUtils, 'getSKIPEM').mockResolvedValue({});
 
@@ -308,7 +310,7 @@ describe('parseIDDocument', () => {
 
   it('surfaces parsing failures when the DSC cannot be parsed', async () => {
     const passportData = {
-      ...(genMockIdDoc({ idType: 'mock_passport' }) as PassportData),
+      ...(asNonMock(genMockIdDoc({ idType: 'mock_passport' })) as PassportData),
       dsc: 'invalid-certificate',
     } as PassportData;
     const protocolState = buildProtocolState({
@@ -344,7 +346,7 @@ describe('parseIDDocument', () => {
   });
 
   it('continues when DSC metadata cannot be read and logs empty dsc payload', async () => {
-    const passportData = genMockIdDoc({ idType: 'mock_passport' }) as PassportData;
+    const passportData = asNonMock(genMockIdDoc({ idType: 'mock_passport' })) as PassportData;
     let metadataProxy: PassportData['passportMetadata'];
     Object.defineProperty(passportData, 'passportMetadata', {
       get() {
@@ -399,7 +401,7 @@ describe('parseIDDocument', () => {
   });
 
   it('emits PARSE_ERROR when storing parsed passport data fails', async () => {
-    const passportData = genMockIdDoc({ idType: 'mock_passport' }) as PassportData;
+    const passportData = asNonMock(genMockIdDoc({ idType: 'mock_passport' })) as PassportData;
     const protocolState = buildProtocolState({
       commitmentTree: null,
       dscTree: null,
@@ -442,7 +444,7 @@ describe('startFetchingData', () => {
 
   it('fetches trees and circuits for passport documents', async () => {
     const passportData = {
-      ...(genMockIdDoc({ idType: 'mock_passport' }) as PassportData),
+      ...(asNonMock(genMockIdDoc({ idType: 'mock_passport' })) as PassportData),
       dsc_parsed: { authorityKeyIdentifier: 'KEY123' } as any,
       documentCategory: 'passport',
     } as PassportData;
@@ -476,7 +478,7 @@ describe('startFetchingData', () => {
 
   it('fetches trees and circuits for id cards', async () => {
     const idCardData = {
-      ...(genMockIdDoc({ idType: 'mock_id_card' }) as PassportData),
+      ...(asNonMock(genMockIdDoc({ idType: 'mock_id_card' })) as PassportData),
       dsc_parsed: { authorityKeyIdentifier: 'IDKEY' } as any,
       documentCategory: 'id_card',
     } as PassportData;
@@ -508,7 +510,7 @@ describe('startFetchingData', () => {
   });
 
   it('fetches aadhaar protocol data via aadhaar fetcher', async () => {
-    const aadhaarData = genMockIdDoc({ idType: 'mock_aadhaar' }) as AadhaarData;
+    const aadhaarData = asNonMock(genMockIdDoc({ idType: 'mock_aadhaar' })) as AadhaarData;
     const protocolState = buildProtocolState({
       commitmentTree: null,
       dscTree: null,
@@ -551,7 +553,7 @@ describe('startFetchingData', () => {
     });
     const selfClient = createSelfClient(protocolState);
 
-    loadSelectedDocumentMock.mockResolvedValue({ data: genMockIdDoc({ idType: 'mock_passport' }) } as any);
+    loadSelectedDocumentMock.mockResolvedValue({ data: asNonMock(genMockIdDoc({ idType: 'mock_passport' })) } as any);
 
     await useProvingStore.getState().init(selfClient, 'register');
     actorMock.send.mockClear();
@@ -569,7 +571,7 @@ describe('startFetchingData', () => {
 
   it('emits FETCH_ERROR when DSC data is missing for passports', async () => {
     const passportData = {
-      ...(genMockIdDoc({ idType: 'mock_passport' }) as PassportData),
+      ...(asNonMock(genMockIdDoc({ idType: 'mock_passport' })) as PassportData),
       dsc_parsed: undefined,
       documentCategory: 'passport',
     } as PassportData;
@@ -604,7 +606,7 @@ describe('startFetchingData', () => {
 
   it('emits FETCH_ERROR when protocol fetch fails', async () => {
     const passportData = {
-      ...(genMockIdDoc({ idType: 'mock_passport' }) as PassportData),
+      ...(asNonMock(genMockIdDoc({ idType: 'mock_passport' })) as PassportData),
       dsc_parsed: { authorityKeyIdentifier: 'KEY123' } as any,
       documentCategory: 'passport',
     } as PassportData;
@@ -756,7 +758,7 @@ describe('validatingDocument', () => {
   });
 
   it('restores data when aadhaar is already registered with alternative keys', async () => {
-    const aadhaarData = genMockIdDoc({ idType: 'mock_aadhaar' }) as AadhaarData;
+    const aadhaarData = asNonMock(genMockIdDoc({ idType: 'mock_aadhaar' })) as AadhaarData;
     const secret = '123456789';
     const { commitment_list: commitmentList } = generateCommitmentInAppAadhaar(
       secret,

--- a/packages/mobile-sdk-alpha/tests/proving/provingMachine.mockSuppression.test.ts
+++ b/packages/mobile-sdk-alpha/tests/proving/provingMachine.mockSuppression.test.ts
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { PassportData } from '@selfxyz/common';
+import { genMockIdDoc } from '@selfxyz/common/utils';
+
+import {
+  _getCurrentOnboardingAttempt,
+  _resetOnboardingFunnelForTests,
+  completeOnboardingAttempt,
+  failOnboardingAttempt,
+  markCurrentAttemptAsMock,
+  trackOnboardingRetry,
+  trackOnboardingStep,
+} from '../../src/analytics/onboardingFunnel';
+import { OnboardingEvents } from '../../src/constants/analytics';
+import * as documentUtils from '../../src/documents/utils';
+import { useProvingStore } from '../../src/proving/provingMachine';
+import type { SelfClient } from '../../src/types/public';
+import { actorMock } from './actorMock';
+
+vi.mock('xstate', async () => {
+  const actual = await vi.importActual<typeof import('xstate')>('xstate');
+  return {
+    ...actual,
+    createActor: vi.fn(() => actorMock),
+  };
+});
+
+vi.mock('../../src/documents/utils', async () => {
+  const actual = await vi.importActual<typeof import('../../src/documents/utils')>('../../src/documents/utils');
+  return {
+    ...actual,
+    loadSelectedDocument: vi.fn(),
+    storePassportData: vi.fn(),
+    clearPassportData: vi.fn(),
+    reStorePassportDataWithRightCSCA: vi.fn(),
+    markCurrentDocumentAsRegistered: vi.fn(),
+  };
+});
+
+function makeClient() {
+  return { trackEvent: vi.fn() };
+}
+
+function makeSelfClient(): SelfClient {
+  return {
+    trackEvent: vi.fn(),
+    logProofEvent: vi.fn(),
+    emit: vi.fn(),
+    getPrivateKey: vi.fn().mockResolvedValue('123456789'),
+    getProvingState: () => useProvingStore.getState(),
+    getSelfAppState: () => ({ selfApp: null }),
+  } as unknown as SelfClient;
+}
+
+beforeEach(() => {
+  _resetOnboardingFunnelForTests();
+  vi.clearAllMocks();
+});
+
+describe('funnel helper — mock suppression (ANA-14)', () => {
+  it('markCurrentAttemptAsMock bootstraps a mock attempt without emitting STARTED', () => {
+    const client = makeClient();
+
+    markCurrentAttemptAsMock(client);
+
+    expect(client.trackEvent).not.toHaveBeenCalled();
+    const attempt = _getCurrentOnboardingAttempt();
+    expect(attempt).not.toBeNull();
+    expect(attempt?.isMock).toBe(true);
+    expect(attempt?.firedSteps.has(OnboardingEvents.STARTED)).toBe(true);
+  });
+
+  it('marks an existing real attempt as mock without firing further events', () => {
+    const client = makeClient();
+
+    trackOnboardingStep(client, OnboardingEvents.COUNTRY_SELECTED, { country_code: 'FR' });
+    expect(client.trackEvent).toHaveBeenCalledTimes(2); // STARTED + COUNTRY_SELECTED
+
+    client.trackEvent.mockClear();
+    markCurrentAttemptAsMock(client);
+
+    expect(client.trackEvent).not.toHaveBeenCalled();
+    expect(_getCurrentOnboardingAttempt()?.isMock).toBe(true);
+  });
+
+  it('suppresses trackOnboardingStep emissions on a mock attempt', () => {
+    const client = makeClient();
+    markCurrentAttemptAsMock(client);
+
+    trackOnboardingStep(client, OnboardingEvents.PROOF_STARTED);
+    trackOnboardingStep(client, OnboardingEvents.PROOF_SUCCEEDED);
+
+    expect(client.trackEvent).not.toHaveBeenCalled();
+  });
+
+  it('suppresses completeOnboardingAttempt on a mock attempt and clears the attempt', () => {
+    const client = makeClient();
+    markCurrentAttemptAsMock(client);
+
+    completeOnboardingAttempt(client);
+
+    expect(client.trackEvent).not.toHaveBeenCalled();
+    expect(_getCurrentOnboardingAttempt()).toBeNull();
+  });
+
+  it('suppresses failOnboardingAttempt on a mock attempt and clears the attempt', () => {
+    const client = makeClient();
+    markCurrentAttemptAsMock(client);
+
+    failOnboardingAttempt(client, 'proof_generation_started', 'circuit_error');
+
+    expect(client.trackEvent).not.toHaveBeenCalled();
+    expect(_getCurrentOnboardingAttempt()).toBeNull();
+  });
+
+  it('suppresses trackOnboardingRetry on a mock attempt while still incrementing the counter', () => {
+    const client = makeClient();
+    markCurrentAttemptAsMock(client);
+
+    trackOnboardingRetry(client, 'scan_started', 'nfc_failed');
+    trackOnboardingRetry(client, 'scan_started', 'nfc_failed');
+
+    expect(client.trackEvent).not.toHaveBeenCalled();
+    expect(_getCurrentOnboardingAttempt()?.retryCounts.scan_started).toBe(2);
+  });
+
+  it('does not suppress emissions on a real attempt (positive control)', () => {
+    const client = makeClient();
+
+    trackOnboardingStep(client, OnboardingEvents.COUNTRY_SELECTED, { country_code: 'FR' });
+    completeOnboardingAttempt(client);
+
+    const eventNames = client.trackEvent.mock.calls.map(call => call[0]);
+    expect(eventNames).toContain(OnboardingEvents.STARTED);
+    expect(eventNames).toContain(OnboardingEvents.COUNTRY_SELECTED);
+    expect(eventNames).toContain(OnboardingEvents.COMPLETED);
+  });
+});
+
+describe('proving machine — mock suppression (ANA-14)', () => {
+  const loadSelectedDocumentMock = vi.mocked(documentUtils.loadSelectedDocument);
+
+  it('init() with mock=true sets isMock on the store and emits no Mixpanel events', async () => {
+    const passportData = genMockIdDoc({ idType: 'mock_passport' }) as PassportData;
+    expect(passportData.mock).toBe(true);
+
+    const selfClient = makeSelfClient();
+    loadSelectedDocumentMock.mockResolvedValue({ data: passportData } as any);
+
+    await useProvingStore.getState().init(selfClient, 'register');
+
+    expect(useProvingStore.getState().isMock).toBe(true);
+    expect(selfClient.trackEvent).not.toHaveBeenCalled();
+  });
+
+  it('init() with mock=false emits the existing diagnostic events (positive control)', async () => {
+    const realPassport = {
+      ...(genMockIdDoc({ idType: 'mock_passport' }) as PassportData),
+      mock: false,
+    } as PassportData;
+
+    const selfClient = makeSelfClient();
+    loadSelectedDocumentMock.mockResolvedValue({ data: realPassport } as any);
+
+    await useProvingStore.getState().init(selfClient, 'register');
+
+    expect(useProvingStore.getState().isMock).toBe(false);
+    expect(selfClient.trackEvent).toHaveBeenCalled();
+  });
+});

--- a/specs/projects/sdk/workstreams/analytics/SPEC.md
+++ b/specs/projects/sdk/workstreams/analytics/SPEC.md
@@ -1,6 +1,6 @@
 # Onboarding Analytics & Funnel — Implementation Spec
 
-> Last updated: 2026-05-06
+> Last updated: 2026-05-07
 > Owner: Self Wallet / Product Analytics
 > Project: [SDK Overview](../../OVERVIEW.md)
 > Status: Active
@@ -48,6 +48,7 @@ Four observability layers, three in Mixpanel, one in Sentry:
 - `Onboarding: Started` fires exactly once per attempt, emitted by the funnel helper's `ensureAttempt` bootstrap when the first canonical step event arrives. Screens never call it directly.
 - Terminal `Onboarding: Completed` fires only when the proving machine reaches `completed` via a true new-registration proof (`circuitType === 'register' && didNewRegistrationProof`). The `ALREADY_REGISTERED` shortcut and disclosure flows fire **no** `Onboarding: *` event.
 - New Mixpanel events require a documented consumer (dashboard, alert, or product question) in the PR description. After ANA-13 phase 3, the cap is enforced at the type system.
+- Mock-passport attempts (`passportData.mock === true`) emit no Mixpanel events from the proving machine or funnel helper (ANA-14). The dev-only `MockDataEvents.*` namespace is the sole telemetry surface for mock flows. The proving machine marks the active attempt as mock immediately after `loadSelectedDocument` and routes all `selfClient.trackEvent` calls through a mock-aware helper.
 
 ## Canonical Event Set
 
@@ -115,16 +116,17 @@ The branch split tells you _what happened_ (initial intent vs final outcome) but
 
 ## Backlog
 
-| ID     | Title                                                                       | Status    | Priority | Depends on             | Plan                                                            |
-| ------ | --------------------------------------------------------------------------- | --------- | -------- | ---------------------- | --------------------------------------------------------------- |
-| ANA-01 | Canonical onboarding funnel events + dead-zone fixes                        | **Done**  | —        | —                      | [plan](./plans/ANA-01-canonical-onboarding-funnel.md)           |
-| ANA-11 | Canonical funnel bug fixes (post-ANA-01 production findings)                | In Review | High     | ANA-01                 | [plan](./plans/ANA-11-canonical-funnel-bug-fixes.md) — PR #2048 |
-| ANA-12 | Branch-specific funnel events (Biometric / KYC / Aadhaar)                   | Ready     | High     | ANA-01, ANA-11         | [plan](./plans/ANA-12-branch-specific-funnel-events.md)         |
-| ANA-13 | Observability migration — Mixpanel diet, Sentry breadcrumbs, Session Replay | Ready     | High     | ANA-01, ANA-11, ANA-12 | [plan](./plans/ANA-13-observability-migration.md)               |
-| ANA-05 | Fallback decision events and fallback-offer mini-funnel                     | Ready     | Medium   | ANA-01, ANA-12         | —                                                               |
-| ANA-08 | Explicit abandonment events on app background                               | Ready     | Low      | ANA-01                 | —                                                               |
-| ANA-02 | Investigation: internal/TestFlight traffic filtering                        | Ready     | Medium   | —                      | —                                                               |
-| ANA-04 | Investigation: native NFC analytics channel                                 | Ready     | Low      | ANA-13                 | —                                                               |
+| ID     | Title                                                                       | Status      | Priority | Depends on             | Plan                                                            |
+| ------ | --------------------------------------------------------------------------- | ----------- | -------- | ---------------------- | --------------------------------------------------------------- |
+| ANA-01 | Canonical onboarding funnel events + dead-zone fixes                        | **Done**    | —        | —                      | [plan](./plans/ANA-01-canonical-onboarding-funnel.md)           |
+| ANA-11 | Canonical funnel bug fixes (post-ANA-01 production findings)                | In Review   | High     | ANA-01                 | [plan](./plans/ANA-11-canonical-funnel-bug-fixes.md) — PR #2048 |
+| ANA-12 | Branch-specific funnel events (Biometric / KYC / Aadhaar)                   | Ready       | High     | ANA-01, ANA-11         | [plan](./plans/ANA-12-branch-specific-funnel-events.md)         |
+| ANA-13 | Observability migration — Mixpanel diet, Sentry breadcrumbs, Session Replay | Ready       | High     | ANA-01, ANA-11, ANA-12 | [plan](./plans/ANA-13-observability-migration.md)               |
+| ANA-14 | Suppress all analytics events from mock passport flow                       | In Progress | High     | ANA-01                 | [plan](./plans/ANA-14-suppress-mock-analytics.md)               |
+| ANA-05 | Fallback decision events and fallback-offer mini-funnel                     | Ready       | Medium   | ANA-01, ANA-12         | —                                                               |
+| ANA-08 | Explicit abandonment events on app background                               | Ready       | Low      | ANA-01                 | —                                                               |
+| ANA-02 | Investigation: internal/TestFlight traffic filtering                        | Ready       | Medium   | —                      | —                                                               |
+| ANA-04 | Investigation: native NFC analytics channel                                 | Ready       | Low      | ANA-13                 | —                                                               |
 
 Allowed statuses: `Ready`, `In Progress`, `In Review`, `Blocked`, `Done`.
 

--- a/specs/projects/sdk/workstreams/analytics/plans/ANA-14-suppress-mock-analytics.md
+++ b/specs/projects/sdk/workstreams/analytics/plans/ANA-14-suppress-mock-analytics.md
@@ -1,0 +1,142 @@
+# ANA-14 — Suppress all analytics events from mock passport flow
+
+> Linear: [SELF-2878](https://linear.app/selfprotocol/issue/SELF-2878/ana-14-suppress-all-analytics-events-from-mock-passport-flow)
+> Workstream: [Onboarding Analytics & Funnel](../SPEC.md)
+> Depends on: ANA-01 (canonical helper), ANA-11 (clean baseline). Forward-compatible with ANA-12 (branch helpers).
+> PR target: <500 LOC.
+
+## Context
+
+The mock-passport developer flow (`CreateMockScreen` → `generateMockDocument` → `storePassportData` → `ConfirmBelonging` → proving machine) currently fires real Mixpanel events. Mock-creation screens themselves only emit `MockDataEvents.*` (a dev-only namespace), but once the mock document hits the proving machine, the analytics path is shared with the real flow with no guard.
+
+Concrete impact:
+
+- **`PassportEvents.PASSPORT_PARSED`** (`provingMachine.ts:1201`) sends `country_code` + `signature_algorithm` + DSC metadata for every QA passport. Once ANA-12 renames this to `BiometricEvents.DOCUMENT_PARSED` and dashboards key off `(country_code, signature_algorithm)` to surface unsupported docs, mock data becomes top contributor.
+- **`OnboardingEvents.STARTED` bootstrap** fires at `PROOF_STARTED` for mock flows (which skip Country/DocType/Scan). Every QA proof inflates `Onboarding: Started` count, breaking conversion math.
+- **`OnboardingEvents.PROOF_SUCCEEDED` + `OnboardingEvents.COMPLETED`** are deterministic for mocks, padding completion-rate numerators.
+- **`ProofEvents.*`** (`PAYLOAD_GEN_STARTED`, `PAYLOAD_SENT`, `PROVING_PROCESS_STARTED`, `PROOF_COMPLETED`, plus diagnostic `DOCUMENT_LOAD_STARTED`, `USER_CONFIRMED`, `POST_PROVING_STARTED`, etc.) fire identically for mocks.
+
+The proving stage already reads `passportData.mock` to choose env (`provingMachine.ts:1140`). The analytics layer ignores the same signal. **Decision: drop at source.** Tagging events with `is_mock: false` and dashboard-filtering was rejected — relies on every consumer remembering, silently re-pollutes the next dashboard built without the filter.
+
+## Files modified
+
+- `packages/mobile-sdk-alpha/src/analytics/onboardingFunnel.ts` — add mock-suppression to attempt state and emit functions.
+- `packages/mobile-sdk-alpha/src/proving/provingMachine.ts` — stash `isMock` on the proving store, route all `selfClient.trackEvent` calls through a mock-aware local helper, mark the funnel attempt as mock immediately after document load.
+- `packages/mobile-sdk-alpha/tests/proving/` — new test verifying mock no-emit invariant.
+- `specs/projects/sdk/workstreams/analytics/SPEC.md` — backlog row + invariant.
+
+## Implementation
+
+### 1. Funnel helper changes — `packages/mobile-sdk-alpha/src/analytics/onboardingFunnel.ts`
+
+You will:
+
+- Add `isMock: boolean` to the `OnboardingAttempt` interface (default `false` on creation in `ensureAttempt`).
+- Add a new exported function `markCurrentAttemptAsMock(selfClient: Pick<SelfClient, 'trackEvent'>): void`. Behavior:
+  - If `currentAttempt` is null: bootstrap a fresh attempt with `isMock: true`, **without** firing `OnboardingEvents.STARTED`. Add `STARTED` to `firedSteps` anyway to keep the fire-once invariant.
+  - If `currentAttempt` exists: set `currentAttempt.isMock = true` (idempotent).
+- Gate every emit path on `attempt.isMock`:
+  - `ensureAttempt` — when bootstrapping and `isMock === false`, emit `STARTED` as today. (When `markCurrentAttemptAsMock` created the attempt, `isMock === true`, so any later `ensureAttempt` call returns the existing attempt and never emits.)
+  - `trackOnboardingStep` — after the dedup check, if `attempt.isMock`, return without calling `selfClient.trackEvent`. Still update `firedSteps`, `countryCode`, `documentType`, and call `captureBranch` so attempt state stays internally consistent for any code that later reads it.
+  - `completeOnboardingAttempt` — if `currentAttempt.isMock`, clear the attempt and return without emitting `COMPLETED`.
+  - `failOnboardingAttempt` — if `currentAttempt.isMock`, clear and return without emitting `FAILED`.
+  - `trackOnboardingRetry` — if `attempt.isMock`, increment retry counter (state) but skip the emit.
+
+Export order remains alphabetical (sort-exports). New export goes between `failOnboardingAttempt` and `resolveOnboardingBranch`.
+
+### 2. Proving machine changes — `packages/mobile-sdk-alpha/src/proving/provingMachine.ts`
+
+You will:
+
+- Add `isMock: boolean` to the proving store state, initialized to `false`. Reset to `false` on `init`.
+- Introduce a local helper `function trackEventIfNotMock(selfClient: SelfClient, get: () => ProvingStateMachine, eventName: string, properties?: Record<string, unknown>): void` defined at module scope below the existing helpers. Body: `if (get().isMock) return; selfClient.trackEvent(eventName, properties);`. Keep it private to the file.
+- Find every `selfClient.trackEvent(...)` call in this file and replace with `trackEventIfNotMock(selfClient, get, ...)`. Inventory (verify by grepping after the edit):
+  - `ProofEvents.PROOF_COMPLETED` — line 503
+  - `ProofEvents.DOCUMENT_LOAD_STARTED` — line 1118
+  - `PassportEvents.PASSPORT_DATA_NOT_FOUND` — line 1122
+  - `ProofEvents.LOAD_SECRET_FAILED` — line 1134
+  - `PassportEvents.PASSPORT_PARSED` — line 1201
+  - `PassportEvents.PASSPORT_PARSE_FAILED` — line 1246
+  - `PassportEvents.COMING_SOON` — line 1350
+  - `ProofEvents.PAYLOAD_GEN_STARTED` — line 1642
+  - `ProofEvents.PAYLOAD_SENT` — line 1652
+  - `ProofEvents.PROVING_PROCESS_STARTED` — line 1653
+  - `ProofEvents.USER_CONFIRMED` — line 1671
+  - `ProofEvents.POST_PROVING_STARTED` — line 1680
+  - `ProofEvents.POST_PROVING_CHAIN_STEP` — line 1683
+  - Any `selfClient.trackEvent` not in this list — wrap it too. Run `grep -n "selfClient.trackEvent(" packages/mobile-sdk-alpha/src/proving/provingMachine.ts` after the edit; the only remaining bare calls should be inside the `trackEventIfNotMock` helper definition itself.
+- Right after `set({ passportData, secret, env })` at `provingMachine.ts:1142`, add:
+  ```ts
+  const isMock = passportData.mock === true;
+  set({ isMock });
+  if (isMock) {
+    markCurrentAttemptAsMock(selfClient);
+  }
+  ```
+  This guarantees that:
+  - `trackEventIfNotMock` short-circuits all subsequent diagnostic events for mock.
+  - The funnel attempt is marked mock before the first canonical `trackOnboardingStep(PROOF_STARTED)` call (line 488) reaches `ensureAttempt`, so `Onboarding: Started` never fires.
+- Import `markCurrentAttemptAsMock` alongside the existing `trackOnboardingStep` / `completeOnboardingAttempt` imports from `../analytics/onboardingFunnel`.
+
+**Note on `selfClient.emit(SdkEvents.PROVING_BEGIN_GENERATION, ...)` at line 1636:** this is `emit`, not `trackEvent`. It is in-process event-bus signaling for SDK consumers, not Mixpanel. Leave it alone — its existing `isMock: passportData?.mock ?? false` payload is correct for downstream consumers that want the signal.
+
+**Note on `selfClient.logProofEvent(...)` calls:** these route to Sentry breadcrumbs, not Mixpanel. Leave them alone — they're diagnostic context for crash reports.
+
+### 3. Test — `packages/mobile-sdk-alpha/tests/proving/provingMachine.mockSuppression.test.ts`
+
+You will create a new test file (Vitest, matches the existing `tests/proving/` style):
+
+- Use `mockAdapters` and `genMockIdDoc({ idType: 'mock_passport' })` per the existing patterns in `tests/proving/provingMachine.documentProcessor.test.ts`.
+- Spy on `selfClient.trackEvent`. Drive the proving machine through `init` → `processIDDocument` → `startProving` → `completed`.
+- Assert: `trackEvent` was called **zero** times.
+- Add a positive control test in the same file: same flow with `mock: false` passportData, assert `trackEvent` was called at least with `OnboardingEvents.STARTED` and `OnboardingEvents.PROOF_STARTED` (sanity check that the helper still works for real flows).
+- Reset funnel state with `_resetOnboardingFunnelForTests()` in `beforeEach`.
+
+### 4. Spec updates — `specs/projects/sdk/workstreams/analytics/SPEC.md`
+
+You will:
+
+- Add a new row to the Backlog table (between ANA-13 and ANA-05):
+  ```
+  | ANA-14 | Suppress all analytics events from mock passport flow | In Progress | High | ANA-01 | [plan](./plans/ANA-14-suppress-mock-analytics.md) |
+  ```
+- Append a new bullet to §Invariants:
+  > - Mock-passport attempts (`passportData.mock === true`) emit no Mixpanel events from the proving machine or funnel helper. The dev-only `MockDataEvents.*` namespace is the sole telemetry surface for mock flows. The proving machine marks the active attempt as mock immediately after `loadSelectedDocument` and routes all `selfClient.trackEvent` calls through a mock-aware helper.
+
+## Out of scope
+
+- You will NOT add an `is_mock` super-property or per-event property. Drop at source, do not tag.
+- You will NOT modify `MockDataEvents.*`, `CreateMockScreen.tsx`, or anything in the mock-creation flow — those are clean.
+- You will NOT touch `selfClient.emit(SdkEvents.PROVING_BEGIN_GENERATION, ...)` or any `selfClient.logProofEvent(...)` calls — these are not Mixpanel.
+- You will NOT change the proving stage's `'stg'` env routing logic at `provingMachine.ts:1140` — it is correct as-is.
+- You will NOT add a "QA funnel" Mixpanel dashboard. If we want one later, build it on `MockDataEvents.*`.
+- You will NOT backfill historical Mixpanel data to remove existing mock contamination.
+- You will NOT introduce a new `BiometricEvents` namespace, rename `PassportEvents`, or pre-empt any ANA-12 work. ANA-14's gate is namespace-agnostic — it sits beneath whatever event names exist.
+- You will NOT add UI or behavioral changes to the mock flow. Mock proofs continue to complete and store credentials as today.
+
+## Validation
+
+Run from the repo root:
+
+```bash
+cd packages/mobile-sdk-alpha && yarn test && yarn types
+```
+
+Both must pass. The new `provingMachine.mockSuppression.test.ts` must be in the run.
+
+Manual smoke test (recommended, not blocking):
+
+1. Build the app for simulator: `cd app && yarn ios` (or Android equivalent).
+2. Enable Mixpanel debug logging in the analytics adapter (or attach a `trackEvent` breakpoint in `selfClient`).
+3. Run the full mock flow: open app → Create Mock Document → confirm → wait for proof completion.
+4. Confirm no `Onboarding:`, `Biometric:`, `Passport:`, or `Proof:` events fire. `MockData:*` events from the creation screens should fire as today.
+5. Repeat with a real passport (TestFlight or staging build) and confirm the canonical funnel still fires end-to-end.
+
+## Acceptance criteria
+
+- Running the full mock flow produces zero `selfClient.trackEvent` calls — verified by the new unit test.
+- A non-mock passportData run still emits `Onboarding: Started` → `Onboarding: Proof Generation Started` → `Onboarding: Proof Generation Succeeded` → `Onboarding: Completed` plus the existing diagnostic stream — verified by the positive-control test and existing tests in `tests/proving/`.
+- `MockDataEvents.*` emissions from `CreateMockScreen.tsx` are unchanged.
+- `yarn test` and `yarn types` in `packages/mobile-sdk-alpha` pass.
+- `SPEC.md` updated with the ANA-14 backlog row and invariant bullet.
+- One PR, <500 LOC including the test file.


### PR DESCRIPTION
## Summary

- Mock-passport flows (CreateMockScreen → generateMockDocument → proving machine) currently fire real Mixpanel events: inflate `Onboarding: Started`, pad completion rates, contaminate the `(country_code, signature_algorithm)` breakdown ANA-12 dashboards rely on. ANA-14 stops it at source.
- Funnel helper (`onboardingFunnel.ts`): adds `isMock` to `OnboardingAttempt`, exports `markCurrentAttemptAsMock(selfClient)` that bootstraps a mock attempt **without** firing `Onboarding: Started`. All emit functions (`trackOnboardingStep`, `completeOnboardingAttempt`, `failOnboardingAttempt`, `trackOnboardingRetry`) short-circuit on mock attempts.
- Proving machine: adds `isMock` to the store, routes all 44 `selfClient.trackEvent` sites through a `trackEventIfNotMock` helper, and reorders `init()` so `loadSelectedDocument` runs before any Mixpanel emission. `loadSelectedDocument` is keychain-free, so the hoist is safe — `enableKeychainErrorModal` still fires before `getPrivateKey()`.
- `MockDataEvents.*` (dev-only namespace) is unaffected and remains the sole telemetry surface for mock flows.
- Linear: [SELF-2878](https://linear.app/selfprotocol/issue/SELF-2878/ana-14-suppress-all-analytics-events-from-mock-passport-flow)
- Repo plan: [`specs/projects/sdk/workstreams/analytics/plans/ANA-14-suppress-mock-analytics.md`](https://github.com/selfxyz/self/blob/self-2878/specs/projects/sdk/workstreams/analytics/plans/ANA-14-suppress-mock-analytics.md)

## Test plan

- [x] `yarn types` in `packages/mobile-sdk-alpha` — pass
- [x] `yarn test` in `packages/mobile-sdk-alpha` — 384/384 pass (9 new in `provingMachine.mockSuppression.test.ts`)
- [x] `yarn lint` in `packages/mobile-sdk-alpha` — clean
- [ ] Manual: build the app for simulator, run the full mock-passport flow (Create Mock Document → confirm → wait for proof completion). Confirm **zero** `Onboarding: *`, `Biometric: *` (post-ANA-12), `Passport: *`, `Kyc: *`, `Aadhaar: *`, `Proof: *` events fire. `MockData: *` events from the creation screens should fire as today.
- [ ] Manual: run a real-passport flow (TestFlight or staging build) and confirm the canonical funnel still fires `Onboarding: Started` → `Onboarding: Proof Generation Started` → `Onboarding: Proof Generation Succeeded` → `Onboarding: Completed`.

## Notes for reviewers

- The `documentProcessor.test.ts` fixture was previously `mock: true` while exercising real-flow code paths. Stripping the flag (via a small `asNonMock` helper) and flipping one assertion (`'staging'` → `'production'` for env routing) was the minimal way to keep those tests meaningful. The mock-suppression branch has its own coverage in the new test file.
- `selfClient.emit(SdkEvents.PROVING_BEGIN_GENERATION, { isMock, ... })` and `selfClient.logProofEvent(...)` are deliberately untouched — those route to the in-process event bus and Sentry breadcrumbs respectively, not Mixpanel.
- No `is_mock` super-property or per-event tag was added. Drop-at-source was chosen over filter-at-dashboard — the latter requires every consumer to remember the filter and silently re-pollutes any new dashboard built without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mock passport flows are auto-detected or can be marked as mock; analytics emissions are suppressed for mocked attempts to keep test data out of production metrics.
  * Onboarding and proving flows track mock state in-memory so completion/failure still proceed without telemetry noise.

* **Tests**
  * Added coverage validating mock suppression and positive controls for non-mock runs.

* **Documentation**
  * Updated analytics spec and added ANA-14 plan detailing mock-flow invariants.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/selfxyz/self/pull/2056)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->