### PR TITLE
fix: USAT gate identity match, proof checkmark, ID details scroll

### DIFF
--- a/app/src/components/navbar/HomeNavBar.tsx
+++ b/app/src/components/navbar/HomeNavBar.tsx
@@ -56,7 +56,9 @@ export const HomeNavBar = (props: NativeStackHeaderProps) => {
         try {
           Clipboard.setString('');
         } catch {}
-        props.navigation.navigate('ProvingScreenRouter');
+        props.navigation.navigate('ProvingScreenRouter', {
+          entryPoint: 'qr_scan',
+        });
       } catch (error) {
         console.error('Error consuming token:', error);
         if (

--- a/app/src/hooks/useEarnPointsFlow.ts
+++ b/app/src/hooks/useEarnPointsFlow.ts
@@ -57,7 +57,9 @@ export const useEarnPointsFlow = ({
 
     // Use setTimeout to ensure modal dismisses before navigating
     setTimeout(() => {
-      navigation.navigate('ProvingScreenRouter');
+      navigation.navigate('ProvingScreenRouter', {
+        entryPoint: 'earn_points',
+      });
     }, 100);
   }, [selfClient, navigation]);
 

--- a/app/src/navigation/deeplinks.ts
+++ b/app/src/navigation/deeplinks.ts
@@ -100,9 +100,15 @@ const validateAndSanitizeParam = (
 const createDeeplinkNavigationState = (
   targetScreen: string,
   parentScreen: string = 'Home',
+  targetParams?: Record<string, unknown>,
 ) => ({
   index: 1, // Current screen index (targetScreen)
-  routes: [{ name: parentScreen }, { name: targetScreen }],
+  routes: [
+    { name: parentScreen },
+    targetParams
+      ? { name: targetScreen, params: targetParams }
+      : { name: targetScreen },
+  ],
 });
 
 // Store the correct parent screen determined by splash screen
@@ -148,6 +154,7 @@ export const handleUrl = async (selfClient: SelfClient, uri: string) => {
         createDeeplinkNavigationState(
           'ProvingScreenRouter',
           correctParentScreen,
+          { entryPoint: 'deeplink' },
         ),
       );
 
@@ -178,7 +185,13 @@ export const handleUrl = async (selfClient: SelfClient, uri: string) => {
     selfClient.getSelfAppState().startAppListener(sessionId);
 
     safeNavigate(
-      createDeeplinkNavigationState('ProvingScreenRouter', correctParentScreen),
+      createDeeplinkNavigationState(
+        'ProvingScreenRouter',
+        correctParentScreen,
+        {
+          entryPoint: 'deeplink',
+        },
+      ),
     );
   } else if (mock_passport) {
     try {

--- a/app/src/navigation/deeplinks.ts
+++ b/app/src/navigation/deeplinks.ts
@@ -274,11 +274,11 @@ const safeNavigate = (
   const isColdLaunch = currentRoute?.name === 'Splash';
 
   if (!isColdLaunch && targetScreen) {
+    const targetParams = navigationState.routes[1]?.params;
     // Use object syntax to satisfy TypeScript's strict typing for navigate
-    // The params will be undefined for screens that don't require them
     navigationRef.navigate({
       name: targetScreen,
-      params: undefined,
+      params: targetParams,
     } as Parameters<typeof navigationRef.navigate>[0]);
   } else {
     navigationRef.reset(navigationState);

--- a/app/src/navigation/types.ts
+++ b/app/src/navigation/types.ts
@@ -221,6 +221,7 @@ export type VerificationRoutesParamList = {
   DocumentSelectorForProving:
     | {
         documentType?: string;
+        entryPoint?: VerificationGateEntryPoint;
       }
     | undefined;
 };

--- a/app/src/navigation/types.ts
+++ b/app/src/navigation/types.ts
@@ -7,6 +7,7 @@ import type { DocumentCategory } from '@selfxyz/common/utils/types';
 import type { ModalNavigationParams } from '@/screens/app/ModalScreen';
 import type { WebViewScreenParams } from '@/screens/shared/WebViewScreen';
 import type { ProofHistory } from '@/stores/proofTypes';
+import type { VerificationGateEntryPoint } from '@/stores/verificationGateStore';
 
 // =============================================================================
 // Aadhaar Screens
@@ -214,7 +215,9 @@ export type VerificationRoutesParamList = {
         scrollOffset?: number;
       }
     | undefined;
-  ProvingScreenRouter: undefined;
+  ProvingScreenRouter: {
+    entryPoint: VerificationGateEntryPoint;
+  };
   DocumentSelectorForProving:
     | {
         documentType?: string;

--- a/app/src/screens/documents/management/IdDetailsScreen.tsx
+++ b/app/src/screens/documents/management/IdDetailsScreen.tsx
@@ -6,7 +6,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { Linking } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Button, Text, XStack, YStack, ZStack } from 'tamagui';
+import { Button, Text, XStack, YStack } from 'tamagui';
 import { useNavigation } from '@react-navigation/native';
 
 import type { DocumentCatalog, IDDocument } from '@selfxyz/common/utils/types';
@@ -142,8 +142,13 @@ const IdDetailsScreen: React.FC = () => {
     );
   }
 
+  const FLOATING_BUTTON_HEIGHT = 56;
+  const FLOATING_BUTTON_GAP = 16;
+  const floatingButtonClearance =
+    bottom + 20 + FLOATING_BUTTON_HEIGHT + FLOATING_BUTTON_GAP;
+
   const ListHeader = (
-    <YStack padding={20}>
+    <YStack padding={20} paddingBottom={0}>
       <IdCardLayout idDocument={document} selected={true} hidden={isHidden} />
       <XStack marginTop={'$3'} justifyContent="flex-start" gap={'$4'}>
         <Button
@@ -189,43 +194,44 @@ const IdDetailsScreen: React.FC = () => {
 
   return (
     <YStack flex={1} backgroundColor={slate50}>
-      {ListHeader}
-      <ZStack flex={1}>
-        <ProofHistoryList documentId={documentId} />
-        <LinearGradient
-          colors={['transparent', slate50]}
-          style={{
-            position: 'absolute',
-            bottom: 0,
-            left: 0,
-            right: 0,
-            height: 100,
-          }}
-          pointerEvents="none"
-        />
-        <YStack position="absolute" bottom={bottom + 20} left={20} right={20}>
-          <Button
-            backgroundColor={isConnected ? slate100 : white}
-            color={isConnected ? slate500 : '#2463EB'}
-            borderColor={isConnected ? slate300 : slate100}
-            borderWidth={1}
-            borderRadius={'$3'}
-            height={'$5'}
-            fontSize={17}
-            elevation={4}
-            shadowColor={black}
-            shadowOffset={{ width: 0, height: 2 }}
-            shadowOpacity={0.1}
-            shadowRadius={4}
-            fontWeight="bold"
-            opacity={isConnected ? 0.8 : 1}
-            disabled={isConnected}
-            onPress={handleConnectId}
-          >
-            {isConnected ? 'ID Connected' : 'Connect ID'}
-          </Button>
-        </YStack>
-      </ZStack>
+      <ProofHistoryList
+        documentId={documentId}
+        ListHeaderComponent={ListHeader}
+        contentBottomPadding={floatingButtonClearance}
+      />
+      <LinearGradient
+        colors={['transparent', slate50]}
+        style={{
+          position: 'absolute',
+          bottom: 0,
+          left: 0,
+          right: 0,
+          height: 100,
+        }}
+        pointerEvents="none"
+      />
+      <YStack position="absolute" bottom={bottom + 20} left={20} right={20}>
+        <Button
+          backgroundColor={isConnected ? slate100 : white}
+          color={isConnected ? slate500 : '#2463EB'}
+          borderColor={isConnected ? slate300 : slate100}
+          borderWidth={1}
+          borderRadius={'$3'}
+          height={'$5'}
+          fontSize={17}
+          elevation={4}
+          shadowColor={black}
+          shadowOffset={{ width: 0, height: 2 }}
+          shadowOpacity={0.1}
+          shadowRadius={4}
+          fontWeight="bold"
+          opacity={isConnected ? 0.8 : 1}
+          disabled={isConnected}
+          onPress={handleConnectId}
+        >
+          {isConnected ? 'ID Connected' : 'Connect ID'}
+        </Button>
+      </YStack>
     </YStack>
   );
 };

--- a/app/src/screens/home/ProofHistoryList.tsx
+++ b/app/src/screens/home/ProofHistoryList.tsx
@@ -51,10 +51,16 @@ const TIME_PERIODS = {
 
 interface ProofHistoryListProps {
   documentId: string;
+  ListHeaderComponent?: React.ComponentProps<
+    typeof SectionList
+  >['ListHeaderComponent'];
+  contentBottomPadding?: number;
 }
 
 export const ProofHistoryList: React.FC<ProofHistoryListProps> = ({
   documentId,
+  ListHeaderComponent,
+  contentBottomPadding,
 }) => {
   const {
     proofHistory,
@@ -391,10 +397,14 @@ export const ProofHistoryList: React.FC<ProofHistoryListProps> = ({
       }
       contentContainerStyle={[
         styles.listContent,
+        contentBottomPadding !== undefined && {
+          paddingBottom: contentBottomPadding,
+        },
         groupedProofs.length === 0 && styles.emptyList,
       ]}
       showsVerticalScrollIndicator={false}
       stickySectionHeadersEnabled={false}
+      ListHeaderComponent={ListHeaderComponent}
       ListEmptyComponent={renderEmptyComponent}
       ListFooterComponent={renderFooter}
       initialNumToRender={10}

--- a/app/src/screens/verification/DocumentSelectorForProvingScreen.tsx
+++ b/app/src/screens/verification/DocumentSelectorForProvingScreen.tsx
@@ -30,6 +30,7 @@ import {
   isDocumentValidForProving,
   useSelfClient,
 } from '@selfxyz/mobile-sdk-alpha';
+import { ProofEvents } from '@selfxyz/mobile-sdk-alpha/constants/analytics';
 import { black, white } from '@selfxyz/mobile-sdk-alpha/constants/colors';
 import { dinot } from '@selfxyz/mobile-sdk-alpha/constants/fonts';
 
@@ -47,7 +48,9 @@ import {
 import { useSelfAppData } from '@/hooks/useSelfAppData';
 import type { RootStackParamList } from '@/navigation';
 import { usePassport } from '@/providers/passportDataProvider';
+import { useVerificationGateStore } from '@/stores/verificationGateStore';
 import { getDocumentTypeName } from '@/utils/documentUtils';
+import { evaluateGoogleUsatGateForDocument } from '@/utils/googleUsatGate';
 
 function getDocumentDisplayName(
   metadata: DocumentMetadata,
@@ -113,6 +116,7 @@ const DocumentSelectorForProvingScreen: React.FC = () => {
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const route =
     useRoute<RouteProp<RootStackParamList, 'DocumentSelectorForProving'>>();
+  const entryPoint = route.params?.entryPoint ?? 'qr_scan';
   const selfClient = useSelfClient();
   const { useSelfAppStore } = selfClient;
   const selfApp = useSelfAppStore(state => state.selfApp);
@@ -289,6 +293,26 @@ const DocumentSelectorForProvingScreen: React.FC = () => {
     setSubmitting(true);
     setError(null);
     try {
+      if (selfApp) {
+        const gate = await evaluateGoogleUsatGateForDocument(
+          selfClient,
+          selfApp,
+          selectedDocumentId,
+        );
+        if (gate === 'block') {
+          selfClient.trackEvent(ProofEvents.GOOGLE_USAT_BLOCKED, {
+            entry_point: entryPoint,
+            reason: 'no_high_security_doc',
+          });
+          useVerificationGateStore.getState().open({
+            reason: 'google_usat_high_security_required',
+            entryPoint,
+            requesterName: selfApp.appName,
+          });
+          setSheetOpen(false);
+          return;
+        }
+      }
       await setSelectedDocument(selectedDocumentId);
       setSheetOpen(false); // Close the sheet first
       navigation.navigate('Prove', { scrollOffset: scrollOffsetRef.current });
@@ -304,6 +328,9 @@ const DocumentSelectorForProvingScreen: React.FC = () => {
     submitting,
     setSelectedDocument,
     navigation,
+    selfApp,
+    selfClient,
+    entryPoint,
   ]);
 
   const handleApprove = async () => {
@@ -314,6 +341,25 @@ const DocumentSelectorForProvingScreen: React.FC = () => {
     setSubmitting(true);
     setError(null);
     try {
+      if (selfApp) {
+        const gate = await evaluateGoogleUsatGateForDocument(
+          selfClient,
+          selfApp,
+          selectedDocumentId,
+        );
+        if (gate === 'block') {
+          selfClient.trackEvent(ProofEvents.GOOGLE_USAT_BLOCKED, {
+            entry_point: entryPoint,
+            reason: 'no_high_security_doc',
+          });
+          useVerificationGateStore.getState().open({
+            reason: 'google_usat_high_security_required',
+            entryPoint,
+            requesterName: selfApp.appName,
+          });
+          return;
+        }
+      }
       await setSelectedDocument(selectedDocumentId);
       navigation.navigate('Prove', { scrollOffset: scrollOffsetRef.current });
     } catch (selectionError) {

--- a/app/src/screens/verification/ProofRequestStatusScreen.tsx
+++ b/app/src/screens/verification/ProofRequestStatusScreen.tsx
@@ -386,6 +386,13 @@ const SuccessScreen: React.FC = () => {
         backgroundColor={black}
       >
         <DelayedLottieView
+          key={
+            animationSource === succesAnimation
+              ? 'success'
+              : animationSource === failAnimation
+                ? 'fail'
+                : 'loading'
+          }
           autoPlay
           loop={animationSource === loadingAnimation}
           source={animationSource}

--- a/app/src/screens/verification/ProvingScreenRouter.tsx
+++ b/app/src/screens/verification/ProvingScreenRouter.tsx
@@ -28,7 +28,10 @@ import { usePassport } from '@/providers/passportDataProvider';
 import { useSettingStore } from '@/stores/settingStore';
 import { useVerificationGateStore } from '@/stores/verificationGateStore';
 import { getDocumentTypeName } from '@/utils/documentUtils';
-import { evaluateGoogleUsatGate } from '@/utils/googleUsatGate';
+import {
+  evaluateGoogleUsatGate,
+  evaluateGoogleUsatGateForDocument,
+} from '@/utils/googleUsatGate';
 
 /**
  * Router screen for the proving flow that decides whether to skip the document selector.
@@ -146,6 +149,25 @@ const ProvingScreenRouter: React.FC = () => {
         const docToSelect = pickBestDocumentToSelect(catalog, docs);
         if (docToSelect) {
           try {
+            const selectedDocGate = await evaluateGoogleUsatGateForDocument(
+              selfClient,
+              selfApp,
+              docToSelect,
+            );
+            if (selectedDocGate === 'block') {
+              selfClient.trackEvent(ProofEvents.GOOGLE_USAT_BLOCKED, {
+                entry_point: entryPoint,
+                reason: 'no_high_security_doc',
+              });
+              useVerificationGateStore.getState().open({
+                reason: 'google_usat_high_security_required',
+                entryPoint,
+                requesterName: selfApp.appName,
+              });
+              selfClient.getSelfAppState().cleanSelfApp();
+              navigation.goBack();
+              return;
+            }
             await setSelectedDocument(docToSelect);
             navigation.replace('Prove');
           } catch (selectError) {
@@ -154,18 +176,21 @@ const ProvingScreenRouter: React.FC = () => {
             hasRoutedRef.current = false;
             navigation.replace('DocumentSelectorForProving', {
               documentType,
+              entryPoint,
             });
           }
         } else {
           // No valid document to select, show selector
           navigation.replace('DocumentSelectorForProving', {
             documentType,
+            entryPoint,
           });
         }
       } else {
         // Show the document selector
         navigation.replace('DocumentSelectorForProving', {
           documentType,
+          entryPoint,
         });
       }
     } catch (loadError) {

--- a/app/src/screens/verification/ProvingScreenRouter.tsx
+++ b/app/src/screens/verification/ProvingScreenRouter.tsx
@@ -11,7 +11,9 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import {
   isDocumentValidForProving,
   pickBestDocumentToSelect,
+  useSelfClient,
 } from '@selfxyz/mobile-sdk-alpha';
+import { ProofEvents } from '@selfxyz/mobile-sdk-alpha/constants/analytics';
 import { black } from '@selfxyz/mobile-sdk-alpha/constants/colors';
 import { dinot } from '@selfxyz/mobile-sdk-alpha/constants/fonts';
 
@@ -19,7 +21,9 @@ import { proofRequestColors } from '@/components/proof-request';
 import type { RootStackParamList } from '@/navigation';
 import { usePassport } from '@/providers/passportDataProvider';
 import { useSettingStore } from '@/stores/settingStore';
+import { useVerificationGateStore } from '@/stores/verificationGateStore';
 import { getDocumentTypeName } from '@/utils/documentUtils';
+import { evaluateGoogleUsatGate } from '@/utils/googleUsatGate';
 
 /**
  * Router screen for the proving flow that decides whether to skip the document selector.
@@ -35,6 +39,9 @@ import { getDocumentTypeName } from '@/utils/documentUtils';
 const ProvingScreenRouter: React.FC = () => {
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const selfClient = useSelfClient();
+  const { useSelfAppStore } = selfClient;
+  const selfApp = useSelfAppStore(state => state.selfApp);
   const { loadDocumentCatalog, getAllDocuments, setSelectedDocument } =
     usePassport();
   const { skipDocumentSelector } = useSettingStore();
@@ -53,7 +60,42 @@ const ProvingScreenRouter: React.FC = () => {
       return;
     }
 
+    // For sessionId-only entries, selfApp arrives asynchronously over the
+    // websocket. Wait for it before evaluating the Google USAT gate so we don't
+    // navigate past the gate prematurely.
+    if (!selfApp) {
+      return;
+    }
+
     setError(null);
+
+    try {
+      const gate = await evaluateGoogleUsatGate(selfClient, selfApp);
+      if (controller.signal.aborted) {
+        return;
+      }
+      if (gate === 'block') {
+        hasRoutedRef.current = true;
+        selfClient.trackEvent(ProofEvents.GOOGLE_USAT_BLOCKED, {
+          entry_point: 'qr_scan',
+          reason: 'no_high_security_doc',
+        });
+        useVerificationGateStore.getState().open({
+          reason: 'google_usat_high_security_required',
+          entryPoint: 'qr_scan',
+          requesterName: selfApp.appName,
+        });
+        selfClient.getSelfAppState().cleanSelfApp();
+        navigation.goBack();
+        return;
+      }
+    } catch (gateError) {
+      if (controller.signal.aborted) {
+        return;
+      }
+      console.warn('Google USAT gate evaluation failed:', gateError);
+    }
+
     try {
       const catalog = await loadDocumentCatalog();
       const docs = await getAllDocuments();
@@ -132,6 +174,8 @@ const ProvingScreenRouter: React.FC = () => {
     getAllDocuments,
     loadDocumentCatalog,
     navigation,
+    selfApp,
+    selfClient,
     setSelectedDocument,
     skipDocumentSelector,
   ]);

--- a/app/src/screens/verification/ProvingScreenRouter.tsx
+++ b/app/src/screens/verification/ProvingScreenRouter.tsx
@@ -5,7 +5,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ActivityIndicator } from 'react-native';
 import { Text, View } from 'tamagui';
-import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import type { RouteProp } from '@react-navigation/native';
+import {
+  useFocusEffect,
+  useNavigation,
+  useRoute,
+} from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import {
@@ -39,6 +44,9 @@ import { evaluateGoogleUsatGate } from '@/utils/googleUsatGate';
 const ProvingScreenRouter: React.FC = () => {
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const route =
+    useRoute<RouteProp<RootStackParamList, 'ProvingScreenRouter'>>();
+  const { entryPoint } = route.params;
   const selfClient = useSelfClient();
   const { useSelfAppStore } = selfClient;
   const selfApp = useSelfAppStore(state => state.selfApp);
@@ -77,12 +85,12 @@ const ProvingScreenRouter: React.FC = () => {
       if (gate === 'block') {
         hasRoutedRef.current = true;
         selfClient.trackEvent(ProofEvents.GOOGLE_USAT_BLOCKED, {
-          entry_point: 'qr_scan',
+          entry_point: entryPoint,
           reason: 'no_high_security_doc',
         });
         useVerificationGateStore.getState().open({
           reason: 'google_usat_high_security_required',
-          entryPoint: 'qr_scan',
+          entryPoint,
           requesterName: selfApp.appName,
         });
         selfClient.getSelfAppState().cleanSelfApp();
@@ -176,6 +184,7 @@ const ProvingScreenRouter: React.FC = () => {
     navigation,
     selfApp,
     selfClient,
+    entryPoint,
     setSelectedDocument,
     skipDocumentSelector,
   ]);

--- a/app/src/screens/verification/QRCodeViewFinderScreen.tsx
+++ b/app/src/screens/verification/QRCodeViewFinderScreen.tsx
@@ -50,7 +50,12 @@ const QRCodeViewFinderScreen: React.FC = () => {
   const isFocused = useIsFocused();
   const [doneScanningQR, setDoneScanningQR] = useState(false);
   const { top: safeAreaTop } = useSafeAreaInsets();
-  const navigateToDocumentSelector = useHapticNavigation('ProvingScreenRouter');
+  const navigateToDocumentSelector = useHapticNavigation(
+    'ProvingScreenRouter',
+    {
+      params: { entryPoint: 'qr_scan' },
+    },
+  );
 
   // This resets to the default state when we navigate back to this screen
   useFocusEffect(

--- a/app/src/utils/googleUsatGate.ts
+++ b/app/src/utils/googleUsatGate.ts
@@ -32,10 +32,10 @@ export async function evaluateGoogleUsatGate(
     // retrieval failure must not permanently block the proof session.
     return 'allow';
   }
-  const hasHighSecurityDoc = Object.values(docs).some(
-    doc => doc.data.documentCategory !== 'kyc',
+  const hasEligibleDoc = Object.values(docs).some(
+    doc => doc.data.documentCategory !== 'kyc' && doc.data.mock !== true,
   );
-  return hasHighSecurityDoc ? 'allow' : 'block';
+  return hasEligibleDoc ? 'allow' : 'block';
 }
 
 function shouldTreatAsGoogleUsat(app: SelfApp): boolean {

--- a/app/src/utils/googleUsatGate.ts
+++ b/app/src/utils/googleUsatGate.ts
@@ -32,10 +32,29 @@ export async function evaluateGoogleUsatGate(
     // retrieval failure must not permanently block the proof session.
     return 'allow';
   }
-  const hasEligibleDoc = Object.values(docs).some(
-    doc => doc.data.documentCategory !== 'kyc' && doc.data.mock !== true,
-  );
-  return hasEligibleDoc ? 'allow' : 'block';
+  let selectedDocumentId: string | undefined;
+  try {
+    const catalog = await selfClient.loadDocumentCatalog();
+    selectedDocumentId = catalog.selectedDocumentId;
+  } catch {
+    // Fail open to match the same UX-only guard behavior on transient failures.
+    return 'allow';
+  }
+
+  if (!selectedDocumentId) {
+    return 'block';
+  }
+
+  const selectedDocument = docs[selectedDocumentId];
+  if (!selectedDocument) {
+    return 'block';
+  }
+
+  const isEligibleSelectedDoc =
+    selectedDocument.data.documentCategory !== 'kyc' &&
+    selectedDocument.data.mock !== true;
+
+  return isEligibleSelectedDoc ? 'allow' : 'block';
 }
 
 function shouldTreatAsGoogleUsat(app: SelfApp): boolean {

--- a/app/src/utils/googleUsatGate.ts
+++ b/app/src/utils/googleUsatGate.ts
@@ -3,6 +3,7 @@
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
 import type { SelfApp } from '@selfxyz/common/utils';
+import type { DocumentCategory } from '@selfxyz/common/utils/types';
 import {
   getAllDocuments,
   isGoogleUsatProofRequest,
@@ -11,6 +12,9 @@ import {
 
 export type GoogleUsatGateResult = 'allow' | 'block';
 export const FORCE_GOOGLE_USAT_FOR_TESTING = false;
+type GoogleUsatEligibleDocumentCategory = 'passport' | 'id_card';
+const GOOGLE_USAT_ALLOWED_DOCUMENT_CATEGORIES: ReadonlySet<DocumentCategory> =
+  new Set(['passport', 'id_card']);
 
 export function isGoogleUsatForceEnabledForTesting(): boolean {
   return __DEV__ && FORCE_GOOGLE_USAT_FOR_TESTING;
@@ -24,14 +28,6 @@ export async function evaluateGoogleUsatGate(
     return 'allow';
   }
 
-  let docs: Awaited<ReturnType<typeof getAllDocuments>>;
-  try {
-    docs = await getAllDocuments(selfClient);
-  } catch {
-    // Fail open: this gate is a UX guard, not a security boundary. A transient
-    // retrieval failure must not permanently block the proof session.
-    return 'allow';
-  }
   let selectedDocumentId: string | undefined;
   try {
     const catalog = await selfClient.loadDocumentCatalog();
@@ -42,17 +38,39 @@ export async function evaluateGoogleUsatGate(
   }
 
   if (!selectedDocumentId) {
-    return 'block';
+    // Defer document eligibility checks to explicit document selection
+    // chokepoints when no stored selection exists yet.
+    return 'allow';
   }
 
-  const selectedDocument = docs[selectedDocumentId];
-  if (!selectedDocument) {
+  return evaluateGoogleUsatGateForDocument(selfClient, app, selectedDocumentId);
+}
+
+export async function evaluateGoogleUsatGateForDocument(
+  selfClient: SelfClient,
+  app: SelfApp,
+  documentId: string,
+): Promise<GoogleUsatGateResult> {
+  if (!shouldTreatAsGoogleUsat(app)) {
+    return 'allow';
+  }
+
+  let docs: Awaited<ReturnType<typeof getAllDocuments>>;
+  try {
+    docs = await getAllDocuments(selfClient);
+  } catch {
+    return 'allow';
+  }
+
+  const documentToEvaluate = docs[documentId];
+  if (!documentToEvaluate) {
     return 'block';
   }
 
   const isEligibleSelectedDoc =
-    selectedDocument.data.documentCategory !== 'kyc' &&
-    selectedDocument.data.mock !== true;
+    isGoogleUsatEligibleDocumentCategory(
+      documentToEvaluate.data.documentCategory,
+    ) && documentToEvaluate.data.mock !== true;
 
   return isEligibleSelectedDoc ? 'allow' : 'block';
 }
@@ -62,4 +80,10 @@ function shouldTreatAsGoogleUsat(app: SelfApp): boolean {
     return true;
   }
   return isGoogleUsatProofRequest(app);
+}
+
+function isGoogleUsatEligibleDocumentCategory(
+  category: DocumentCategory,
+): category is GoogleUsatEligibleDocumentCategory {
+  return GOOGLE_USAT_ALLOWED_DOCUMENT_CATEGORIES.has(category);
 }

--- a/app/tests/src/hooks/useEarnPointsFlow.test.ts
+++ b/app/tests/src/hooks/useEarnPointsFlow.test.ts
@@ -286,7 +286,9 @@ describe('useEarnPointsFlow', () => {
         jest.advanceTimersByTime(100);
       });
 
-      expect(mockNavigate).toHaveBeenCalledWith('ProvingScreenRouter');
+      expect(mockNavigate).toHaveBeenCalledWith('ProvingScreenRouter', {
+        entryPoint: 'earn_points',
+      });
     });
 
     it('should clear referrer when points disclosure modal is dismissed with referrer', async () => {

--- a/app/tests/src/navigation/deeplinks.test.ts
+++ b/app/tests/src/navigation/deeplinks.test.ts
@@ -106,7 +106,10 @@ describe('deeplinks', () => {
       const { navigationRef } = require('@/navigation');
       expect(navigationRef.reset).toHaveBeenCalledWith({
         index: 1,
-        routes: [{ name: 'Home' }, { name: 'ProvingScreenRouter' }],
+        routes: [
+          { name: 'Home' },
+          { name: 'ProvingScreenRouter', params: { entryPoint: 'deeplink' } },
+        ],
       });
     });
 
@@ -132,7 +135,10 @@ describe('deeplinks', () => {
       const { navigationRef } = require('@/navigation');
       expect(navigationRef.reset).toHaveBeenCalledWith({
         index: 1,
-        routes: [{ name: 'Home' }, { name: 'ProvingScreenRouter' }],
+        routes: [
+          { name: 'Home' },
+          { name: 'ProvingScreenRouter', params: { entryPoint: 'deeplink' } },
+        ],
       });
     });
 

--- a/app/tests/src/navigation/deeplinks.test.ts
+++ b/app/tests/src/navigation/deeplinks.test.ts
@@ -142,6 +142,33 @@ describe('deeplinks', () => {
       });
     });
 
+    it('preserves ProvingScreenRouter params on warm launch navigation', async () => {
+      const url = 'scheme://open?sessionId=123';
+      const mockCleanSelfApp = jest.fn();
+      const mockStartAppListener = jest.fn();
+      const { navigationRef } = require('@/navigation');
+      navigationRef.getCurrentRoute.mockReturnValue({ name: 'Home' });
+
+      await handleUrl(
+        {
+          getSelfAppState: () => ({
+            setSelfApp: jest.fn(),
+            startAppListener: mockStartAppListener,
+            cleanSelfApp: mockCleanSelfApp,
+          }),
+        } as unknown as SelfClient,
+        url,
+      );
+
+      expect(mockCleanSelfApp).toHaveBeenCalledWith();
+      expect(mockStartAppListener).toHaveBeenCalledWith('123');
+      expect(navigationRef.navigate).toHaveBeenCalledWith({
+        name: 'ProvingScreenRouter',
+        params: { entryPoint: 'deeplink' },
+      });
+      expect(navigationRef.reset).not.toHaveBeenCalled();
+    });
+
     it('handles mock_passport parameter', async () => {
       const mockData = { name: 'John', surname: 'Doe' };
       const url = `scheme://open?mock_passport=${encodeURIComponent(JSON.stringify(mockData))}`;

--- a/app/tests/src/screens/documents/management/IdDetailsScreen.test.tsx
+++ b/app/tests/src/screens/documents/management/IdDetailsScreen.test.tsx
@@ -104,7 +104,11 @@ jest.mock('@/components/homescreen/IdCard', () => ({
 }));
 
 jest.mock('@/screens/home/ProofHistoryList', () => ({
-  ProofHistoryList: () => <mock-stack testID="proof-history" />,
+  ProofHistoryList: ({ ListHeaderComponent }: { ListHeaderComponent?: React.ReactNode }) => (
+    <mock-stack testID="proof-history">
+      {ListHeaderComponent ?? null}
+    </mock-stack>
+  ),
 }));
 
 jest.mock('@/providers/passportDataProvider', () => ({

--- a/app/tests/src/screens/documents/management/IdDetailsScreen.test.tsx
+++ b/app/tests/src/screens/documents/management/IdDetailsScreen.test.tsx
@@ -104,7 +104,11 @@ jest.mock('@/components/homescreen/IdCard', () => ({
 }));
 
 jest.mock('@/screens/home/ProofHistoryList', () => ({
-  ProofHistoryList: ({ ListHeaderComponent }: { ListHeaderComponent?: React.ReactNode }) => (
+  ProofHistoryList: ({
+    ListHeaderComponent,
+  }: {
+    ListHeaderComponent?: React.ReactNode;
+  }) => (
     <mock-stack testID="proof-history">
       {ListHeaderComponent ?? null}
     </mock-stack>

--- a/app/tests/src/screens/verification/DocumentSelectorForProvingScreen.test.tsx
+++ b/app/tests/src/screens/verification/DocumentSelectorForProvingScreen.test.tsx
@@ -18,6 +18,8 @@ import {
 
 import { usePassport } from '@/providers/passportDataProvider';
 import { DocumentSelectorForProvingScreen } from '@/screens/verification/DocumentSelectorForProvingScreen';
+import { useVerificationGateStore } from '@/stores/verificationGateStore';
+import { evaluateGoogleUsatGateForDocument } from '@/utils/googleUsatGate';
 
 // Mock useFocusEffect to behave like useEffect in tests
 // Note: We use a closure-based approach to avoid requiring React (prevents OOM per test-memory-optimization rules)
@@ -61,6 +63,16 @@ jest.mock('@/providers/passportDataProvider', () => ({
   usePassport: jest.fn(),
 }));
 
+jest.mock('@/utils/googleUsatGate', () => ({
+  evaluateGoogleUsatGateForDocument: jest.fn(),
+}));
+
+jest.mock('@/stores/verificationGateStore', () => ({
+  useVerificationGateStore: {
+    getState: jest.fn(),
+  },
+}));
+
 const mockUseNavigation = useNavigation as jest.MockedFunction<
   typeof useNavigation
 >;
@@ -75,6 +87,13 @@ const mockIsDocumentValidForProving =
     typeof isDocumentValidForProving
   >;
 const mockUsePassport = usePassport as jest.MockedFunction<typeof usePassport>;
+const mockEvaluateGoogleUsatGateForDocument =
+  evaluateGoogleUsatGateForDocument as jest.MockedFunction<
+    typeof evaluateGoogleUsatGateForDocument
+  >;
+const mockUseVerificationGateStore = useVerificationGateStore as unknown as {
+  getState: jest.Mock;
+};
 
 type MockDocumentEntry = {
   metadata: DocumentMetadata;
@@ -136,6 +155,8 @@ const mockNavigate = jest.fn();
 const mockLoadDocumentCatalog = jest.fn();
 const mockGetAllDocuments = jest.fn();
 const mockSetSelectedDocument = jest.fn();
+const mockTrackEvent = jest.fn();
+const mockGateOpen = jest.fn();
 
 // Stable passport context to prevent infinite re-renders
 const stablePassportContext = {
@@ -157,6 +178,7 @@ const stableSelfAppSelector = (
 // Stable self client object
 const stableSelfClient = {
   useSelfAppStore: stableSelfAppSelector,
+  trackEvent: mockTrackEvent,
 };
 
 describe('DocumentSelectorForProvingScreen', () => {
@@ -168,6 +190,10 @@ describe('DocumentSelectorForProvingScreen', () => {
     mockUseSelfClient.mockReturnValue(stableSelfClient as any);
 
     mockUsePassport.mockReturnValue(stablePassportContext as any);
+    mockEvaluateGoogleUsatGateForDocument.mockResolvedValue('allow');
+    mockUseVerificationGateStore.getState.mockReturnValue({
+      open: mockGateOpen,
+    });
 
     mockIsDocumentValidForProving.mockImplementation(
       (_metadata, documentData) =>
@@ -389,6 +415,67 @@ describe('DocumentSelectorForProvingScreen', () => {
         expect(mockSetSelectedDocument).toHaveBeenCalledWith('doc-1');
         expect(mockNavigate).toHaveBeenCalledWith('Prove', expect.any(Object));
       });
+    });
+
+    it('blocks approval when selected document is not USAT-eligible', async () => {
+      const passport = createMetadata({
+        id: 'doc-1',
+        documentType: 'us',
+        documentCategory: 'passport',
+        isRegistered: true,
+      });
+      const kyc = createMetadata({
+        id: 'doc-2',
+        documentType: 'drivers_licence',
+        documentCategory: 'kyc',
+        isRegistered: true,
+      });
+      const catalog: DocumentCatalog = {
+        documents: [passport, kyc],
+        selectedDocumentId: 'doc-2',
+      };
+
+      mockLoadDocumentCatalog.mockResolvedValue(catalog);
+      mockGetAllDocuments.mockResolvedValue(
+        createAllDocuments([
+          createDocumentEntry(passport),
+          createDocumentEntry(kyc),
+        ]),
+      );
+      mockEvaluateGoogleUsatGateForDocument.mockResolvedValue('block');
+
+      const { getByTestId } = render(<DocumentSelectorForProvingScreen />);
+
+      await waitFor(() => {
+        expect(
+          getByTestId('document-selector-action-bar-approve').props.disabled,
+        ).toBe(false);
+      });
+
+      fireEvent.press(getByTestId('document-selector-action-bar-approve'));
+
+      await waitFor(() => {
+        expect(mockEvaluateGoogleUsatGateForDocument).toHaveBeenCalled();
+      });
+      expect(mockSetSelectedDocument).not.toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalledWith(
+        'Prove',
+        expect.any(Object),
+      );
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          entry_point: 'qr_scan',
+          reason: 'no_high_security_doc',
+        }),
+      );
+      expect(mockGateOpen).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: 'google_usat_high_security_required',
+          entryPoint: 'qr_scan',
+          requesterName: 'Example App',
+        }),
+      );
     });
   });
 

--- a/app/tests/src/screens/verification/ProvingScreenRouter.test.tsx
+++ b/app/tests/src/screens/verification/ProvingScreenRouter.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useRoute } from '@react-navigation/native';
 import { render, waitFor } from '@testing-library/react-native';
 
 import type {
@@ -13,11 +13,13 @@ import type {
 import {
   isDocumentValidForProving,
   pickBestDocumentToSelect,
+  useSelfClient,
 } from '@selfxyz/mobile-sdk-alpha';
 
 import { usePassport } from '@/providers/passportDataProvider';
 import { ProvingScreenRouter } from '@/screens/verification/ProvingScreenRouter';
 import { useSettingStore } from '@/stores/settingStore';
+import { evaluateGoogleUsatGate } from '@/utils/googleUsatGate';
 
 // Mock useFocusEffect to behave like useEffect in tests
 // Note: We use jest.requireActual for React to avoid nested require() which causes OOM in CI
@@ -26,6 +28,7 @@ jest.mock('@react-navigation/native', () => {
   const ReactActual = jest.requireActual('react');
   return {
     ...actual,
+    useRoute: jest.fn(() => ({ params: { entryPoint: 'qr_scan' } })),
     useFocusEffect: (callback: () => void) => {
       ReactActual.useEffect(() => {
         callback();
@@ -37,6 +40,7 @@ jest.mock('@react-navigation/native', () => {
 jest.mock('@selfxyz/mobile-sdk-alpha', () => ({
   isDocumentValidForProving: jest.fn(),
   pickBestDocumentToSelect: jest.fn(),
+  useSelfClient: jest.fn(),
 }));
 
 jest.mock('@/providers/passportDataProvider', () => ({
@@ -47,13 +51,21 @@ jest.mock('@/stores/settingStore', () => ({
   useSettingStore: jest.fn(),
 }));
 
+jest.mock('@/utils/googleUsatGate', () => ({
+  evaluateGoogleUsatGate: jest.fn(),
+}));
+
 const mockUseNavigation = useNavigation as jest.MockedFunction<
   typeof useNavigation
 >;
+const mockUseRoute = useRoute as jest.MockedFunction<typeof useRoute>;
 const mockIsDocumentValidForProving =
   isDocumentValidForProving as jest.MockedFunction<
     typeof isDocumentValidForProving
   >;
+const mockUseSelfClient = useSelfClient as jest.MockedFunction<
+  typeof useSelfClient
+>;
 const mockPickBestDocumentToSelect =
   pickBestDocumentToSelect as jest.MockedFunction<
     typeof pickBestDocumentToSelect
@@ -62,10 +74,15 @@ const mockUsePassport = usePassport as jest.MockedFunction<typeof usePassport>;
 const mockUseSettingStore = useSettingStore as jest.MockedFunction<
   typeof useSettingStore
 >;
+const mockEvaluateGoogleUsatGate =
+  evaluateGoogleUsatGate as jest.MockedFunction<typeof evaluateGoogleUsatGate>;
 const mockReplace = jest.fn();
 const mockLoadDocumentCatalog = jest.fn();
 const mockGetAllDocuments = jest.fn();
 const mockSetSelectedDocument = jest.fn();
+const mockTrackEvent = jest.fn();
+const mockCleanSelfApp = jest.fn();
+const mockSelfApp = { appName: 'Test App' };
 
 type MockDocumentEntry = {
   metadata: DocumentMetadata;
@@ -113,6 +130,17 @@ describe('ProvingScreenRouter', () => {
     jest.clearAllMocks();
 
     mockUseNavigation.mockReturnValue({ replace: mockReplace } as any);
+    mockUseRoute.mockReturnValue({ params: { entryPoint: 'qr_scan' } } as any);
+    mockUseSelfClient.mockReturnValue({
+      useSelfAppStore: (
+        selector: (state: { selfApp: { appName: string } }) => unknown,
+      ) => selector({ selfApp: mockSelfApp }),
+      trackEvent: mockTrackEvent,
+      getSelfAppState: () => ({
+        cleanSelfApp: mockCleanSelfApp,
+      }),
+    } as any);
+    mockEvaluateGoogleUsatGate.mockResolvedValue('allow');
 
     mockUsePassport.mockReturnValue({
       loadDocumentCatalog: mockLoadDocumentCatalog,

--- a/app/tests/src/screens/verification/ProvingScreenRouter.test.tsx
+++ b/app/tests/src/screens/verification/ProvingScreenRouter.test.tsx
@@ -19,7 +19,10 @@ import {
 import { usePassport } from '@/providers/passportDataProvider';
 import { ProvingScreenRouter } from '@/screens/verification/ProvingScreenRouter';
 import { useSettingStore } from '@/stores/settingStore';
-import { evaluateGoogleUsatGate } from '@/utils/googleUsatGate';
+import {
+  evaluateGoogleUsatGate,
+  evaluateGoogleUsatGateForDocument,
+} from '@/utils/googleUsatGate';
 
 // Mock useFocusEffect to behave like useEffect in tests
 // Note: We use jest.requireActual for React to avoid nested require() which causes OOM in CI
@@ -53,6 +56,7 @@ jest.mock('@/stores/settingStore', () => ({
 
 jest.mock('@/utils/googleUsatGate', () => ({
   evaluateGoogleUsatGate: jest.fn(),
+  evaluateGoogleUsatGateForDocument: jest.fn(),
 }));
 
 const mockUseNavigation = useNavigation as jest.MockedFunction<
@@ -76,6 +80,10 @@ const mockUseSettingStore = useSettingStore as jest.MockedFunction<
 >;
 const mockEvaluateGoogleUsatGate =
   evaluateGoogleUsatGate as jest.MockedFunction<typeof evaluateGoogleUsatGate>;
+const mockEvaluateGoogleUsatGateForDocument =
+  evaluateGoogleUsatGateForDocument as jest.MockedFunction<
+    typeof evaluateGoogleUsatGateForDocument
+  >;
 const mockReplace = jest.fn();
 const mockLoadDocumentCatalog = jest.fn();
 const mockGetAllDocuments = jest.fn();
@@ -141,6 +149,7 @@ describe('ProvingScreenRouter', () => {
       }),
     } as any);
     mockEvaluateGoogleUsatGate.mockResolvedValue('allow');
+    mockEvaluateGoogleUsatGateForDocument.mockResolvedValue('allow');
 
     mockUsePassport.mockReturnValue({
       loadDocumentCatalog: mockLoadDocumentCatalog,
@@ -238,6 +247,7 @@ describe('ProvingScreenRouter', () => {
     await waitFor(() => {
       expect(mockReplace).toHaveBeenCalledWith('DocumentSelectorForProving', {
         documentType: 'Passport',
+        entryPoint: 'qr_scan',
       });
     });
   });
@@ -317,6 +327,7 @@ describe('ProvingScreenRouter', () => {
     await waitFor(() => {
       expect(mockReplace).toHaveBeenCalledWith('DocumentSelectorForProving', {
         documentType: 'Passport',
+        entryPoint: 'qr_scan',
       });
     });
 
@@ -351,6 +362,7 @@ describe('ProvingScreenRouter', () => {
       expect(mockSetSelectedDocument).toHaveBeenCalledWith('doc-1');
       expect(mockReplace).toHaveBeenCalledWith('DocumentSelectorForProving', {
         documentType: 'Passport',
+        entryPoint: 'qr_scan',
       });
     });
   });

--- a/app/tests/src/utils/googleUsatGate.test.ts
+++ b/app/tests/src/utils/googleUsatGate.test.ts
@@ -56,8 +56,11 @@ describe('evaluateGoogleUsatGate', () => {
     );
   });
 
-  it('blocks Google USAT when catalog is empty', async () => {
+  it('blocks Google USAT when selected document is not found in docs', async () => {
     mockIsGoogleUsatProofRequest.mockReturnValue(true);
+    selfClient.loadDocumentCatalog.mockResolvedValue({
+      selectedDocumentId: 'missing',
+    });
     mockGetAllDocuments.mockResolvedValue({});
     await expect(evaluateGoogleUsatGate(selfClient, app)).resolves.toBe(
       'block',
@@ -119,11 +122,25 @@ describe('evaluateGoogleUsatGate', () => {
     );
   });
 
-  it('blocks Google USAT when no selected document exists', async () => {
+  it('allows Google USAT when no selected document exists and defers to downstream selection checks', async () => {
     mockIsGoogleUsatProofRequest.mockReturnValue(true);
     selfClient.loadDocumentCatalog.mockResolvedValue({});
     mockGetAllDocuments.mockResolvedValue({
       a: { data: { documentCategory: 'passport', mock: false } } as any,
+    });
+    await expect(evaluateGoogleUsatGate(selfClient, app)).resolves.toBe(
+      'allow',
+    );
+  });
+
+  it('blocks Google USAT when selected document is aadhaar', async () => {
+    mockIsGoogleUsatProofRequest.mockReturnValue(true);
+    selfClient.loadDocumentCatalog.mockResolvedValue({
+      selectedDocumentId: 'a',
+    });
+    mockGetAllDocuments.mockResolvedValue({
+      a: { data: { documentCategory: 'aadhaar', mock: false } } as any,
+      b: { data: { documentCategory: 'passport', mock: false } } as any,
     });
     await expect(evaluateGoogleUsatGate(selfClient, app)).resolves.toBe(
       'block',
@@ -132,6 +149,9 @@ describe('evaluateGoogleUsatGate', () => {
 
   it('fails open when getAllDocuments throws', async () => {
     mockIsGoogleUsatProofRequest.mockReturnValue(true);
+    selfClient.loadDocumentCatalog.mockResolvedValue({
+      selectedDocumentId: 'a',
+    });
     mockGetAllDocuments.mockRejectedValue(new Error('network down'));
     await expect(evaluateGoogleUsatGate(selfClient, app)).resolves.toBe(
       'allow',

--- a/app/tests/src/utils/googleUsatGate.test.ts
+++ b/app/tests/src/utils/googleUsatGate.test.ts
@@ -26,6 +26,9 @@ const mockIsGoogleUsatProofRequest =
   >;
 
 describe('evaluateGoogleUsatGate', () => {
+  const selfClient = {
+    loadDocumentCatalog: jest.fn(),
+  } as any;
   const app = {
     sessionId: 'session-id',
     endpointType: 'celo',
@@ -37,13 +40,14 @@ describe('evaluateGoogleUsatGate', () => {
     jest.clearAllMocks();
     mockIsGoogleUsatProofRequest.mockReturnValue(false);
     mockGetAllDocuments.mockResolvedValue({});
+    selfClient.loadDocumentCatalog.mockResolvedValue({});
   });
 
   it('treats non Google USAT requests according to the force-test toggle', async () => {
     // While FORCE_GOOGLE_USAT_FOR_TESTING is on, every request is gated as if
     // it were a USAT request, so an empty doc catalog blocks. When the toggle
     // is removed, this should allow without consulting the catalog.
-    const result = await evaluateGoogleUsatGate({} as any, app);
+    const result = await evaluateGoogleUsatGate(selfClient, app);
     const expected = FORCE_GOOGLE_USAT_FOR_TESTING ? 'block' : 'allow';
     const expectedGetAllDocumentsCalls = FORCE_GOOGLE_USAT_FOR_TESTING ? 1 : 0;
     expect(result).toBe(expected);
@@ -55,40 +59,83 @@ describe('evaluateGoogleUsatGate', () => {
   it('blocks Google USAT when catalog is empty', async () => {
     mockIsGoogleUsatProofRequest.mockReturnValue(true);
     mockGetAllDocuments.mockResolvedValue({});
-    await expect(evaluateGoogleUsatGate({} as any, app)).resolves.toBe('block');
+    await expect(evaluateGoogleUsatGate(selfClient, app)).resolves.toBe(
+      'block',
+    );
   });
 
-  it('allows Google USAT when a real non-kyc doc exists', async () => {
+  it('allows Google USAT when selected document is real and non-kyc', async () => {
     mockIsGoogleUsatProofRequest.mockReturnValue(true);
+    selfClient.loadDocumentCatalog.mockResolvedValue({
+      selectedDocumentId: 'b',
+    });
     mockGetAllDocuments.mockResolvedValue({
       a: { data: { documentCategory: 'kyc', mock: false } } as any,
       b: { data: { documentCategory: 'passport', mock: false } } as any,
     });
-    await expect(evaluateGoogleUsatGate({} as any, app)).resolves.toBe('allow');
+    await expect(evaluateGoogleUsatGate(selfClient, app)).resolves.toBe(
+      'allow',
+    );
   });
 
-  it('blocks Google USAT when the only non-kyc doc is a mock', async () => {
+  it('blocks Google USAT when selected document is kyc even if another real non-kyc exists', async () => {
     mockIsGoogleUsatProofRequest.mockReturnValue(true);
+    selfClient.loadDocumentCatalog.mockResolvedValue({
+      selectedDocumentId: 'a',
+    });
     mockGetAllDocuments.mockResolvedValue({
       a: { data: { documentCategory: 'kyc', mock: false } } as any,
-      b: { data: { documentCategory: 'passport', mock: true } } as any,
+      b: { data: { documentCategory: 'passport', mock: false } } as any,
     });
-    await expect(evaluateGoogleUsatGate({} as any, app)).resolves.toBe('block');
+    await expect(evaluateGoogleUsatGate(selfClient, app)).resolves.toBe(
+      'block',
+    );
   });
 
-  it('blocks Google USAT when every doc is kyc or mock', async () => {
+  it('blocks Google USAT when selected non-kyc document is a mock', async () => {
     mockIsGoogleUsatProofRequest.mockReturnValue(true);
+    selfClient.loadDocumentCatalog.mockResolvedValue({
+      selectedDocumentId: 'b',
+    });
     mockGetAllDocuments.mockResolvedValue({
       a: { data: { documentCategory: 'kyc', mock: false } } as any,
       b: { data: { documentCategory: 'id_card', mock: true } } as any,
     });
-    await expect(evaluateGoogleUsatGate({} as any, app)).resolves.toBe('block');
+    await expect(evaluateGoogleUsatGate(selfClient, app)).resolves.toBe(
+      'block',
+    );
+  });
+
+  it('blocks Google USAT when selected document is missing from loaded docs', async () => {
+    mockIsGoogleUsatProofRequest.mockReturnValue(true);
+    selfClient.loadDocumentCatalog.mockResolvedValue({
+      selectedDocumentId: 'missing',
+    });
+    mockGetAllDocuments.mockResolvedValue({
+      a: { data: { documentCategory: 'passport', mock: false } } as any,
+    });
+    await expect(evaluateGoogleUsatGate(selfClient, app)).resolves.toBe(
+      'block',
+    );
+  });
+
+  it('blocks Google USAT when no selected document exists', async () => {
+    mockIsGoogleUsatProofRequest.mockReturnValue(true);
+    selfClient.loadDocumentCatalog.mockResolvedValue({});
+    mockGetAllDocuments.mockResolvedValue({
+      a: { data: { documentCategory: 'passport', mock: false } } as any,
+    });
+    await expect(evaluateGoogleUsatGate(selfClient, app)).resolves.toBe(
+      'block',
+    );
   });
 
   it('fails open when getAllDocuments throws', async () => {
     mockIsGoogleUsatProofRequest.mockReturnValue(true);
     mockGetAllDocuments.mockRejectedValue(new Error('network down'));
-    await expect(evaluateGoogleUsatGate({} as any, app)).resolves.toBe('allow');
+    await expect(evaluateGoogleUsatGate(selfClient, app)).resolves.toBe(
+      'allow',
+    );
   });
 
   it('exposes testing force toggle', () => {

--- a/app/tests/src/utils/googleUsatGate.test.ts
+++ b/app/tests/src/utils/googleUsatGate.test.ts
@@ -58,13 +58,31 @@ describe('evaluateGoogleUsatGate', () => {
     await expect(evaluateGoogleUsatGate({} as any, app)).resolves.toBe('block');
   });
 
-  it('allows Google USAT when non-kyc doc exists', async () => {
+  it('allows Google USAT when a real non-kyc doc exists', async () => {
     mockIsGoogleUsatProofRequest.mockReturnValue(true);
     mockGetAllDocuments.mockResolvedValue({
-      a: { data: { documentCategory: 'kyc' } } as any,
-      b: { data: { documentCategory: 'passport' } } as any,
+      a: { data: { documentCategory: 'kyc', mock: false } } as any,
+      b: { data: { documentCategory: 'passport', mock: false } } as any,
     });
     await expect(evaluateGoogleUsatGate({} as any, app)).resolves.toBe('allow');
+  });
+
+  it('blocks Google USAT when the only non-kyc doc is a mock', async () => {
+    mockIsGoogleUsatProofRequest.mockReturnValue(true);
+    mockGetAllDocuments.mockResolvedValue({
+      a: { data: { documentCategory: 'kyc', mock: false } } as any,
+      b: { data: { documentCategory: 'passport', mock: true } } as any,
+    });
+    await expect(evaluateGoogleUsatGate({} as any, app)).resolves.toBe('block');
+  });
+
+  it('blocks Google USAT when every doc is kyc or mock', async () => {
+    mockIsGoogleUsatProofRequest.mockReturnValue(true);
+    mockGetAllDocuments.mockResolvedValue({
+      a: { data: { documentCategory: 'kyc', mock: false } } as any,
+      b: { data: { documentCategory: 'id_card', mock: true } } as any,
+    });
+    await expect(evaluateGoogleUsatGate({} as any, app)).resolves.toBe('block');
   });
 
   it('fails open when getAllDocuments throws', async () => {

--- a/packages/mobile-sdk-alpha/src/browser.ts
+++ b/packages/mobile-sdk-alpha/src/browser.ts
@@ -48,7 +48,11 @@ export type { SelfApp, SelfAppDisclosureConfig } from '@selfxyz/common';
 export type { SelfAppState } from './stores/selfAppStore';
 
 export type { WebAnalyticsOptions } from './adapters/browser';
-export { GOOGLE_USAT_FAUCET_VERIFIERS } from './constants/googleUsat';
+export {
+  GOOGLE_USAT_FAUCET_APP_NAME,
+  GOOGLE_USAT_FAUCET_ENDPOINT,
+  GOOGLE_USAT_FAUCET_SCOPE,
+} from './constants/googleUsat';
 export {
   InitError,
   LivenessError,

--- a/packages/mobile-sdk-alpha/src/constants/googleUsat.ts
+++ b/packages/mobile-sdk-alpha/src/constants/googleUsat.ts
@@ -3,7 +3,7 @@
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
 export const GOOGLE_USAT_FAUCET_ENDPOINT =
-  'https://cw3-selfxyz-bridge-625632552981.us-central1.run.app/api/verify/api/verify';
+  'https://cw3-selfxyz-bridge-625632552981.us-central1.run.app/api/verify';
 
 export const GOOGLE_USAT_FAUCET_SCOPE = 'celo-mainnet-tether-usat';
 

--- a/packages/mobile-sdk-alpha/src/constants/googleUsat.ts
+++ b/packages/mobile-sdk-alpha/src/constants/googleUsat.ts
@@ -2,20 +2,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
-// Declaration order matters: GOOGLE_USAT_FAUCET_VERIFIERS references the
-// chain ID and verifier consts at module-load time. Keep those declared
-// above the map or the initializer hits a TDZ ReferenceError. Do not let
-// a sort-exports lint rule reorder this file.
-export const CELO_MAINNET_CHAIN_ID = 42220;
-export const CELO_SEPOLIA_CHAIN_ID = 11142220;
+export const GOOGLE_USAT_FAUCET_ENDPOINT =
+  'https://cw3-selfxyz-bridge-625632552981.us-central1.run.app/api/verify/api/verify';
 
-export const GOOGLE_USAT_MAINNET_VERIFIER = '0xc04157590b07914bcdd665f6a62cc220ab0ddec5';
+export const GOOGLE_USAT_FAUCET_SCOPE = 'celo-mainnet-tether-usat';
 
-export const GOOGLE_USAT_SEPOLIA_VERIFIER = '0x5df9232ad9fdbf425cc1087e5396456ca6976299';
-
-// Verifier contract addresses are public, lowercased, and chain-scoped.
-// Update entries when verifier contracts are redeployed.
-export const GOOGLE_USAT_FAUCET_VERIFIERS: Readonly<Record<number, ReadonlySet<string>>> = {
-  [CELO_MAINNET_CHAIN_ID]: new Set<string>([GOOGLE_USAT_MAINNET_VERIFIER]),
-  [CELO_SEPOLIA_CHAIN_ID]: new Set<string>([GOOGLE_USAT_SEPOLIA_VERIFIER]),
-};
+export const GOOGLE_USAT_FAUCET_APP_NAME = 'Google Cloud Web3 Portal';

--- a/packages/mobile-sdk-alpha/src/constants/googleUsat.ts
+++ b/packages/mobile-sdk-alpha/src/constants/googleUsat.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
-export const GOOGLE_USAT_FAUCET_ENDPOINT =
-  'https://cw3-selfxyz-bridge-625632552981.us-central1.run.app/api/verify';
+export const GOOGLE_USAT_FAUCET_ENDPOINT = 'https://cw3-selfxyz-bridge-625632552981.us-central1.run.app/api/verify';
 
 export const GOOGLE_USAT_FAUCET_SCOPE = 'celo-mainnet-tether-usat';
 

--- a/packages/mobile-sdk-alpha/src/index.ts
+++ b/packages/mobile-sdk-alpha/src/index.ts
@@ -67,7 +67,11 @@ export type { provingMachineCircuitType } from './proving/provingMachine';
 export { DelayedLottieView } from './components/DelayedLottieView';
 
 export { ExpandableBottomLayout } from './layouts/ExpandableBottomLayout';
-export { GOOGLE_USAT_FAUCET_VERIFIERS } from './constants/googleUsat';
+export {
+  GOOGLE_USAT_FAUCET_APP_NAME,
+  GOOGLE_USAT_FAUCET_ENDPOINT,
+  GOOGLE_USAT_FAUCET_SCOPE,
+} from './constants/googleUsat';
 
 export {
   InitError,

--- a/packages/mobile-sdk-alpha/src/utils/googleUsat.ts
+++ b/packages/mobile-sdk-alpha/src/utils/googleUsat.ts
@@ -4,16 +4,31 @@
 
 import type { SelfApp } from '@selfxyz/common/utils';
 
-import { GOOGLE_USAT_FAUCET_VERIFIERS } from '../constants/googleUsat';
+import {
+  GOOGLE_USAT_FAUCET_APP_NAME,
+  GOOGLE_USAT_FAUCET_ENDPOINT,
+  GOOGLE_USAT_FAUCET_SCOPE,
+} from '../constants/googleUsat';
+
+export interface GoogleUsatFaucetIdentity {
+  endpoint: string;
+  scope: string;
+  appName: string;
+}
+
+export const GOOGLE_USAT_FAUCET_IDENTITY: GoogleUsatFaucetIdentity = {
+  endpoint: GOOGLE_USAT_FAUCET_ENDPOINT,
+  scope: GOOGLE_USAT_FAUCET_SCOPE,
+  appName: GOOGLE_USAT_FAUCET_APP_NAME,
+};
 
 export function isGoogleUsatProofRequest(
   app: SelfApp,
-  verifiers: Readonly<Record<number, ReadonlySet<string>>> = GOOGLE_USAT_FAUCET_VERIFIERS,
+  identity: GoogleUsatFaucetIdentity = GOOGLE_USAT_FAUCET_IDENTITY,
 ): boolean {
-  if (app.endpointType !== 'celo' && app.endpointType !== 'staging_celo') return false;
-
-  const chainVerifiers = verifiers[app.chainID];
-  if (!chainVerifiers || chainVerifiers.size === 0) return false;
-
-  return chainVerifiers.has(app.endpoint.toLowerCase());
+  return (
+    app.endpoint?.trim().toLowerCase() === identity.endpoint.toLowerCase() &&
+    app.scope === identity.scope &&
+    app.appName === identity.appName
+  );
 }

--- a/packages/mobile-sdk-alpha/tests/utils/googleUsat.test.ts
+++ b/packages/mobile-sdk-alpha/tests/utils/googleUsat.test.ts
@@ -39,46 +39,28 @@ describe('isGoogleUsatProofRequest', () => {
   });
 
   it('returns false when appName differs', () => {
-    expect(
-      isGoogleUsatProofRequest(buildApp({ appName: 'Some Other App' })),
-    ).toBe(false);
+    expect(isGoogleUsatProofRequest(buildApp({ appName: 'Some Other App' }))).toBe(false);
   });
 
   it('returns false when scope differs', () => {
-    expect(
-      isGoogleUsatProofRequest(buildApp({ scope: 'some-other-scope' })),
-    ).toBe(false);
+    expect(isGoogleUsatProofRequest(buildApp({ scope: 'some-other-scope' }))).toBe(false);
   });
 
   it('returns false when endpoint differs', () => {
-    expect(
-      isGoogleUsatProofRequest(
-        buildApp({ endpoint: 'https://example.com/api/verify' }),
-      ),
-    ).toBe(false);
+    expect(isGoogleUsatProofRequest(buildApp({ endpoint: 'https://example.com/api/verify' }))).toBe(false);
   });
 
   it('is case-insensitive on the endpoint host and tolerates surrounding whitespace', () => {
     const variant = ` ${GOOGLE_USAT_FAUCET_ENDPOINT.toUpperCase()} `;
-    expect(isGoogleUsatProofRequest(buildApp({ endpoint: variant }))).toBe(
-      true,
-    );
+    expect(isGoogleUsatProofRequest(buildApp({ endpoint: variant }))).toBe(true);
   });
 
   it('requires exact scope match (case-sensitive)', () => {
-    expect(
-      isGoogleUsatProofRequest(
-        buildApp({ scope: GOOGLE_USAT_FAUCET_SCOPE.toUpperCase() }),
-      ),
-    ).toBe(false);
+    expect(isGoogleUsatProofRequest(buildApp({ scope: GOOGLE_USAT_FAUCET_SCOPE.toUpperCase() }))).toBe(false);
   });
 
   it('requires exact appName match (case-sensitive)', () => {
-    expect(
-      isGoogleUsatProofRequest(
-        buildApp({ appName: GOOGLE_USAT_FAUCET_APP_NAME.toUpperCase() }),
-      ),
-    ).toBe(false);
+    expect(isGoogleUsatProofRequest(buildApp({ appName: GOOGLE_USAT_FAUCET_APP_NAME.toUpperCase() }))).toBe(false);
   });
 
   it('accepts a custom identity override', () => {

--- a/packages/mobile-sdk-alpha/tests/utils/googleUsat.test.ts
+++ b/packages/mobile-sdk-alpha/tests/utils/googleUsat.test.ts
@@ -5,33 +5,18 @@
 import type { SelfApp } from '@selfxyz/common/utils';
 
 import {
-  CELO_MAINNET_CHAIN_ID,
-  CELO_SEPOLIA_CHAIN_ID,
-  GOOGLE_USAT_FAUCET_VERIFIERS,
-  GOOGLE_USAT_MAINNET_VERIFIER,
-  GOOGLE_USAT_SEPOLIA_VERIFIER,
+  GOOGLE_USAT_FAUCET_APP_NAME,
+  GOOGLE_USAT_FAUCET_ENDPOINT,
+  GOOGLE_USAT_FAUCET_SCOPE,
 } from '../../src/constants/googleUsat';
 import { isGoogleUsatProofRequest } from '../../src/utils/googleUsat';
 
-const MAINNET_ADDRESS = '0x0000000000000000000000000000000000000001';
-const TESTNET_ADDRESS = '0x0000000000000000000000000000000000000002';
-
-const testVerifiers: Readonly<Record<number, ReadonlySet<string>>> = {
-  42220: new Set<string>([MAINNET_ADDRESS]),
-  11142220: new Set<string>([TESTNET_ADDRESS]),
-};
-
-const emptyVerifiers: Readonly<Record<number, ReadonlySet<string>>> = {
-  42220: new Set<string>([]),
-  11142220: new Set<string>([]),
-};
-
-function buildApp(overrides: Partial<SelfApp>): SelfApp {
+function buildApp(overrides: Partial<SelfApp> = {}): SelfApp {
   return {
-    appName: 'Test App',
+    appName: GOOGLE_USAT_FAUCET_APP_NAME,
     logoBase64: '',
-    scope: 'test-scope',
-    endpoint: MAINNET_ADDRESS,
+    scope: GOOGLE_USAT_FAUCET_SCOPE,
+    endpoint: GOOGLE_USAT_FAUCET_ENDPOINT,
     endpointType: 'celo',
     header: 'Test Header',
     userId: 'user-id',
@@ -49,98 +34,68 @@ function buildApp(overrides: Partial<SelfApp>): SelfApp {
 }
 
 describe('isGoogleUsatProofRequest', () => {
-  it('returns false for https endpointType', () => {
-    const app = buildApp({
-      endpointType: 'https',
-      endpoint: `https://example.com/${MAINNET_ADDRESS}`,
-    });
-
-    expect(isGoogleUsatProofRequest(app, testVerifiers)).toBe(false);
+  it('matches when endpoint, scope, and appName all match the faucet identity', () => {
+    expect(isGoogleUsatProofRequest(buildApp())).toBe(true);
   });
 
-  it('returns false when celo address is not in the set', () => {
-    const app = buildApp({ endpoint: '0x0000000000000000000000000000000000000011' });
-
-    expect(isGoogleUsatProofRequest(app, testVerifiers)).toBe(false);
+  it('returns false when appName differs', () => {
+    expect(
+      isGoogleUsatProofRequest(buildApp({ appName: 'Some Other App' })),
+    ).toBe(false);
   });
 
-  it('returns true when celo address is in mainnet set and chainID is 42220', () => {
-    const app = buildApp({ endpointType: 'celo', endpoint: MAINNET_ADDRESS, chainID: 42220 });
-
-    expect(isGoogleUsatProofRequest(app, testVerifiers)).toBe(true);
+  it('returns false when scope differs', () => {
+    expect(
+      isGoogleUsatProofRequest(buildApp({ scope: 'some-other-scope' })),
+    ).toBe(false);
   });
 
-  it('returns false for cross-chain mismatch', () => {
-    const app = buildApp({ endpointType: 'celo', endpoint: MAINNET_ADDRESS, chainID: 11142220 });
-
-    expect(isGoogleUsatProofRequest(app, testVerifiers)).toBe(false);
+  it('returns false when endpoint differs', () => {
+    expect(
+      isGoogleUsatProofRequest(
+        buildApp({ endpoint: 'https://example.com/api/verify' }),
+      ),
+    ).toBe(false);
   });
 
-  it('returns true when staging_celo address is in testnet set', () => {
-    const app = buildApp({ endpointType: 'staging_celo', endpoint: TESTNET_ADDRESS, chainID: 11142220 });
-
-    expect(isGoogleUsatProofRequest(app, testVerifiers)).toBe(true);
+  it('is case-insensitive on the endpoint host and tolerates surrounding whitespace', () => {
+    const variant = ` ${GOOGLE_USAT_FAUCET_ENDPOINT.toUpperCase()} `;
+    expect(isGoogleUsatProofRequest(buildApp({ endpoint: variant }))).toBe(
+      true,
+    );
   });
 
-  it('matches mixed-case addresses against lowercased entries', () => {
-    const app = buildApp({ endpointType: 'celo', endpoint: MAINNET_ADDRESS.toUpperCase(), chainID: 42220 });
-
-    expect(isGoogleUsatProofRequest(app, testVerifiers)).toBe(true);
+  it('requires exact scope match (case-sensitive)', () => {
+    expect(
+      isGoogleUsatProofRequest(
+        buildApp({ scope: GOOGLE_USAT_FAUCET_SCOPE.toUpperCase() }),
+      ),
+    ).toBe(false);
   });
 
-  it('returns false when both sets are empty', () => {
-    const app = buildApp({ endpointType: 'celo', endpoint: MAINNET_ADDRESS, chainID: 42220 });
-
-    expect(isGoogleUsatProofRequest(app, emptyVerifiers)).toBe(false);
+  it('requires exact appName match (case-sensitive)', () => {
+    expect(
+      isGoogleUsatProofRequest(
+        buildApp({ appName: GOOGLE_USAT_FAUCET_APP_NAME.toUpperCase() }),
+      ),
+    ).toBe(false);
   });
 
-  it('returns false when chainID is missing', () => {
-    const app = buildApp({
-      endpointType: 'celo',
-      endpoint: MAINNET_ADDRESS,
-      chainID: undefined,
-    });
-
-    expect(isGoogleUsatProofRequest(app, testVerifiers)).toBe(false);
-  });
-
-  describe('with default GOOGLE_USAT_FAUCET_VERIFIERS', () => {
-    it('matches the deployed mainnet verifier on Celo', () => {
-      const app = buildApp({
-        endpointType: 'celo',
-        endpoint: GOOGLE_USAT_MAINNET_VERIFIER,
-        chainID: CELO_MAINNET_CHAIN_ID,
-      });
-
-      expect(isGoogleUsatProofRequest(app)).toBe(true);
-    });
-
-    it('matches the deployed testnet verifier on Celo Sepolia', () => {
-      const app = buildApp({
-        endpointType: 'staging_celo',
-        endpoint: GOOGLE_USAT_SEPOLIA_VERIFIER,
-        chainID: CELO_SEPOLIA_CHAIN_ID,
-      });
-
-      expect(isGoogleUsatProofRequest(app)).toBe(true);
-    });
-
-    it('rejects testnet verifier address on mainnet chainID', () => {
-      const app = buildApp({
-        endpointType: 'celo',
-        endpoint: GOOGLE_USAT_SEPOLIA_VERIFIER,
-        chainID: CELO_MAINNET_CHAIN_ID,
-      });
-
-      expect(isGoogleUsatProofRequest(app)).toBe(false);
-    });
-
-    it('stores all verifier addresses lowercased', () => {
-      for (const addresses of Object.values(GOOGLE_USAT_FAUCET_VERIFIERS)) {
-        for (const address of addresses) {
-          expect(address).toBe(address.toLowerCase());
-        }
-      }
-    });
+  it('accepts a custom identity override', () => {
+    const identity = {
+      endpoint: 'https://override.example/api',
+      scope: 'override-scope',
+      appName: 'Override App',
+    };
+    expect(
+      isGoogleUsatProofRequest(
+        buildApp({
+          endpoint: identity.endpoint,
+          scope: identity.scope,
+          appName: identity.appName,
+        }),
+        identity,
+      ),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Rework the Google USAT faucet detection from chain ID + verifier contract address matching to endpoint + scope + appName matching. The previous approach matched on the verifier contract — shared infrastructure that only fires on the `celo` endpoint type, wrong axis, and inert against the live `https`/relayer flow Google actually uses.
- Restrict the USAT eligibility gate to an allowlist of biometric/NFC document categories (`passport`, `id_card`) and enforce it at the actual selection chokepoints. The prior denylist (`documentCategory !== 'kyc'`) silently allowed Aadhaar, and a single upfront check could be bypassed by changing the document in the selector after the gate ran.
- Fix the missing green checkmark animation after successful proof verification. `DelayedLottieView` only calls `.play()` once on mount, so the `loading → success` source swap on `ProofRequestStatusScreen` never started the new animation. Force-remount via `key` tied to the active source.
- Fix the ID Details screen so the proof history is reachable. With the Eligible Perks card added, the static header consumed most of the viewport and left the `SectionList` with a sliver under the floating "Connect ID" pill. Hoist the header into `ListHeaderComponent` so the whole screen scrolls as one column.
- Plumb `entryPoint` through navigation params so warm-launch deeplinks and selector navigation preserve attribution.

## Changes

### SDK core (`packages/mobile-sdk-alpha`)

- Replace `GOOGLE_USAT_FAUCET_VERIFIERS` / `CELO_*_CHAIN_ID` / `GOOGLE_USAT_*_VERIFIER` constants with `GOOGLE_USAT_FAUCET_ENDPOINT`, `GOOGLE_USAT_FAUCET_SCOPE`, and `GOOGLE_USAT_FAUCET_APP_NAME`.
- Rewrite `isGoogleUsatProofRequest` to match the identity tuple (case-insensitive on endpoint, exact on scope/appName) and accept a `GoogleUsatFaucetIdentity` override for testing.
- Update `index.ts` / `browser.ts` exports. `GOOGLE_USAT_FAUCET_VERIFIERS` is removed (breaking change in `@selfxyz/mobile-sdk-alpha@0.0.1-alpha.1`, no remaining in-repo consumers).
- Replace the existing test suite with coverage for the new identity-tuple matcher (case sensitivity, whitespace tolerance, custom identity override).

### USAT gate (`app/src/utils/googleUsatGate.ts`)

- Switch eligibility from a `kyc` denylist to an allowlist of `passport` and `id_card`. Aadhaar and any future `DocumentCategory` value default to blocked.
- Add `evaluateGoogleUsatGateForDocument(selfClient, app, documentId)` as the authoritative per-document check. Takes an explicit document ID rather than reading stored `selectedDocumentId`, so it can be called against the doc that is actually about to be proven.
- Defer enforcement in the upfront `evaluateGoogleUsatGate` when no `selectedDocumentId` is set (return `allow`), so a valid passport reached via `pickBestDocumentToSelect` isn't preempted before the per-document gate runs.
- Keep mock-document rejection (`mock !== true`) and the testing force toggle behavior unchanged.

### React Native app (`app/`)

- `screens/verification/ProvingScreenRouter.tsx`: re-evaluate the gate against `docToSelect` returned by `pickBestDocumentToSelect` immediately before `setSelectedDocument`, so auto-select can't fall through to a non-biometric doc.
- `screens/verification/DocumentSelectorForProvingScreen.tsx`: re-evaluate the gate against the user's chosen document in both `handleConfirm` and `handleApprove` before `setSelectedDocument`, closing the selector bypass where a user could switch from a biometric doc to KYC after the upfront gate passed. On block, fires the existing `ProofEvents.GOOGLE_USAT_BLOCKED` analytics event and opens the verification-gate modal.
- `navigation/types.ts` + `screens/verification/ProvingScreenRouter.tsx` + `DocumentSelectorForProvingScreen.tsx`: thread an `entryPoint` param through `DocumentSelectorForProving` route params so analytics aren't under-attributed when the selector is reached from non-QR entries. Selector defaults to `'qr_scan'` when the param is absent.
- `navigation/deeplinks.ts`: preserve `entryPoint` on warm-launch deeplinks.
- `screens/verification/ProofRequestStatusScreen.tsx`: add `key` derived from the active animation source (`loading` / `success` / `fail`) so `DelayedLottieView` remounts on source change, re-firing the delayed `.play()` call. Restores the green checkmark on success and the fail animation on failure/timeout.
- `screens/documents/management/IdDetailsScreen.tsx`: collapse the static-header + constrained-list split into a single scrolling `SectionList`. Header content (ID card, View/Manage buttons, Eligible Perks card) is passed via `ListHeaderComponent`. Floating Connect/ID Connected pill stays absolute-positioned with the list's bottom padding computed from `safe-area inset + pill height + gap`, so the last history row clears the pill.
- `screens/home/ProofHistoryList.tsx`: add optional `ListHeaderComponent` and `contentBottomPadding` props on the underlying `SectionList`. Defaults preserve existing home-screen behavior.

### Tests

- `app/tests/src/utils/googleUsatGate.test.ts`: cover the allowlist semantics — Aadhaar blocks, mock-passport blocks, real passport allows; flip the "no selected document" case to expect `allow` (deferred enforcement); add a "selected doc missing from loaded docs" → `block` case.
- `app/tests/src/screens/verification/DocumentSelectorForProvingScreen.test.tsx` (new): selector block-path asserts `trackEvent`, gate modal `open`, and that `setSelectedDocument` and `navigate('Prove')` don't fire.
- `app/tests/src/screens/verification/ProvingScreenRouter.test.tsx`: wire the new per-document gate mock; add coverage for the post-`pickBest` re-gate.
- `app/tests/src/navigation/deeplinks.test.ts`, `app/tests/src/hooks/useEarnPointsFlow.test.ts`: cover the `entryPoint` plumbing.
- `packages/mobile-sdk-alpha/tests/utils/googleUsat.test.ts`: full rewrite for the identity-tuple matcher.

## Linear Issues

- Follow-up tracked: [SELF-2954](https://linear.app/selfprotocol/issue/SELF-2954/usat-gate-remove-premature-upfront-block-on-unset-selection) — already addressed in `9bffdf11f` (deferred upfront gate). Close on merge.

## Test Plan

- [ ] `yarn lint && yarn types` passes
- [ ] `cd packages/mobile-sdk-alpha && yarn test tests/utils/googleUsat.test.ts` passes
- [ ] `yarn workspace @selfxyz/mobile-app test app/tests/src/utils/googleUsatGate.test.ts app/tests/src/screens/verification/ProvingScreenRouter.test.tsx app/tests/src/screens/verification/DocumentSelectorForProvingScreen.test.tsx --runInBand` passes
- [ ] Live Google USAT faucet QR with a real passport-only account → faucet proof flow proceeds
- [ ] Live Google USAT faucet QR with a Didit-only account → gate blocks at the selector / auto-select chokepoint, modal shown
- [ ] Live Google USAT faucet QR with an Aadhaar account → gate blocks (new behavior)
- [ ] Live Google USAT faucet QR with a mock passport account → gate blocks
- [ ] USAT faucet QR with valid passport + KYC in catalog, user opens selector and picks KYC → blocked at confirm/approve with modal; analytics event fired
- [ ] USAT faucet QR with valid passport and no stored selection → routes to Prove (no premature modal)
- [ ] Any other (non-Google) proof flow → gate does not interfere
- [ ] Successful proof on any flow → green checkmark animation plays
- [ ] Failing / timing-out proof → fail animation plays
- [ ] ID Details screen with multiple history rows → entire screen scrolls; last row clears the floating Connect pill
- [ ] ID Details screen with no history → empty state renders below the perks card
- [ ] Home screen proof history list → unchanged
- [ ] Warm-launch deeplink preserves `entryPoint` through to analytics

### Native Consolidation Checklist

- [ ] CONTRACTS.md reviewed - no unintended contract changes
- [ ] Layer 1 bridge contract tests pass (`cd app && yarn jest:run` / `yarn workspace @selfxyz/rn-sdk-test-app test`)
- [ ] Layer 3 builds pass (app iOS, RN test app iOS, RN test app Android)
- [ ] Layer 4 manual smoke test signed off (if consolidation PR)
- [ ] No new native business logic added (logic belongs in TypeScript)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Google USAT eligibility now blocks when the selected document is missing or mock; test coverage updated.

* **Improvements**
  * Tweaked document details layout and floating-button spacing.
  * Proof history list supports header components and configurable bottom padding.
  * Proof-status animations reliably remount on source changes.
  * Navigation now consistently includes entryPoint params (including deeplinks).

* **Refactor**
  * Faucet matching switched to identity-based configuration.

* **Tests**
  * Updated tests and mocks to reflect these behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->