### PR TITLE
scope sort-exports to public barrels across the monorepo

### DIFF
--- a/app/.eslintrc.cjs
+++ b/app/.eslintrc.cjs
@@ -68,12 +68,13 @@ module.exports = {
       },
     ],
 
-    // Export sorting
+    // Export sorting is off here. The rule reorders `export const`
+    // declarations, which breaks files with inter-export dependencies or
+    // intentional grouping. It's only safe on pure re-export barrels —
+    // none in this app, since it's leaf code consumed via Metro, not a
+    // published library.
 
-    'sort-exports/sort-exports': [
-      'error',
-      { sortDir: 'asc', ignoreCase: false, sortExportKindFirst: 'type' },
-    ],
+    'sort-exports/sort-exports': 'off',
 
     // Standard import rules
 
@@ -206,19 +207,6 @@ module.exports = {
         'no-console': 'off',
         'no-unused-vars': 'off',
         'import/no-unresolved': 'off',
-      },
-    },
-    {
-      // Disable export sorting for files with dependency issues
-      files: [
-        'src/components/navbar/BaseNavBar.tsx',
-        'src/navigation/index.tsx',
-        'src/providers/passportDataProvider.tsx',
-        'src/services/cloud-backup/helpers.ts',
-        'src/integrations/haptics/index.ts',
-      ],
-      rules: {
-        'sort-exports/sort-exports': 'off',
       },
     },
     {

--- a/app/tests/__setup__/selfClientProvider.ts
+++ b/app/tests/__setup__/selfClientProvider.ts
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1; Copyright (c) 2025 Social Connect Labs, Inc.; Licensed under BUSL-1.1 (see LICENSE); Apache-2.0 from 2029-06-11
 
-/* eslint-disable sort-exports/sort-exports */
-
 import type {
   AuthAdapter,
   CryptoAdapter,

--- a/common/.eslintrc.cjs
+++ b/common/.eslintrc.cjs
@@ -52,11 +52,11 @@ module.exports = {
       },
     ],
 
-    // Export sorting - using sort-exports for better type prioritization
-    'sort-exports/sort-exports': [
-      'error',
-      { sortDir: 'asc', ignoreCase: false, sortExportKindFirst: 'type' },
-    ],
+    // Export sorting is opt-in per file via overrides below. The rule
+    // reorders `export const` declarations, which breaks files with
+    // inter-export dependencies or intentional grouping. Only enable on
+    // pure re-export barrels.
+    'sort-exports/sort-exports': 'off',
 
     // Standard import rules
     'import/first': 'error',
@@ -92,6 +92,19 @@ module.exports = {
     ],
   },
   overrides: [
+    {
+      // Opt the public-API barrels into export sorting. These files exist
+      // only to re-export from other modules and have no inter-export
+      // dependencies, so alphabetical order is a clear win for scanability.
+      // Do not add source files here.
+      files: ['index.ts', 'src/types/index.ts', 'src/constants/index.ts', 'src/utils/index.ts'],
+      rules: {
+        'sort-exports/sort-exports': [
+          'error',
+          { sortDir: 'asc', ignoreCase: false, sortExportKindFirst: 'type' },
+        ],
+      },
+    },
     {
       files: ['*.cjs'],
       env: {

--- a/common/src/utils/aadhaar/constants.ts
+++ b/common/src/utils/aadhaar/constants.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-exports/sort-exports */
 export const MAX_FIELD_BYTE_SIZE = 31;
 export const NAME_MAX_LENGTH = 2 * MAX_FIELD_BYTE_SIZE; // 62 bytes
 export const TOTAL_REVEAL_DATA_LENGTH = 119;

--- a/packages/mobile-sdk-alpha/.eslintrc.cjs
+++ b/packages/mobile-sdk-alpha/.eslintrc.cjs
@@ -57,8 +57,11 @@ module.exports = {
         ],
       },
     ],
-    // Export sorting - using sort-exports for better type prioritization
-    'sort-exports/sort-exports': ['error', { sortDir: 'asc', ignoreCase: false, sortExportKindFirst: 'type' }],
+    // Export sorting is opt-in per file via overrides below. The rule
+    // reorders `export const` declarations, which breaks files with
+    // inter-export dependencies or intentional grouping. Only enable on
+    // pure re-export barrels.
+    'sort-exports/sort-exports': 'off',
 
     'import/first': 'error',
     'import/newline-after-import': 'error',
@@ -118,17 +121,13 @@ module.exports = {
       },
     },
     {
-      // Disable export sorting for type definition files to preserve logical grouping
-      files: ['src/types/**/*.ts'],
+      // Opt explicit public-API barrels into export sorting. These files exist
+      // only to re-export from other modules — no inter-export dependencies,
+      // no semantic grouping — so alphabetical order is a clear win for
+      // scanability. Do not add source files here.
+      files: ['src/index.ts', 'src/browser.ts'],
       rules: {
-        'sort-exports/sort-exports': 'off',
-      },
-    },
-    {
-      // Disable export sorting for files with dependency issues
-      files: ['src/haptic/index.ts'],
-      rules: {
-        'sort-exports/sort-exports': 'off',
+        'sort-exports/sort-exports': ['error', { sortDir: 'asc', ignoreCase: false, sortExportKindFirst: 'type' }],
       },
     },
     {

--- a/packages/mobile-sdk-alpha/tests/utils/testHelpers.ts
+++ b/packages/mobile-sdk-alpha/tests/utils/testHelpers.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
-/* eslint-disable sort-exports/sort-exports */
 import type { NavigationAdapter } from 'src/types/public';
 
 import type { CryptoAdapter, DocumentsAdapter, NetworkAdapter, NFCScannerAdapter } from '../../src';

--- a/packages/webview-app/.eslintrc.cjs
+++ b/packages/webview-app/.eslintrc.cjs
@@ -56,8 +56,11 @@ module.exports = {
         ],
       },
     ],
