### PR TITLE
fix(analytics): fire canonical SCAN_STARTED for pure-KYC direct-entry path

### DIFF
--- a/app/src/providers/selfClientProvider.tsx
+++ b/app/src/providers/selfClientProvider.tsx
@@ -17,10 +17,12 @@ import {
   SdkEvents,
   SelfClientProvider as SDKSelfClientProvider,
   type TrackEventParams,
+  trackOnboardingStep,
   useMRZStore,
   webNFCScannerShim,
   type WsConn,
 } from '@selfxyz/mobile-sdk-alpha';
+import { OnboardingEvents } from '@selfxyz/mobile-sdk-alpha/constants/analytics';
 
 import { logNFCEvent, logProofEvent } from '@/config/sentry';
 import { createKycSession, launchKycVerification } from '@/integrations/kyc';
@@ -346,6 +348,12 @@ export const SelfClientProvider = ({ children }: PropsWithChildren) => {
             case 'kyc':
               (async () => {
                 try {
+                  trackOnboardingStep(
+                    { trackEvent },
+                    OnboardingEvents.SCAN_STARTED,
+                    { branch: 'kyc' },
+                  );
+
                   // Dev-only: Check for injected initialization error
                   if (
                     useErrorInjectionStore


### PR DESCRIPTION
## Summary

ANA-11 (#2048) moved the canonical `Onboarding: Document Scan Started` emission into `useKycLauncher` to cover pure-KYC users — but missed a sibling code path. First-time users who pick the **KYC tile directly** on the IDPicker (`id-selection-screen.tsx:185`) emit `SdkEvents.DOCUMENT_TYPE_SELECTED` with `documentType: 'kyc'`, which is handled by the `case 'kyc':` listener in `selfClientProvider.tsx`. That listener calls `launchKycVerification` from `@/integrations/kyc` **directly**, bypassing the hook — so `SCAN_STARTED` never fires for this cohort.

This PR adds the same `trackOnboardingStep(SCAN_STARTED, branch: 'kyc')` call at the start of the `case 'kyc':` async block.

## Why this matters

Pure-KYC users who never intended biometric (the `initial_branch = kyc AND current_branch = kyc` cohort) currently:

- Don't appear in the canonical onboarding funnel's `Document Scan Started` step
- Skew the funnel's drop-off math because their COMPLETED events fire without prior SCAN_STARTED
- Are invisible to dashboard queries that segment by initial intent

Paths ANA-11 actually covered (via `useKycLauncher`):
- `RegistrationFallbackMRZScreen` (MRZ failed → KYC)
- `RegistrationFallbackNFCScreen` (NFC failed → KYC)
- `DocumentNFCScanScreen` (mid-NFC bail-out → KYC)
- `DocumentNFCTroubleScreen` (NFC trouble → KYC)
- `DataConfirmationScreen` (post-MRZ "Try alternative" → KYC)
- `AadhaarUploadErrorScreen` (Aadhaar failed → KYC)

Path ANA-11 missed (this PR):
- `selfClientProvider.tsx case 'kyc':` — first-time pure-KYC pick from IDPicker

## Safety

Fire-once guard in `trackOnboardingStep` dedupes against any later emission. If a user picks KYC, hits an error, navigates back, and re-enters via a fallback path, only the first `SCAN_STARTED` fires.

## Out of scope

The KYC drilldown events from ANA-12 (`Kyc: Session Requested`, `Session Created`, `Provider Opened`, `Provider Closed`) for this same code path will be added once ANA-12 lands on dev. They're not addable here because `KycEvents` and `trackBranchEvent` don't exist yet on `dev`.

## Test plan

- [ ] Open the app fresh, country-pick, select the KYC tile on the IDPicker. Verify `Onboarding: Document Scan Started` fires once in dev Mixpanel with `branch: 'kyc'`, `initial_branch: 'kyc'`, `current_branch: 'kyc'`.
- [ ] Same flow, then complete KYC. Verify `Onboarding: Completed` fires with `used_fallback: false`.
- [ ] Sanity check: biometric→KYC fallback paths still fire SCAN_STARTED exactly once (no double-fire from this addition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added analytics tracking to measure KYC onboarding progression, enabling better insights into user journey through the verification process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->