### PR TITLE
Improve iOS e2e prerequisite failure messaging

### DIFF
--- a/app/scripts/test-e2e-local.sh
+++ b/app/scripts/test-e2e-local.sh
@@ -169,6 +169,12 @@ run_maestro_tests() {
 
 
 shutdown_all_simulators() {
+    if ! command -v xcrun &> /dev/null; then
+        log_error "xcrun not found. iOS E2E tests require Xcode Command Line Tools."
+        echo "Install Xcode and run: xcode-select --install"
+        exit 1
+    fi
+
     log_info "🔌 Shutting down all running iOS simulators..."
     xcrun simctl shutdown all
     log_success "All simulators shut down"


### PR DESCRIPTION
### Motivation
- The local iOS E2E script failed with an opaque `xcrun: command not found` error when Xcode Command Line Tools were missing, causing confusing failure mode during test setup.

### Description
- Add a guard in `app/scripts/test-e2e-local.sh` inside `shutdown_all_simulators()` that checks for `xcrun` and prints a clear, actionable message (`xcode-select --install`) and exits early if the tool is missing.

### Testing
- Ran `yarn workspace @selfxyz/mobile-app test:e2e:ios` to reproduce the failure; it failed in this environment with `xcrun: command not found` (expected and reproduced the root cause). 
- Ran `bash -n app/scripts/test-e2e-local.sh` (syntax check) which passed after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a027446e830832d8e0616dda4fe2d06)