-    // Export sorting - using sort-exports for better type prioritization
-    'sort-exports/sort-exports': ['error', { sortDir: 'asc', ignoreCase: false, sortExportKindFirst: 'type' }],
+    // Export sorting is off here. The rule reorders `export const`
+    // declarations, which breaks files with inter-export dependencies or
+    // intentional grouping. It's only safe on pure re-export barrels —
+    // none in this app, since it's the WebView UI, not a published library.
+    'sort-exports/sort-exports': 'off',
 
     'import/first': 'error',
     'import/newline-after-import': 'error',

--- a/packages/webview-bridge/.eslintrc.cjs
+++ b/packages/webview-bridge/.eslintrc.cjs
@@ -50,8 +50,11 @@ module.exports = {
         ],
       },
     ],
-    // Export sorting - using sort-exports for better type prioritization
-    'sort-exports/sort-exports': ['error', { sortDir: 'asc', ignoreCase: false, sortExportKindFirst: 'type' }],
+    // Export sorting is opt-in per file via overrides below. The rule
+    // reorders `export const` declarations, which breaks files with
+    // inter-export dependencies or intentional grouping. Only enable on
+    // pure re-export barrels.
+    'sort-exports/sort-exports': 'off',
 
     'import/first': 'error',
     'import/newline-after-import': 'error',
