### PR TITLE
fix: gate Google USAT in ProvingScreenRouter and propagate entryPoint

### DIFF
--- a/app/src/components/navbar/HomeNavBar.tsx
+++ b/app/src/components/navbar/HomeNavBar.tsx
@@ -56,7 +56,9 @@ export const HomeNavBar = (props: NativeStackHeaderProps) => {
         try {
           Clipboard.setString('');
         } catch {}
-        props.navigation.navigate('ProvingScreenRouter');
+        props.navigation.navigate('ProvingScreenRouter', {
+          entryPoint: 'qr_scan',
+        });
       } catch (error) {
         console.error('Error consuming token:', error);
         if (

--- a/app/src/hooks/useEarnPointsFlow.ts
+++ b/app/src/hooks/useEarnPointsFlow.ts
@@ -57,7 +57,9 @@ export const useEarnPointsFlow = ({
 
     // Use setTimeout to ensure modal dismisses before navigating
     setTimeout(() => {
-      navigation.navigate('ProvingScreenRouter');
+      navigation.navigate('ProvingScreenRouter', {
+        entryPoint: 'earn_points',
+      });
     }, 100);
   }, [selfClient, navigation]);
 

--- a/app/src/navigation/deeplinks.ts
+++ b/app/src/navigation/deeplinks.ts
@@ -100,9 +100,15 @@ const validateAndSanitizeParam = (
 const createDeeplinkNavigationState = (
   targetScreen: string,
   parentScreen: string = 'Home',
+  targetParams?: Record<string, unknown>,
 ) => ({
   index: 1, // Current screen index (targetScreen)
-  routes: [{ name: parentScreen }, { name: targetScreen }],
+  routes: [
+    { name: parentScreen },
+    targetParams
+      ? { name: targetScreen, params: targetParams }
+      : { name: targetScreen },
+  ],
 });
 
 // Store the correct parent screen determined by splash screen
@@ -148,6 +154,7 @@ export const handleUrl = async (selfClient: SelfClient, uri: string) => {
         createDeeplinkNavigationState(
           'ProvingScreenRouter',
           correctParentScreen,
+          { entryPoint: 'deeplink' },
         ),
       );
 
@@ -178,7 +185,13 @@ export const handleUrl = async (selfClient: SelfClient, uri: string) => {
     selfClient.getSelfAppState().startAppListener(sessionId);
 
     safeNavigate(
-      createDeeplinkNavigationState('ProvingScreenRouter', correctParentScreen),
+      createDeeplinkNavigationState(
+        'ProvingScreenRouter',
+        correctParentScreen,
+        {
+          entryPoint: 'deeplink',
+        },
+      ),
     );
   } else if (mock_passport) {
     try {

--- a/app/src/navigation/deeplinks.ts
+++ b/app/src/navigation/deeplinks.ts
@@ -274,11 +274,11 @@ const safeNavigate = (
   const isColdLaunch = currentRoute?.name === 'Splash';
 
   if (!isColdLaunch && targetScreen) {
+    const targetParams = navigationState.routes[1]?.params;
     // Use object syntax to satisfy TypeScript's strict typing for navigate
-    // The params will be undefined for screens that don't require them
     navigationRef.navigate({
       name: targetScreen,
-      params: undefined,
+      params: targetParams,
     } as Parameters<typeof navigationRef.navigate>[0]);
   } else {
     navigationRef.reset(navigationState);

--- a/app/src/navigation/types.ts
+++ b/app/src/navigation/types.ts
@@ -7,6 +7,7 @@ import type { DocumentCategory } from '@selfxyz/common/utils/types';
 import type { ModalNavigationParams } from '@/screens/app/ModalScreen';
 import type { WebViewScreenParams } from '@/screens/shared/WebViewScreen';
 import type { ProofHistory } from '@/stores/proofTypes';
+import type { VerificationGateEntryPoint } from '@/stores/verificationGateStore';
 
 // =============================================================================
 // Aadhaar Screens
@@ -214,7 +215,9 @@ export type VerificationRoutesParamList = {
         scrollOffset?: number;
       }
     | undefined;
-  ProvingScreenRouter: undefined;
+  ProvingScreenRouter: {
+    entryPoint: VerificationGateEntryPoint;
+  };
   DocumentSelectorForProving:
     | {
         documentType?: string;

--- a/app/src/screens/verification/ProvingScreenRouter.tsx
+++ b/app/src/screens/verification/ProvingScreenRouter.tsx
@@ -11,7 +11,9 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import {
   isDocumentValidForProving,
   pickBestDocumentToSelect,
+  useSelfClient,
 } from '@selfxyz/mobile-sdk-alpha';
+import { ProofEvents } from '@selfxyz/mobile-sdk-alpha/constants/analytics';
 import { black } from '@selfxyz/mobile-sdk-alpha/constants/colors';
 import { dinot } from '@selfxyz/mobile-sdk-alpha/constants/fonts';
 
@@ -19,7 +21,9 @@ import { proofRequestColors } from '@/components/proof-request';
 import type { RootStackParamList } from '@/navigation';
 import { usePassport } from '@/providers/passportDataProvider';
 import { useSettingStore } from '@/stores/settingStore';
+import { useVerificationGateStore } from '@/stores/verificationGateStore';
 import { getDocumentTypeName } from '@/utils/documentUtils';
+import { evaluateGoogleUsatGate } from '@/utils/googleUsatGate';
 
 /**
  * Router screen for the proving flow that decides whether to skip the document selector.
@@ -35,6 +39,9 @@ import { getDocumentTypeName } from '@/utils/documentUtils';
 const ProvingScreenRouter: React.FC = () => {
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const selfClient = useSelfClient();
+  const { useSelfAppStore } = selfClient;
+  const selfApp = useSelfAppStore(state => state.selfApp);
   const { loadDocumentCatalog, getAllDocuments, setSelectedDocument } =
     usePassport();
   const { skipDocumentSelector } = useSettingStore();
@@ -53,7 +60,42 @@ const ProvingScreenRouter: React.FC = () => {
       return;
     }
 
+    // For sessionId-only entries, selfApp arrives asynchronously over the
+    // websocket. Wait for it before evaluating the Google USAT gate so we don't
+    // navigate past the gate prematurely.
+    if (!selfApp) {
+      return;
+    }
+
     setError(null);
+
+    try {
+      const gate = await evaluateGoogleUsatGate(selfClient, selfApp);
+      if (controller.signal.aborted) {
+        return;
+      }
+      if (gate === 'block') {
+        hasRoutedRef.current = true;
+        selfClient.trackEvent(ProofEvents.GOOGLE_USAT_BLOCKED, {
+          entry_point: 'qr_scan',
+          reason: 'no_high_security_doc',
+        });
+        useVerificationGateStore.getState().open({
+          reason: 'google_usat_high_security_required',
+          entryPoint: 'qr_scan',
+          requesterName: selfApp.appName,
+        });
+        selfClient.getSelfAppState().cleanSelfApp();
+        navigation.goBack();
+        return;
+      }
+    } catch (gateError) {
+      if (controller.signal.aborted) {
+        return;
+      }
+      console.warn('Google USAT gate evaluation failed:', gateError);
+    }
+
     try {
       const catalog = await loadDocumentCatalog();
       const docs = await getAllDocuments();
@@ -132,6 +174,8 @@ const ProvingScreenRouter: React.FC = () => {
     getAllDocuments,
     loadDocumentCatalog,
     navigation,
+    selfApp,
+    selfClient,
     setSelectedDocument,
     skipDocumentSelector,
   ]);

--- a/app/src/screens/verification/ProvingScreenRouter.tsx
+++ b/app/src/screens/verification/ProvingScreenRouter.tsx
@@ -5,7 +5,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ActivityIndicator } from 'react-native';
 import { Text, View } from 'tamagui';
-import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import type { RouteProp } from '@react-navigation/native';
+import {
+  useFocusEffect,
+  useNavigation,
+  useRoute,
+} from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import {
@@ -39,6 +44,9 @@ import { evaluateGoogleUsatGate } from '@/utils/googleUsatGate';
 const ProvingScreenRouter: React.FC = () => {
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const route =
+    useRoute<RouteProp<RootStackParamList, 'ProvingScreenRouter'>>();
+  const { entryPoint } = route.params;
   const selfClient = useSelfClient();
   const { useSelfAppStore } = selfClient;
   const selfApp = useSelfAppStore(state => state.selfApp);
@@ -77,12 +85,12 @@ const ProvingScreenRouter: React.FC = () => {
       if (gate === 'block') {
         hasRoutedRef.current = true;
         selfClient.trackEvent(ProofEvents.GOOGLE_USAT_BLOCKED, {
-          entry_point: 'qr_scan',
+          entry_point: entryPoint,
           reason: 'no_high_security_doc',
         });
         useVerificationGateStore.getState().open({
           reason: 'google_usat_high_security_required',
-          entryPoint: 'qr_scan',
+          entryPoint,
           requesterName: selfApp.appName,
         });
         selfClient.getSelfAppState().cleanSelfApp();
@@ -176,6 +184,7 @@ const ProvingScreenRouter: React.FC = () => {
     navigation,
     selfApp,
     selfClient,
+    entryPoint,
     setSelectedDocument,
     skipDocumentSelector,
   ]);

--- a/app/src/screens/verification/QRCodeViewFinderScreen.tsx
+++ b/app/src/screens/verification/QRCodeViewFinderScreen.tsx
@@ -50,7 +50,12 @@ const QRCodeViewFinderScreen: React.FC = () => {
   const isFocused = useIsFocused();
   const [doneScanningQR, setDoneScanningQR] = useState(false);
   const { top: safeAreaTop } = useSafeAreaInsets();
-  const navigateToDocumentSelector = useHapticNavigation('ProvingScreenRouter');
+  const navigateToDocumentSelector = useHapticNavigation(
+    'ProvingScreenRouter',
+    {
+      params: { entryPoint: 'qr_scan' },
+    },
+  );
 
   // This resets to the default state when we navigate back to this screen
   useFocusEffect(

--- a/app/tests/src/hooks/useEarnPointsFlow.test.ts
+++ b/app/tests/src/hooks/useEarnPointsFlow.test.ts
@@ -286,7 +286,9 @@ describe('useEarnPointsFlow', () => {
         jest.advanceTimersByTime(100);
       });
 
-      expect(mockNavigate).toHaveBeenCalledWith('ProvingScreenRouter');
+      expect(mockNavigate).toHaveBeenCalledWith('ProvingScreenRouter', {
+        entryPoint: 'earn_points',
+      });
     });
 
     it('should clear referrer when points disclosure modal is dismissed with referrer', async () => {

--- a/app/tests/src/navigation/deeplinks.test.ts
+++ b/app/tests/src/navigation/deeplinks.test.ts
@@ -106,7 +106,10 @@ describe('deeplinks', () => {
       const { navigationRef } = require('@/navigation');
       expect(navigationRef.reset).toHaveBeenCalledWith({
         index: 1,
-        routes: [{ name: 'Home' }, { name: 'ProvingScreenRouter' }],
+        routes: [
+          { name: 'Home' },
+          { name: 'ProvingScreenRouter', params: { entryPoint: 'deeplink' } },
+        ],
       });
     });
 
@@ -132,7 +135,10 @@ describe('deeplinks', () => {
       const { navigationRef } = require('@/navigation');
       expect(navigationRef.reset).toHaveBeenCalledWith({
         index: 1,
-        routes: [{ name: 'Home' }, { name: 'ProvingScreenRouter' }],
+        routes: [
+          { name: 'Home' },
+          { name: 'ProvingScreenRouter', params: { entryPoint: 'deeplink' } },
+        ],
       });
     });
 

--- a/app/tests/src/navigation/deeplinks.test.ts
+++ b/app/tests/src/navigation/deeplinks.test.ts
@@ -142,6 +142,33 @@ describe('deeplinks', () => {
       });
     });
 
+    it('preserves ProvingScreenRouter params on warm launch navigation', async () => {
+      const url = 'scheme://open?sessionId=123';
+      const mockCleanSelfApp = jest.fn();
+      const mockStartAppListener = jest.fn();
+      const { navigationRef } = require('@/navigation');
+      navigationRef.getCurrentRoute.mockReturnValue({ name: 'Home' });
+
+      await handleUrl(
+        {
+          getSelfAppState: () => ({
+            setSelfApp: jest.fn(),
+            startAppListener: mockStartAppListener,
+            cleanSelfApp: mockCleanSelfApp,
+          }),
+        } as unknown as SelfClient,
+        url,
+      );
+
+      expect(mockCleanSelfApp).toHaveBeenCalledWith();
+      expect(mockStartAppListener).toHaveBeenCalledWith('123');
+      expect(navigationRef.navigate).toHaveBeenCalledWith({
+        name: 'ProvingScreenRouter',
+        params: { entryPoint: 'deeplink' },
+      });
+      expect(navigationRef.reset).not.toHaveBeenCalled();
+    });
+
     it('handles mock_passport parameter', async () => {
       const mockData = { name: 'John', surname: 'Doe' };
       const url = `scheme://open?mock_passport=${encodeURIComponent(JSON.stringify(mockData))}`;

--- a/app/tests/src/screens/verification/ProvingScreenRouter.test.tsx
+++ b/app/tests/src/screens/verification/ProvingScreenRouter.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useRoute } from '@react-navigation/native';
 import { render, waitFor } from '@testing-library/react-native';
 
 import type {
@@ -13,11 +13,13 @@ import type {
 import {
   isDocumentValidForProving,
   pickBestDocumentToSelect,
+  useSelfClient,
 } from '@selfxyz/mobile-sdk-alpha';
 
 import { usePassport } from '@/providers/passportDataProvider';
 import { ProvingScreenRouter } from '@/screens/verification/ProvingScreenRouter';
 import { useSettingStore } from '@/stores/settingStore';
+import { evaluateGoogleUsatGate } from '@/utils/googleUsatGate';
 
 // Mock useFocusEffect to behave like useEffect in tests
 // Note: We use jest.requireActual for React to avoid nested require() which causes OOM in CI
@@ -26,6 +28,7 @@ jest.mock('@react-navigation/native', () => {
   const ReactActual = jest.requireActual('react');
   return {
     ...actual,
+    useRoute: jest.fn(() => ({ params: { entryPoint: 'qr_scan' } })),
     useFocusEffect: (callback: () => void) => {
       ReactActual.useEffect(() => {
         callback();
@@ -37,6 +40,7 @@ jest.mock('@react-navigation/native', () => {
 jest.mock('@selfxyz/mobile-sdk-alpha', () => ({
   isDocumentValidForProving: jest.fn(),
   pickBestDocumentToSelect: jest.fn(),
+  useSelfClient: jest.fn(),
 }));
 
 jest.mock('@/providers/passportDataProvider', () => ({
@@ -47,13 +51,21 @@ jest.mock('@/stores/settingStore', () => ({
   useSettingStore: jest.fn(),
 }));
 
+jest.mock('@/utils/googleUsatGate', () => ({
+  evaluateGoogleUsatGate: jest.fn(),
+}));
+
 const mockUseNavigation = useNavigation as jest.MockedFunction<
   typeof useNavigation
 >;
+const mockUseRoute = useRoute as jest.MockedFunction<typeof useRoute>;
 const mockIsDocumentValidForProving =
   isDocumentValidForProving as jest.MockedFunction<
     typeof isDocumentValidForProving
   >;
+const mockUseSelfClient = useSelfClient as jest.MockedFunction<
+  typeof useSelfClient
+>;
 const mockPickBestDocumentToSelect =
   pickBestDocumentToSelect as jest.MockedFunction<
     typeof pickBestDocumentToSelect
@@ -62,10 +74,15 @@ const mockUsePassport = usePassport as jest.MockedFunction<typeof usePassport>;
 const mockUseSettingStore = useSettingStore as jest.MockedFunction<
   typeof useSettingStore
 >;
+const mockEvaluateGoogleUsatGate =
+  evaluateGoogleUsatGate as jest.MockedFunction<typeof evaluateGoogleUsatGate>;
 const mockReplace = jest.fn();
 const mockLoadDocumentCatalog = jest.fn();
 const mockGetAllDocuments = jest.fn();
 const mockSetSelectedDocument = jest.fn();
+const mockTrackEvent = jest.fn();
+const mockCleanSelfApp = jest.fn();
+const mockSelfApp = { appName: 'Test App' };
 
 type MockDocumentEntry = {
   metadata: DocumentMetadata;
@@ -113,6 +130,17 @@ describe('ProvingScreenRouter', () => {
     jest.clearAllMocks();
 
     mockUseNavigation.mockReturnValue({ replace: mockReplace } as any);
+    mockUseRoute.mockReturnValue({ params: { entryPoint: 'qr_scan' } } as any);
+    mockUseSelfClient.mockReturnValue({
+      useSelfAppStore: (
+        selector: (state: { selfApp: { appName: string } }) => unknown,
+      ) => selector({ selfApp: mockSelfApp }),
+      trackEvent: mockTrackEvent,
+      getSelfAppState: () => ({
+        cleanSelfApp: mockCleanSelfApp,
+      }),
+    } as any);
+    mockEvaluateGoogleUsatGate.mockResolvedValue('allow');
 
     mockUsePassport.mockReturnValue({
       loadDocumentCatalog: mockLoadDocumentCatalog,

--- a/packages/mobile-sdk-alpha/src/constants/googleUsat.ts
+++ b/packages/mobile-sdk-alpha/src/constants/googleUsat.ts
@@ -3,7 +3,7 @@
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
 export const GOOGLE_USAT_FAUCET_ENDPOINT =
-  'https://cw3-selfxyz-bridge-625632552981.us-central1.run.app/api/verify/api/verify';
+  'https://cw3-selfxyz-bridge-625632552981.us-central1.run.app/api/verify';
 
 export const GOOGLE_USAT_FAUCET_SCOPE = 'celo-mainnet-tether-usat';
 


### PR DESCRIPTION
## Summary

- Evaluates the Google USAT gate inside `ProvingScreenRouter` so sessionId-only entries (where `selfApp` arrives over the websocket after navigation) are gated correctly — the router waits for `selfApp`, then blocks and opens the verification gate modal when no eligible document is present.
- Threads an explicit `entryPoint` through `ProvingScreenRouter` as a required route param so the `GOOGLE_USAT_BLOCKED` event and `useVerificationGateStore.open(...)` reflect the real entry (`qr_scan` / `deeplink` / `earn_points`) instead of a hardcoded value.
- Fixes a related warm-launch bug in `safeNavigate` where deeplink route params were dropped, which would now crash since `entryPoint` is required.

## Changes

### React Native app

- `ProvingScreenRouter.tsx`: waits for `selfApp`, calls `evaluateGoogleUsatGate`, and on `block` emits analytics + opens the gate store + clears `selfApp` + `goBack()`.
- `navigation/types.ts`: `ProvingScreenRouter` route param is now `{ entryPoint: VerificationGateEntryPoint }` (required).
- Call sites pass entry explicitly: `QRCodeViewFinderScreen` and `HomeNavBar` → `qr_scan`; `useEarnPointsFlow` → `earn_points`; `navigation/deeplinks` → `deeplink`.
- `navigation/deeplinks.ts` `safeNavigate`: forwards `navigationState.routes[1]?.params` on the warm-launch branch so deeplink params survive instead of being replaced with `undefined`.

### Tests

- `deeplinks.test.ts`: asserts `ProvingScreenRouter` is reached with `params: { entryPoint: 'deeplink' }` on both cold and warm launches.
- `useEarnPointsFlow.test.ts`: asserts navigation with `entryPoint: 'earn_points'`.
- `ProvingScreenRouter.test.tsx`: updated for the required route param and gate-evaluation path.

## Test Plan

- [ ] `yarn lint && yarn types` passes
- [ ] `yarn workspace @selfxyz/mobile-app test app/tests/src/navigation/deeplinks.test.ts app/tests/src/hooks/useEarnPointsFlow.test.ts app/tests/src/screens/verification/ProvingScreenRouter.test.tsx`
- [ ] Manual: open a Google USAT deeplink with no eligible doc on warm launch → gate modal opens, analytics shows `entry_point: 'deeplink'` (not `qr_scan`).
- [ ] Manual: scan a Google USAT QR with no eligible doc → gate modal opens with `entry_point: 'qr_scan'`.
- [ ] Manual: trigger from earn-points flow → `entry_point: 'earn_points'`.
- [ ] Manual: sessionId-only entry (selfApp arrives async) is gated correctly — router does not flash past the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added verification gate enforcement during the verification process for enhanced account security.

* **Improvements**
  * Enhanced verification routing to track entry points across QR scans, points earning, and deeplink pathways.
  * Updated navigation parameters to support better routing flow management.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/selfxyz/self/pull/2072)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->