@@ -75,6 +78,14 @@ module.exports = {
     'prettier/prettier': ['warn', {}, { usePrettierrc: true }],
   },
   overrides: [
+    {
+      // Opt the public-API barrels into export sorting. These files exist
+      // only to re-export from other modules. Do not add source files here.
+      files: ['src/index.ts', 'src/adapters/index.ts'],
+      rules: {
+        'sort-exports/sort-exports': ['error', { sortDir: 'asc', ignoreCase: false, sortExportKindFirst: 'type' }],
+      },
+    },
     {
       // Enable TypeScript project service for source files (required by consistent-type-exports)
       files: ['src/**/*.ts'],

--- a/sdk/qrcode/.eslintrc.cjs
+++ b/sdk/qrcode/.eslintrc.cjs
@@ -23,10 +23,11 @@ module.exports = {
   },
   rules: {
     'simple-import-sort/imports': 'error',
-    'sort-exports/sort-exports': [
-      'error',
-      { sortDir: 'asc', ignoreCase: false, sortExportKindFirst: 'type' },
-    ],
+    // Export sorting is opt-in per file via overrides below. The rule
+    // reorders `export const` declarations, which breaks files with
+    // inter-export dependencies or intentional grouping. Only enable on
+    // pure re-export barrels.
+    'sort-exports/sort-exports': 'off',
 
     'import/first': 'error',
     'import/no-duplicates': 'error',
@@ -34,6 +35,17 @@ module.exports = {
   },
   ignorePatterns: ['dist/', 'node_modules/'],
   overrides: [
+    {
+      // Opt the public-API barrel into export sorting. This file exists only
+      // to re-export from other modules. Do not add source files here.
+      files: ['index.ts'],
+      rules: {
+        'sort-exports/sort-exports': [
+          'error',
+          { sortDir: 'asc', ignoreCase: false, sortExportKindFirst: 'type' },
+        ],
+      },
+    },
     {
       files: ['*.cjs'],
       env: {


### PR DESCRIPTION
## Summary

- The `sort-exports/sort-exports` rule was running on every TS file across six packages, reordering `export const` declarations even when one export referenced another (TDZ ReferenceError) or when blank-line grouping carried meaning. Authors had been working around it with file-by-file overrides and inline `eslint-disable` comments — net dev burden, not net tidiness.
- Inverts the default: rule is now off everywhere, opted in only on pure re-export barrels (the files where alphabetical order is a clear win and there are no inter-export dependencies).
- Removes the accumulated workarounds: 7 file-by-file overrides across `app/` and `packages/mobile-sdk-alpha/`, plus 3 inline `eslint-disable sort-exports` comments.

## Changes

### Config/infra

- `packages/mobile-sdk-alpha/.eslintrc.cjs` — rule off; opt-in: `src/index.ts`, `src/browser.ts`. Removes overrides for `src/types/**/*.ts` and `src/haptic/index.ts`.
- `packages/webview-bridge/.eslintrc.cjs` — rule off; opt-in: `src/index.ts`, `src/adapters/index.ts`.
- `common/.eslintrc.cjs` — rule off; opt-in: `index.ts`, `src/{types,constants,utils}/index.ts`.
- `sdk/qrcode/.eslintrc.cjs` — rule off; opt-in: `index.ts`.
- `app/.eslintrc.cjs` — rule off, no opt-in (RN app, no public barrel). Removes 5 file-by-file disables.
- `packages/webview-app/.eslintrc.cjs` — rule off, no opt-in (WebView UI, not a library).

### React Native app

- `app/tests/__setup__/selfClientProvider.ts` — removed now-redundant inline disable.

### SDK core

- `packages/mobile-sdk-alpha/tests/utils/testHelpers.ts` — removed now-redundant inline disable.

### Common/shared

- `common/src/utils/aadhaar/constants.ts` — removed now-redundant inline disable.

## Test Plan

- [x] `yarn lint` green per-package (mobile-sdk-alpha, common, sdk/qrcode, webview-app, webview-bridge, app)
- [x] `yarn lint` green repo-wide
- [x] `yarn types` green per-package and repo-wide
- [ ] Spot-check one barrel file (e.g., `packages/mobile-sdk-alpha/src/index.ts`) still reports a sort violation when intentionally misordered, to confirm opt-in is wired correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ESLint export sorting configurations across the codebase to apply selectively to re-export modules while preserving intentional export grouping in other files, improving code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->