### PR TITLE
fix USAT gate: dedup fetch, route to selector, add policy registry

### DIFF
--- a/app/src/screens/verification/ProvingScreenRouter.tsx
+++ b/app/src/screens/verification/ProvingScreenRouter.tsx
@@ -31,6 +31,7 @@ import { getDocumentTypeName } from '@/utils/documentUtils';
 import {
   evaluateGoogleUsatGate,
   evaluateGoogleUsatGateForDocument,
+  hasEligibleGoogleUsatAlternativeDocument,
 } from '@/utils/googleUsatGate';
 
 /**
@@ -81,35 +82,32 @@ const ProvingScreenRouter: React.FC = () => {
     setError(null);
 
     try {
-      const gate = await evaluateGoogleUsatGate(selfClient, selfApp);
-      if (controller.signal.aborted) {
-        return;
-      }
-      if (gate === 'block') {
-        hasRoutedRef.current = true;
-        selfClient.trackEvent(ProofEvents.GOOGLE_USAT_BLOCKED, {
-          entry_point: entryPoint,
-          reason: 'no_high_security_doc',
-        });
-        useVerificationGateStore.getState().open({
-          reason: 'google_usat_high_security_required',
-          entryPoint,
-          requesterName: selfApp.appName,
-        });
-        selfClient.getSelfAppState().cleanSelfApp();
-        navigation.goBack();
-        return;
-      }
-    } catch (gateError) {
-      if (controller.signal.aborted) {
-        return;
-      }
-      console.warn('Google USAT gate evaluation failed:', gateError);
-    }
-
-    try {
       const catalog = await loadDocumentCatalog();
       const docs = await getAllDocuments();
+
+      const gate = await evaluateGoogleUsatGate(selfClient, selfApp);
+      if (gate === 'block') {
+        const selectedDocumentId = catalog.selectedDocumentId;
+        const hasAlternativeEligibleDocument = selectedDocumentId
+          ? hasEligibleGoogleUsatAlternativeDocument(docs, selectedDocumentId)
+          : false;
+
+        if (!hasAlternativeEligibleDocument) {
+          hasRoutedRef.current = true;
+          selfClient.trackEvent(ProofEvents.GOOGLE_USAT_BLOCKED, {
+            entry_point: entryPoint,
+            reason: 'no_high_security_doc',
+          });
+          useVerificationGateStore.getState().open({
+            reason: 'google_usat_high_security_required',
+            entryPoint,
+            requesterName: selfApp.appName,
+          });
+          selfClient.getSelfAppState().cleanSelfApp();
+          navigation.goBack();
+          return;
+        }
+      }
 
       // Don't continue if this request was aborted
       if (controller.signal.aborted) {
@@ -153,6 +151,7 @@ const ProvingScreenRouter: React.FC = () => {
               selfClient,
               selfApp,
               docToSelect,
+              docs,
             );
             if (selectedDocGate === 'block') {
               selfClient.trackEvent(ProofEvents.GOOGLE_USAT_BLOCKED, {

--- a/app/src/screens/verification/ProvingScreenRouter.tsx
+++ b/app/src/screens/verification/ProvingScreenRouter.tsx
@@ -84,12 +84,35 @@ const ProvingScreenRouter: React.FC = () => {
 
     try {
       const catalog = await loadDocumentCatalog();
+      if (controller.signal.aborted) {
+        return;
+      }
       const docs = await getAllDocuments();
+      if (controller.signal.aborted) {
+        return;
+      }
 
       const gate = await evaluateGoogleUsatGate(selfClient, selfApp, {
         catalog,
         docs,
       });
+      if (controller.signal.aborted) {
+        return;
+      }
+
+      // Count valid documents up front so we can derive documentType for the
+      // selector even when the gate forces us there.
+      const validDocuments = catalog.documents.filter(doc => {
+        const docData = docs[doc.id];
+        return isDocumentValidForProving(doc, docData?.data);
+      });
+      const validCount = validDocuments.length;
+      const firstValidDoc = validDocuments[0];
+      const documentType = getDocumentTypeName(
+        firstValidDoc?.documentCategory,
+        firstValidDoc?.idType,
+      );
+
       if (gate === 'block') {
         const selectedDocumentId = catalog.selectedDocumentId;
         const hasAlternativeEligibleDocument = selectedDocumentId
@@ -100,35 +123,31 @@ const ProvingScreenRouter: React.FC = () => {
             )
           : false;
 
-        if (!hasAlternativeEligibleDocument) {
+        if (hasAlternativeEligibleDocument) {
+          // Force selector regardless of skipDocumentSelector so the user can
+          // pick the eligible alternative.
           hasRoutedRef.current = true;
-          selfClient.trackEvent(ProofEvents.GOOGLE_USAT_BLOCKED, {
-            entry_point: entryPoint,
-            reason: 'no_high_security_doc',
-          });
-          useVerificationGateStore.getState().open({
-            reason: 'google_usat_high_security_required',
+          navigation.replace('DocumentSelectorForProving', {
+            documentType,
             entryPoint,
-            requesterName: selfApp.appName,
           });
-          selfClient.getSelfAppState().cleanSelfApp();
-          navigation.goBack();
           return;
         }
-      }
 
-      // Don't continue if this request was aborted
-      if (controller.signal.aborted) {
+        hasRoutedRef.current = true;
+        selfClient.trackEvent(ProofEvents.GOOGLE_USAT_BLOCKED, {
+          entry_point: entryPoint,
+          reason: 'no_high_security_doc',
+        });
+        useVerificationGateStore.getState().open({
+          reason: 'google_usat_high_security_required',
+          entryPoint,
+          requesterName: selfApp.appName,
+        });
+        selfClient.getSelfAppState().cleanSelfApp();
+        navigation.goBack();
         return;
       }
-
-      // Count valid documents
-      const validDocuments = catalog.documents.filter(doc => {
-        const docData = docs[doc.id];
-        return isDocumentValidForProving(doc, docData?.data);
-      });
-
-      const validCount = validDocuments.length;
 
       // Mark as routed to prevent re-routing
       hasRoutedRef.current = true;
@@ -139,13 +158,6 @@ const ProvingScreenRouter: React.FC = () => {
         navigation.replace('DocumentDataNotFound');
         return;
       }
-
-      // Determine document type from first valid document for display
-      const firstValidDoc = validDocuments[0];
-      const documentType = getDocumentTypeName(
-        firstValidDoc?.documentCategory,
-        firstValidDoc?.idType,
-      );
 
       // Determine if we should skip the selector
       const shouldSkip = skipDocumentSelector || validCount === 1;
@@ -161,6 +173,9 @@ const ProvingScreenRouter: React.FC = () => {
               docToSelect,
               docs,
             );
+            if (controller.signal.aborted) {
+              return;
+            }
             if (selectedDocGate === 'block') {
               selfClient.trackEvent(ProofEvents.GOOGLE_USAT_BLOCKED, {
                 entry_point: entryPoint,

--- a/app/src/screens/verification/ProvingScreenRouter.tsx
+++ b/app/src/screens/verification/ProvingScreenRouter.tsx
@@ -61,6 +61,29 @@ const ProvingScreenRouter: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
   const hasRoutedRef = useRef(false);
+  const openDocumentSelector = useCallback(
+    (documentType: string) => {
+      navigation.replace('DocumentSelectorForProving', {
+        documentType,
+        entryPoint,
+      });
+    },
+    [entryPoint, navigation],
+  );
+
+  const handleGoogleUsatBlocked = useCallback(() => {
+    selfClient.trackEvent(ProofEvents.GOOGLE_USAT_BLOCKED, {
+      entry_point: entryPoint,
+      reason: 'no_high_security_doc',
+    });
+    useVerificationGateStore.getState().open({
+      reason: 'google_usat_high_security_required',
+      entryPoint,
+      requesterName: selfApp?.appName ?? '',
+    });
+    selfClient.getSelfAppState().cleanSelfApp();
+    navigation.goBack();
+  }, [entryPoint, navigation, selfApp?.appName, selfClient]);
 
   const loadAndRoute = useCallback(async () => {
     // Cancel any in-flight request
@@ -123,29 +146,38 @@ const ProvingScreenRouter: React.FC = () => {
             )
           : false;
 
-        if (hasAlternativeEligibleDocument) {
+        let hasAlternativeEligibleValidDocument = false;
+        if (hasAlternativeEligibleDocument && selectedDocumentId) {
+          const alternativeValidDocuments = validDocuments.filter(
+            doc => doc.id !== selectedDocumentId,
+          );
+          for (const doc of alternativeValidDocuments) {
+            const alternativeDocGate = await evaluateGoogleUsatGateForDocument(
+              selfClient,
+              selfApp,
+              doc.id,
+              docs,
+            );
+            if (controller.signal.aborted) {
+              return;
+            }
+            if (alternativeDocGate === 'allow') {
+              hasAlternativeEligibleValidDocument = true;
+              break;
+            }
+          }
+        }
+
+        if (hasAlternativeEligibleValidDocument) {
           // Force selector regardless of skipDocumentSelector so the user can
           // pick the eligible alternative.
           hasRoutedRef.current = true;
-          navigation.replace('DocumentSelectorForProving', {
-            documentType,
-            entryPoint,
-          });
+          openDocumentSelector(documentType);
           return;
         }
 
         hasRoutedRef.current = true;
-        selfClient.trackEvent(ProofEvents.GOOGLE_USAT_BLOCKED, {
-          entry_point: entryPoint,
-          reason: 'no_high_security_doc',
-        });
-        useVerificationGateStore.getState().open({
-          reason: 'google_usat_high_security_required',
-          entryPoint,
-          requesterName: selfApp.appName,
-        });
-        selfClient.getSelfAppState().cleanSelfApp();
-        navigation.goBack();
+        handleGoogleUsatBlocked();
         return;
       }
 
@@ -162,58 +194,39 @@ const ProvingScreenRouter: React.FC = () => {
       // Determine if we should skip the selector
       const shouldSkip = skipDocumentSelector || validCount === 1;
 
-      if (shouldSkip) {
-        // Auto-select and navigate to Prove
-        const docToSelect = pickBestDocumentToSelect(catalog, docs);
-        if (docToSelect) {
-          try {
-            const selectedDocGate = await evaluateGoogleUsatGateForDocument(
-              selfClient,
-              selfApp,
-              docToSelect,
-              docs,
-            );
-            if (controller.signal.aborted) {
-              return;
-            }
-            if (selectedDocGate === 'block') {
-              selfClient.trackEvent(ProofEvents.GOOGLE_USAT_BLOCKED, {
-                entry_point: entryPoint,
-                reason: 'no_high_security_doc',
-              });
-              useVerificationGateStore.getState().open({
-                reason: 'google_usat_high_security_required',
-                entryPoint,
-                requesterName: selfApp.appName,
-              });
-              selfClient.getSelfAppState().cleanSelfApp();
-              navigation.goBack();
-              return;
-            }
-            await setSelectedDocument(docToSelect);
-            navigation.replace('Prove');
-          } catch (selectError) {
-            console.error('Failed to auto-select document:', selectError);
-            // On error, fall back to showing the selector
-            hasRoutedRef.current = false;
-            navigation.replace('DocumentSelectorForProving', {
-              documentType,
-              entryPoint,
-            });
-          }
-        } else {
-          // No valid document to select, show selector
-          navigation.replace('DocumentSelectorForProving', {
-            documentType,
-            entryPoint,
-          });
+      if (!shouldSkip) {
+        openDocumentSelector(documentType);
+        return;
+      }
+
+      // Auto-select and navigate to Prove
+      const docToSelect = pickBestDocumentToSelect(catalog, docs);
+      if (!docToSelect) {
+        openDocumentSelector(documentType);
+        return;
+      }
+
+      try {
+        const selectedDocGate = await evaluateGoogleUsatGateForDocument(
+          selfClient,
+          selfApp,
+          docToSelect,
+          docs,
+        );
+        if (controller.signal.aborted) {
+          return;
         }
-      } else {
-        // Show the document selector
-        navigation.replace('DocumentSelectorForProving', {
-          documentType,
-          entryPoint,
-        });
+        if (selectedDocGate === 'block') {
+          handleGoogleUsatBlocked();
+          return;
+        }
+        await setSelectedDocument(docToSelect);
+        navigation.replace('Prove');
+      } catch (selectError) {
+        console.error('Failed to auto-select document:', selectError);
+        // On error, fall back to showing the selector
+        hasRoutedRef.current = false;
+        openDocumentSelector(documentType);
       }
     } catch (loadError) {
       // Don't show error if this request was aborted
@@ -231,7 +244,8 @@ const ProvingScreenRouter: React.FC = () => {
     navigation,
     selfApp,
     selfClient,
-    entryPoint,
+    handleGoogleUsatBlocked,
+    openDocumentSelector,
     setSelectedDocument,
     skipDocumentSelector,
   ]);

--- a/app/src/screens/verification/ProvingScreenRouter.tsx
+++ b/app/src/screens/verification/ProvingScreenRouter.tsx
@@ -14,6 +14,8 @@ import {
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import {
+  GOOGLE_USAT_FAUCET_POLICY,
+  hasEligibleAlternativeDocumentForPolicy,
   isDocumentValidForProving,
   pickBestDocumentToSelect,
   useSelfClient,
@@ -31,7 +33,6 @@ import { getDocumentTypeName } from '@/utils/documentUtils';
 import {
   evaluateGoogleUsatGate,
   evaluateGoogleUsatGateForDocument,
-  hasEligibleGoogleUsatAlternativeDocument,
 } from '@/utils/googleUsatGate';
 
 /**
@@ -85,11 +86,18 @@ const ProvingScreenRouter: React.FC = () => {
       const catalog = await loadDocumentCatalog();
       const docs = await getAllDocuments();
 
-      const gate = await evaluateGoogleUsatGate(selfClient, selfApp);
+      const gate = await evaluateGoogleUsatGate(selfClient, selfApp, {
+        catalog,
+        docs,
+      });
       if (gate === 'block') {
         const selectedDocumentId = catalog.selectedDocumentId;
         const hasAlternativeEligibleDocument = selectedDocumentId
-          ? hasEligibleGoogleUsatAlternativeDocument(docs, selectedDocumentId)
+          ? hasEligibleAlternativeDocumentForPolicy(
+              GOOGLE_USAT_FAUCET_POLICY,
+              docs,
+              selectedDocumentId,
+            )
           : false;
 
         if (!hasAlternativeEligibleDocument) {

--- a/app/src/utils/googleUsatGate.ts
+++ b/app/src/utils/googleUsatGate.ts
@@ -3,20 +3,24 @@
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
 import type { SelfApp } from '@selfxyz/common/utils';
-import type { DocumentCategory } from '@selfxyz/common/utils/types';
+import type { DocumentCatalog } from '@selfxyz/common/utils/types';
 import {
   getAllDocuments,
+  GOOGLE_USAT_FAUCET_POLICY,
+  isDocumentEligibleForPolicy,
   isGoogleUsatProofRequest,
   type SelfClient,
 } from '@selfxyz/mobile-sdk-alpha';
 
 export type GoogleUsatGateResult = 'allow' | 'block';
 export const FORCE_GOOGLE_USAT_FOR_TESTING = false;
-type GoogleUsatEligibleDocumentCategory = 'passport' | 'id_card';
-const GOOGLE_USAT_ALLOWED_DOCUMENT_CATEGORIES: ReadonlySet<DocumentCategory> =
-  new Set(['passport', 'id_card']);
 
 type DocumentMap = Awaited<ReturnType<typeof getAllDocuments>>;
+
+export interface GoogleUsatGateContext {
+  catalog?: DocumentCatalog;
+  docs?: DocumentMap;
+}
 
 export function isGoogleUsatForceEnabledForTesting(): boolean {
   return __DEV__ && FORCE_GOOGLE_USAT_FOR_TESTING;
@@ -25,21 +29,27 @@ export function isGoogleUsatForceEnabledForTesting(): boolean {
 export async function evaluateGoogleUsatGate(
   selfClient: SelfClient,
   app: SelfApp,
+  context: GoogleUsatGateContext = {},
 ): Promise<GoogleUsatGateResult> {
   if (!shouldTreatAsGoogleUsat(app)) {
     return 'allow';
   }
 
   try {
-    const catalog = await selfClient.loadDocumentCatalog();
+    const catalog = context.catalog ?? (await selfClient.loadDocumentCatalog());
     const selectedDocumentId = catalog.selectedDocumentId;
 
     if (!selectedDocumentId) {
       return 'allow';
     }
 
-    const docs = await getAllDocuments(selfClient);
-    return evaluateGoogleUsatGateForDocument(selfClient, app, selectedDocumentId, docs);
+    const docs = context.docs ?? (await getAllDocuments(selfClient));
+    return evaluateGoogleUsatGateForDocument(
+      selfClient,
+      app,
+      selectedDocumentId,
+      docs,
+    );
   } catch {
     return 'allow';
   }
@@ -69,7 +79,8 @@ export async function evaluateGoogleUsatGateForDocument(
     return 'block';
   }
 
-  const isEligibleSelectedDoc = isGoogleUsatDocumentEligible(
+  const isEligibleSelectedDoc = isDocumentEligibleForPolicy(
+    GOOGLE_USAT_FAUCET_POLICY,
     documentToEvaluate.data.documentCategory,
     documentToEvaluate.data.mock,
   );
@@ -77,38 +88,9 @@ export async function evaluateGoogleUsatGateForDocument(
   return isEligibleSelectedDoc ? 'allow' : 'block';
 }
 
-export function hasEligibleGoogleUsatAlternativeDocument(
-  docs: DocumentMap,
-  excludedDocumentId: string,
-): boolean {
-  return Object.entries(docs).some(([documentId, document]) => {
-    if (documentId === excludedDocumentId) {
-      return false;
-    }
-
-    return isGoogleUsatDocumentEligible(
-      document.data.documentCategory,
-      document.data.mock,
-    );
-  });
-}
-
 function shouldTreatAsGoogleUsat(app: SelfApp): boolean {
   if (isGoogleUsatForceEnabledForTesting()) {
     return true;
   }
   return isGoogleUsatProofRequest(app);
-}
-
-function isGoogleUsatEligibleDocumentCategory(
-  category: DocumentCategory,
-): category is GoogleUsatEligibleDocumentCategory {
-  return GOOGLE_USAT_ALLOWED_DOCUMENT_CATEGORIES.has(category);
-}
-
-function isGoogleUsatDocumentEligible(
-  category: DocumentCategory,
-  isMock: boolean | undefined,
-): boolean {
-  return isGoogleUsatEligibleDocumentCategory(category) && isMock !== true;
 }

--- a/app/src/utils/googleUsatGate.ts
+++ b/app/src/utils/googleUsatGate.ts
@@ -16,6 +16,8 @@ type GoogleUsatEligibleDocumentCategory = 'passport' | 'id_card';
 const GOOGLE_USAT_ALLOWED_DOCUMENT_CATEGORIES: ReadonlySet<DocumentCategory> =
   new Set(['passport', 'id_card']);
 
+type DocumentMap = Awaited<ReturnType<typeof getAllDocuments>>;
+
 export function isGoogleUsatForceEnabledForTesting(): boolean {
   return __DEV__ && FORCE_GOOGLE_USAT_FOR_TESTING;
 }
@@ -28,38 +30,38 @@ export async function evaluateGoogleUsatGate(
     return 'allow';
   }
 
-  let selectedDocumentId: string | undefined;
   try {
     const catalog = await selfClient.loadDocumentCatalog();
-    selectedDocumentId = catalog.selectedDocumentId;
+    const selectedDocumentId = catalog.selectedDocumentId;
+
+    if (!selectedDocumentId) {
+      return 'allow';
+    }
+
+    const docs = await getAllDocuments(selfClient);
+    return evaluateGoogleUsatGateForDocument(selfClient, app, selectedDocumentId, docs);
   } catch {
-    // Fail open to match the same UX-only guard behavior on transient failures.
     return 'allow';
   }
-
-  if (!selectedDocumentId) {
-    // Defer document eligibility checks to explicit document selection
-    // chokepoints when no stored selection exists yet.
-    return 'allow';
-  }
-
-  return evaluateGoogleUsatGateForDocument(selfClient, app, selectedDocumentId);
 }
 
 export async function evaluateGoogleUsatGateForDocument(
   selfClient: SelfClient,
   app: SelfApp,
   documentId: string,
+  prefetchedDocs?: DocumentMap,
 ): Promise<GoogleUsatGateResult> {
   if (!shouldTreatAsGoogleUsat(app)) {
     return 'allow';
   }
 
-  let docs: Awaited<ReturnType<typeof getAllDocuments>>;
-  try {
-    docs = await getAllDocuments(selfClient);
-  } catch {
-    return 'allow';
+  let docs = prefetchedDocs;
+  if (!docs) {
+    try {
+      docs = await getAllDocuments(selfClient);
+    } catch {
+      return 'allow';
+    }
   }
 
   const documentToEvaluate = docs[documentId];
@@ -67,12 +69,28 @@ export async function evaluateGoogleUsatGateForDocument(
     return 'block';
   }
 
-  const isEligibleSelectedDoc =
-    isGoogleUsatEligibleDocumentCategory(
-      documentToEvaluate.data.documentCategory,
-    ) && documentToEvaluate.data.mock !== true;
+  const isEligibleSelectedDoc = isGoogleUsatDocumentEligible(
+    documentToEvaluate.data.documentCategory,
+    documentToEvaluate.data.mock,
+  );
 
   return isEligibleSelectedDoc ? 'allow' : 'block';
+}
+
+export function hasEligibleGoogleUsatAlternativeDocument(
+  docs: DocumentMap,
+  excludedDocumentId: string,
+): boolean {
+  return Object.entries(docs).some(([documentId, document]) => {
+    if (documentId === excludedDocumentId) {
+      return false;
+    }
+
+    return isGoogleUsatDocumentEligible(
+      document.data.documentCategory,
+      document.data.mock,
+    );
+  });
 }
 
 function shouldTreatAsGoogleUsat(app: SelfApp): boolean {
@@ -86,4 +104,11 @@ function isGoogleUsatEligibleDocumentCategory(
   category: DocumentCategory,
 ): category is GoogleUsatEligibleDocumentCategory {
   return GOOGLE_USAT_ALLOWED_DOCUMENT_CATEGORIES.has(category);
+}
+
+function isGoogleUsatDocumentEligible(
+  category: DocumentCategory,
+  isMock: boolean | undefined,
+): boolean {
+  return isGoogleUsatEligibleDocumentCategory(category) && isMock !== true;
 }

--- a/app/tests/src/screens/verification/ProvingScreenRouter.test.tsx
+++ b/app/tests/src/screens/verification/ProvingScreenRouter.test.tsx
@@ -3,7 +3,7 @@
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
 import { useNavigation, useRoute } from '@react-navigation/native';
-import { render, waitFor } from '@testing-library/react-native';
+import { act, render, waitFor } from '@testing-library/react-native';
 
 import type {
   DocumentCatalog,
@@ -25,21 +25,9 @@ import {
   evaluateGoogleUsatGateForDocument,
 } from '@/utils/googleUsatGate';
 
-// Mock useFocusEffect to behave like useEffect in tests
-// Note: We use jest.requireActual for React to avoid nested require() which causes OOM in CI
-jest.mock('@react-navigation/native', () => {
-  const actual = jest.requireActual('@react-navigation/native');
-  const ReactActual = jest.requireActual('react');
-  return {
-    ...actual,
-    useRoute: jest.fn(() => ({ params: { entryPoint: 'qr_scan' } })),
-    useFocusEffect: (callback: () => void) => {
-      ReactActual.useEffect(() => {
-        callback();
-      }, [callback]);
-    },
-  };
-});
+// `@react-navigation/native` is globally mocked in tests/__setup__/mocks/navigation.js
+// (loaded via jest.setup.js). Reuse it instead of requireActual, which pulls in
+// the real react-native ESM and fails to parse.
 
 jest.mock('@selfxyz/mobile-sdk-alpha', () => ({
   GOOGLE_USAT_FAUCET_POLICY: { id: 'google-usat-faucet' },
@@ -443,6 +431,112 @@ describe('ProvingScreenRouter', () => {
 
     expect(mockLoadDocumentCatalog).toHaveBeenCalledTimes(1);
     expect(mockGetAllDocuments).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes to selector even when skipDocumentSelector is true if an eligible alternative exists', async () => {
+    const kyc = createMetadata({
+      id: 'doc-kyc',
+      documentCategory: 'kyc',
+      isRegistered: true,
+    });
+    const passport = createMetadata({
+      id: 'doc-passport',
+      documentType: 'us',
+      isRegistered: true,
+    });
+    const catalog: DocumentCatalog = {
+      documents: [kyc, passport],
+      selectedDocumentId: 'doc-kyc',
+    } as any;
+    const allDocs = createAllDocuments([
+      createDocumentEntry(kyc),
+      createDocumentEntry(passport),
+    ]);
+
+    const mockGoBack = jest.fn();
+    mockUseNavigation.mockReturnValue({
+      replace: mockReplace,
+      goBack: mockGoBack,
+    } as any);
+
+    mockUseSettingStore.mockReturnValue({
+      skipDocumentSelector: true,
+      skipDocumentSelectorIfSingle: false,
+    } as any);
+
+    mockLoadDocumentCatalog.mockResolvedValue(catalog);
+    mockGetAllDocuments.mockResolvedValue(allDocs);
+    mockEvaluateGoogleUsatGate.mockResolvedValue('block');
+    mockHasEligibleGoogleUsatAlternativeDocument.mockReturnValue(true);
+    // pickBestDocumentToSelect would pick the blocked doc-kyc and the
+    // per-document gate would re-block it — proving the previous bug.
+    mockPickBestDocumentToSelect.mockReturnValue('doc-kyc');
+    mockEvaluateGoogleUsatGateForDocument.mockResolvedValue('block');
+
+    render(<ProvingScreenRouter />);
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith(
+        'DocumentSelectorForProving',
+        expect.objectContaining({ entryPoint: 'qr_scan' }),
+      );
+    });
+
+    expect(mockSetSelectedDocument).not.toHaveBeenCalled();
+    expect(mockReplace).not.toHaveBeenCalledWith('Prove');
+    expect(mockGoBack).not.toHaveBeenCalled();
+    expect(mockCleanSelfApp).not.toHaveBeenCalled();
+    expect(mockEvaluateGoogleUsatGateForDocument).not.toHaveBeenCalled();
+  });
+
+  it('skips block-path side effects when the routing pass is aborted mid-gate', async () => {
+    const kyc = createMetadata({
+      id: 'doc-kyc',
+      documentCategory: 'kyc',
+      isRegistered: true,
+    });
+    const catalog: DocumentCatalog = {
+      documents: [kyc],
+      selectedDocumentId: 'doc-kyc',
+    } as any;
+    const allDocs = createAllDocuments([createDocumentEntry(kyc)]);
+
+    const mockGoBack = jest.fn();
+    mockUseNavigation.mockReturnValue({
+      replace: mockReplace,
+      goBack: mockGoBack,
+    } as any);
+
+    mockLoadDocumentCatalog.mockResolvedValue(catalog);
+    mockGetAllDocuments.mockResolvedValue(allDocs);
+
+    // Hold the gate evaluation pending until we abort.
+    let resolveGate: (value: 'allow' | 'block') => void = () => {};
+    mockEvaluateGoogleUsatGate.mockReturnValueOnce(
+      new Promise(resolve => {
+        resolveGate = resolve;
+      }),
+    );
+    mockHasEligibleGoogleUsatAlternativeDocument.mockReturnValue(false);
+
+    const { unmount } = render(<ProvingScreenRouter />);
+
+    await waitFor(() => {
+      expect(mockEvaluateGoogleUsatGate).toHaveBeenCalledTimes(1);
+    });
+
+    // Unmount triggers the cleanup effect, which aborts the in-flight pass.
+    unmount();
+
+    await act(async () => {
+      resolveGate('block');
+      await Promise.resolve();
+    });
+
+    expect(mockTrackEvent).not.toHaveBeenCalled();
+    expect(mockCleanSelfApp).not.toHaveBeenCalled();
+    expect(mockGoBack).not.toHaveBeenCalled();
+    expect(mockReplace).not.toHaveBeenCalled();
   });
 
   it('falls back to document selector when setSelectedDocument fails', async () => {

--- a/app/tests/src/screens/verification/ProvingScreenRouter.test.tsx
+++ b/app/tests/src/screens/verification/ProvingScreenRouter.test.tsx
@@ -11,6 +11,7 @@ import type {
   IDDocument,
 } from '@selfxyz/common/utils/types';
 import {
+  hasEligibleAlternativeDocumentForPolicy,
   isDocumentValidForProving,
   pickBestDocumentToSelect,
   useSelfClient,
@@ -41,6 +42,8 @@ jest.mock('@react-navigation/native', () => {
 });
 
 jest.mock('@selfxyz/mobile-sdk-alpha', () => ({
+  GOOGLE_USAT_FAUCET_POLICY: { id: 'google-usat-faucet' },
+  hasEligibleAlternativeDocumentForPolicy: jest.fn(() => false),
   isDocumentValidForProving: jest.fn(),
   pickBestDocumentToSelect: jest.fn(),
   useSelfClient: jest.fn(),
@@ -83,6 +86,10 @@ const mockEvaluateGoogleUsatGate =
 const mockEvaluateGoogleUsatGateForDocument =
   evaluateGoogleUsatGateForDocument as jest.MockedFunction<
     typeof evaluateGoogleUsatGateForDocument
+  >;
+const mockHasEligibleGoogleUsatAlternativeDocument =
+  hasEligibleAlternativeDocumentForPolicy as jest.MockedFunction<
+    typeof hasEligibleAlternativeDocumentForPolicy
   >;
 const mockReplace = jest.fn();
 const mockLoadDocumentCatalog = jest.fn();
@@ -150,6 +157,7 @@ describe('ProvingScreenRouter', () => {
     } as any);
     mockEvaluateGoogleUsatGate.mockResolvedValue('allow');
     mockEvaluateGoogleUsatGateForDocument.mockResolvedValue('allow');
+    mockHasEligibleGoogleUsatAlternativeDocument.mockReturnValue(false);
 
     mockUsePassport.mockReturnValue({
       loadDocumentCatalog: mockLoadDocumentCatalog,
@@ -333,6 +341,108 @@ describe('ProvingScreenRouter', () => {
 
     // Should NOT auto-select since there are multiple documents
     expect(mockSetSelectedDocument).not.toHaveBeenCalled();
+  });
+
+  it('routes to selector instead of hard-blocking when an eligible alternative doc exists', async () => {
+    const kyc = createMetadata({
+      id: 'doc-kyc',
+      documentCategory: 'kyc',
+      isRegistered: true,
+    });
+    const passport = createMetadata({
+      id: 'doc-passport',
+      documentType: 'us',
+      isRegistered: true,
+    });
+    const catalog: DocumentCatalog = {
+      documents: [kyc, passport],
+      selectedDocumentId: 'doc-kyc',
+    } as any;
+    const allDocs = createAllDocuments([
+      createDocumentEntry(kyc),
+      createDocumentEntry(passport),
+    ]);
+
+    mockLoadDocumentCatalog.mockResolvedValue(catalog);
+    mockGetAllDocuments.mockResolvedValue(allDocs);
+    mockEvaluateGoogleUsatGate.mockResolvedValue('block');
+    mockHasEligibleGoogleUsatAlternativeDocument.mockReturnValue(true);
+
+    render(<ProvingScreenRouter />);
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith(
+        'DocumentSelectorForProving',
+        expect.objectContaining({ entryPoint: 'qr_scan' }),
+      );
+    });
+
+    expect(mockCleanSelfApp).not.toHaveBeenCalled();
+    expect(mockTrackEvent).not.toHaveBeenCalledWith(
+      'Proof: Google USAT Disclosure Blocked',
+      expect.anything(),
+    );
+  });
+
+  it('hard-blocks (modal + cleanSelfApp + goBack) when no eligible alternative doc exists', async () => {
+    const kyc = createMetadata({
+      id: 'doc-kyc',
+      documentCategory: 'kyc',
+      isRegistered: true,
+    });
+    const catalog: DocumentCatalog = {
+      documents: [kyc],
+      selectedDocumentId: 'doc-kyc',
+    } as any;
+    const allDocs = createAllDocuments([createDocumentEntry(kyc)]);
+
+    const mockGoBack = jest.fn();
+    mockUseNavigation.mockReturnValue({
+      replace: mockReplace,
+      goBack: mockGoBack,
+    } as any);
+
+    mockLoadDocumentCatalog.mockResolvedValue(catalog);
+    mockGetAllDocuments.mockResolvedValue(allDocs);
+    mockEvaluateGoogleUsatGate.mockResolvedValue('block');
+    mockHasEligibleGoogleUsatAlternativeDocument.mockReturnValue(false);
+
+    render(<ProvingScreenRouter />);
+
+    await waitFor(() => {
+      expect(mockCleanSelfApp).toHaveBeenCalledTimes(1);
+      expect(mockGoBack).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      expect.stringContaining('Google USAT'),
+      expect.objectContaining({ reason: 'no_high_security_doc' }),
+    );
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('fetches catalog and docs at most once per routing pass', async () => {
+    const passport = createMetadata({
+      id: 'doc-1',
+      documentType: 'us',
+      isRegistered: true,
+    });
+    const catalog: DocumentCatalog = {
+      documents: [passport],
+    };
+    const allDocs = createAllDocuments([createDocumentEntry(passport)]);
+
+    mockLoadDocumentCatalog.mockResolvedValue(catalog);
+    mockGetAllDocuments.mockResolvedValue(allDocs);
+
+    render(<ProvingScreenRouter />);
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalled();
+    });
+
+    expect(mockLoadDocumentCatalog).toHaveBeenCalledTimes(1);
+    expect(mockGetAllDocuments).toHaveBeenCalledTimes(1);
   });
 
   it('falls back to document selector when setSelectedDocument fails', async () => {

--- a/app/tests/src/screens/verification/ProvingScreenRouter.test.tsx
+++ b/app/tests/src/screens/verification/ProvingScreenRouter.test.tsx
@@ -468,10 +468,10 @@ describe('ProvingScreenRouter', () => {
     mockGetAllDocuments.mockResolvedValue(allDocs);
     mockEvaluateGoogleUsatGate.mockResolvedValue('block');
     mockHasEligibleGoogleUsatAlternativeDocument.mockReturnValue(true);
-    // pickBestDocumentToSelect would pick the blocked doc-kyc and the
-    // per-document gate would re-block it — proving the previous bug.
-    mockPickBestDocumentToSelect.mockReturnValue('doc-kyc');
-    mockEvaluateGoogleUsatGateForDocument.mockResolvedValue('block');
+    mockEvaluateGoogleUsatGateForDocument.mockImplementation(
+      async (_selfClient, _app, documentId) =>
+        documentId === 'doc-passport' ? 'allow' : 'block',
+    );
 
     render(<ProvingScreenRouter />);
 
@@ -486,7 +486,12 @@ describe('ProvingScreenRouter', () => {
     expect(mockReplace).not.toHaveBeenCalledWith('Prove');
     expect(mockGoBack).not.toHaveBeenCalled();
     expect(mockCleanSelfApp).not.toHaveBeenCalled();
-    expect(mockEvaluateGoogleUsatGateForDocument).not.toHaveBeenCalled();
+    expect(mockEvaluateGoogleUsatGateForDocument).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'doc-passport',
+      expect.anything(),
+    );
   });
 
   it('skips block-path side effects when the routing pass is aborted mid-gate', async () => {

--- a/app/tests/src/utils/googleUsatGate.test.ts
+++ b/app/tests/src/utils/googleUsatGate.test.ts
@@ -9,15 +9,50 @@ import {
 
 import {
   evaluateGoogleUsatGate,
-  FORCE_GOOGLE_USAT_FOR_TESTING,
   evaluateGoogleUsatGateForDocument,
-  hasEligibleGoogleUsatAlternativeDocument,
+  FORCE_GOOGLE_USAT_FOR_TESTING,
 } from '@/utils/googleUsatGate';
 
-jest.mock('@selfxyz/mobile-sdk-alpha', () => ({
-  getAllDocuments: jest.fn(),
-  isGoogleUsatProofRequest: jest.fn(),
-}));
+jest.mock('@selfxyz/mobile-sdk-alpha', () => {
+  const policy = {
+    id: 'google-usat-faucet',
+    match: {
+      endpoint: 'https://example/api/verify',
+      scope: 'celo-mainnet-tether-usat',
+      appName: 'Google Cloud Web3 Portal',
+    },
+    allowedCategories: ['passport', 'id_card'],
+    allowMock: false,
+  };
+  return {
+    getAllDocuments: jest.fn(),
+    isGoogleUsatProofRequest: jest.fn(),
+    GOOGLE_USAT_FAUCET_POLICY: policy,
+    isDocumentEligibleForPolicy: (
+      p: typeof policy,
+      category: string,
+      isMock: boolean | undefined,
+    ) =>
+      p.allowedCategories.includes(category) &&
+      !(isMock === true && !p.allowMock),
+    hasEligibleAlternativeDocumentForPolicy: (
+      p: typeof policy,
+      docs: Record<
+        string,
+        { data: { documentCategory: string; mock?: boolean } }
+      >,
+      excludedDocumentId: string,
+    ) =>
+      Object.entries(docs).some(([id, doc]) => {
+        if (id === excludedDocumentId) return false;
+        const { documentCategory, mock } = doc.data;
+        return (
+          p.allowedCategories.includes(documentCategory) &&
+          !(mock === true && !p.allowMock)
+        );
+      }),
+  };
+});
 
 const mockGetAllDocuments = getAllDocuments as jest.MockedFunction<
   typeof getAllDocuments
@@ -168,19 +203,5 @@ describe('evaluateGoogleUsatGate', () => {
       evaluateGoogleUsatGateForDocument(selfClient, app, 'selected', docs),
     ).resolves.toBe('allow');
     expect(mockGetAllDocuments).not.toHaveBeenCalled();
-  });
-
-  it('detects eligible alternative docs when selected one is excluded', () => {
-    expect(
-      hasEligibleGoogleUsatAlternativeDocument(
-        {
-          selected: { data: { documentCategory: 'kyc', mock: false } } as any,
-          eligible: {
-            data: { documentCategory: 'passport', mock: false },
-          } as any,
-        },
-        'selected',
-      ),
-    ).toBe(true);
   });
 });

--- a/app/tests/src/utils/googleUsatGate.test.ts
+++ b/app/tests/src/utils/googleUsatGate.test.ts
@@ -10,6 +10,8 @@ import {
 import {
   evaluateGoogleUsatGate,
   FORCE_GOOGLE_USAT_FOR_TESTING,
+  evaluateGoogleUsatGateForDocument,
+  hasEligibleGoogleUsatAlternativeDocument,
 } from '@/utils/googleUsatGate';
 
 jest.mock('@selfxyz/mobile-sdk-alpha', () => ({
@@ -44,15 +46,10 @@ describe('evaluateGoogleUsatGate', () => {
   });
 
   it('treats non Google USAT requests according to the force-test toggle', async () => {
-    // While FORCE_GOOGLE_USAT_FOR_TESTING is on, every request is gated as if
-    // it were a USAT request, so an empty doc catalog blocks. When the toggle
-    // is removed, this should allow without consulting the catalog.
     const result = await evaluateGoogleUsatGate(selfClient, app);
-    const expected = FORCE_GOOGLE_USAT_FOR_TESTING ? 'block' : 'allow';
-    const expectedGetAllDocumentsCalls = FORCE_GOOGLE_USAT_FOR_TESTING ? 1 : 0;
-    expect(result).toBe(expected);
+    expect(result).toBe('allow');
     expect(mockGetAllDocuments).toHaveBeenCalledTimes(
-      expectedGetAllDocumentsCalls,
+      FORCE_GOOGLE_USAT_FOR_TESTING ? 1 : 0,
     );
   });
 
@@ -160,5 +157,30 @@ describe('evaluateGoogleUsatGate', () => {
 
   it('exposes testing force toggle', () => {
     expect(typeof FORCE_GOOGLE_USAT_FOR_TESTING).toBe('boolean');
+  });
+
+  it('reuses prefetched docs for per-document gate checks', async () => {
+    mockIsGoogleUsatProofRequest.mockReturnValue(true);
+    const docs = {
+      selected: { data: { documentCategory: 'passport', mock: false } } as any,
+    };
+    await expect(
+      evaluateGoogleUsatGateForDocument(selfClient, app, 'selected', docs),
+    ).resolves.toBe('allow');
+    expect(mockGetAllDocuments).not.toHaveBeenCalled();
+  });
+
+  it('detects eligible alternative docs when selected one is excluded', () => {
+    expect(
+      hasEligibleGoogleUsatAlternativeDocument(
+        {
+          selected: { data: { documentCategory: 'kyc', mock: false } } as any,
+          eligible: {
+            data: { documentCategory: 'passport', mock: false },
+          } as any,
+        },
+        'selected',
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/mobile-sdk-alpha/src/browser.ts
+++ b/packages/mobile-sdk-alpha/src/browser.ts
@@ -53,6 +53,7 @@ export {
   GOOGLE_USAT_FAUCET_ENDPOINT,
   GOOGLE_USAT_FAUCET_SCOPE,
 } from './constants/googleUsat';
+export { GOOGLE_USAT_FAUCET_POLICY } from './constants/restrictedApps';
 export {
   InitError,
   LivenessError,
@@ -85,13 +86,15 @@ export {
   createWebNetworkAdapter,
 } from './adapters/browser';
 export { createListenersMap, createSelfClient } from './client';
+
 export { defaultConfig } from './config/defaults';
 /** @deprecated Use createSelfClient().extractMRZInfo or import from './mrz' */
 export { extractMRZInfo, extractNameFromMRZ, formatDateToYYMMDD } from './mrz';
 export { finalizeRecoveredDocumentRegistration, validateRecoverySecretForDocument } from './proving/recoveryValidation';
-export { generateMockDocument, signatureAlgorithmToStrictSignatureAlgorithm } from './mock/generator';
 
+export { generateMockDocument, signatureAlgorithmToStrictSignatureAlgorithm } from './mock/generator';
 export { getPostVerificationRoute, useProvingStore } from './proving/provingMachine';
+export { hasEligibleAlternativeDocumentForPolicy, isDocumentEligibleForPolicy } from './utils/restrictedApps';
 export { isGoogleUsatProofRequest } from './utils/googleUsat';
 export { isPassportDataValid } from './validation/document';
 export { mergeConfig } from './config/merge';

--- a/packages/mobile-sdk-alpha/src/constants/restrictedApps.ts
+++ b/packages/mobile-sdk-alpha/src/constants/restrictedApps.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import type { DocumentCategory } from '@selfxyz/common/utils/types';
+
+import { GOOGLE_USAT_FAUCET_APP_NAME, GOOGLE_USAT_FAUCET_ENDPOINT, GOOGLE_USAT_FAUCET_SCOPE } from './googleUsat';
+
+/**
+ * A RestrictedAppPolicy declares that a verifier app, identified by an
+ * (endpoint, scope, appName) triple, requires a constrained set of document
+ * categories and excludes mock documents.
+ *
+ * Add entries to RESTRICTED_APP_REGISTRY to apply the same UX gate to a new
+ * partner without changing call-site code. The gate is a UX guard, not a
+ * security boundary — server-side checks remain authoritative.
+ */
+export interface RestrictedAppPolicy {
+  /** Stable identifier used in analytics and modal copy lookup. */
+  readonly id: string;
+  /** Identity to match on. Endpoint comparison is trim+lowercase normalized. */
+  readonly match: {
+    readonly endpoint: string;
+    readonly scope: string;
+    readonly appName: string;
+  };
+  /** Document categories the verifier accepts. Others fail the gate. */
+  readonly allowedCategories: ReadonlyArray<DocumentCategory>;
+  /** Whether mock documents are accepted by the verifier. */
+  readonly allowMock: boolean;
+}
+
+export const GOOGLE_USAT_FAUCET_POLICY: RestrictedAppPolicy = {
+  id: 'google-usat-faucet',
+  match: {
+    endpoint: GOOGLE_USAT_FAUCET_ENDPOINT,
+    scope: GOOGLE_USAT_FAUCET_SCOPE,
+    appName: GOOGLE_USAT_FAUCET_APP_NAME,
+  },
+  allowedCategories: ['passport', 'id_card'],
+  allowMock: false,
+};
+
+export const RESTRICTED_APP_REGISTRY: ReadonlyArray<RestrictedAppPolicy> = [GOOGLE_USAT_FAUCET_POLICY];

--- a/packages/mobile-sdk-alpha/src/index.ts
+++ b/packages/mobile-sdk-alpha/src/index.ts
@@ -73,6 +73,8 @@ export {
   GOOGLE_USAT_FAUCET_SCOPE,
 } from './constants/googleUsat';
 
+export { GOOGLE_USAT_FAUCET_POLICY } from './constants/restrictedApps';
+
 export {
   InitError,
   LivenessError,
@@ -145,21 +147,21 @@ export { createDocumentsAdapter, createInMemoryDocumentsAdapter } from './adapte
 export { createListenersMap, createSelfClient } from './client';
 
 export { createNetworkAdapter } from './adapters/react-native/network';
-
 export { createReactNativeAdapters } from './adapters/react-native/factory';
 export { defaultConfig } from './config/defaults';
-export { defaultOptions } from './haptic/shared';
 
+export { defaultOptions } from './haptic/shared';
 /** @deprecated Use createSelfClient().extractMRZInfo or import from './mrz' */
 export { extractMRZInfo } from './mrz';
-export { extractNameFromDocument } from './documents/utils';
 
+export { extractNameFromDocument } from './documents/utils';
 export { extractNameFromMRZ, formatDateToYYMMDD, parseMRZBirthDate, parseMRZExpiryDate } from './mrz';
+
 export { finalizeRecoveredDocumentRegistration, validateRecoverySecretForDocument } from './proving/recoveryValidation';
 
 export { generateMockDocument, signatureAlgorithmToStrictSignatureAlgorithm } from './mock/generator';
-
 export { getEligiblePerksForIdType } from './flows/onboarding/perks';
+export { hasEligibleAlternativeDocumentForPolicy, isDocumentEligibleForPolicy } from './utils/restrictedApps';
 export { isGoogleUsatProofRequest } from './utils/googleUsat';
 
 export { isPassportDataValid } from './validation/document';

--- a/packages/mobile-sdk-alpha/src/utils/googleUsat.ts
+++ b/packages/mobile-sdk-alpha/src/utils/googleUsat.ts
@@ -27,7 +27,7 @@ export function isGoogleUsatProofRequest(
   identity: GoogleUsatFaucetIdentity = GOOGLE_USAT_FAUCET_IDENTITY,
 ): boolean {
   return (
-    app.endpoint?.trim().toLowerCase() === identity.endpoint.toLowerCase() &&
+    app.endpoint?.trim().toLowerCase() === identity.endpoint.trim().toLowerCase() &&
     app.scope === identity.scope &&
     app.appName === identity.appName
   );

--- a/packages/mobile-sdk-alpha/src/utils/googleUsat.ts
+++ b/packages/mobile-sdk-alpha/src/utils/googleUsat.ts
@@ -4,11 +4,8 @@
 
 import type { SelfApp } from '@selfxyz/common/utils';
 
-import {
-  GOOGLE_USAT_FAUCET_APP_NAME,
-  GOOGLE_USAT_FAUCET_ENDPOINT,
-  GOOGLE_USAT_FAUCET_SCOPE,
-} from '../constants/googleUsat';
+import { GOOGLE_USAT_FAUCET_POLICY } from '../constants/restrictedApps';
+import { findRestrictedAppPolicy } from './restrictedApps';
 
 export interface GoogleUsatFaucetIdentity {
   endpoint: string;
@@ -17,18 +14,28 @@ export interface GoogleUsatFaucetIdentity {
 }
 
 export const GOOGLE_USAT_FAUCET_IDENTITY: GoogleUsatFaucetIdentity = {
-  endpoint: GOOGLE_USAT_FAUCET_ENDPOINT,
-  scope: GOOGLE_USAT_FAUCET_SCOPE,
-  appName: GOOGLE_USAT_FAUCET_APP_NAME,
+  endpoint: GOOGLE_USAT_FAUCET_POLICY.match.endpoint,
+  scope: GOOGLE_USAT_FAUCET_POLICY.match.scope,
+  appName: GOOGLE_USAT_FAUCET_POLICY.match.appName,
 };
 
+/**
+ * Matches the Google USAT faucet app by identity. Backed by the
+ * RESTRICTED_APP_REGISTRY — for general restricted-app matching prefer
+ * findRestrictedAppPolicy(). This function exists so existing call sites
+ * continue to compile unchanged.
+ */
 export function isGoogleUsatProofRequest(
   app: SelfApp,
   identity: GoogleUsatFaucetIdentity = GOOGLE_USAT_FAUCET_IDENTITY,
 ): boolean {
-  return (
-    app.endpoint?.trim().toLowerCase() === identity.endpoint.trim().toLowerCase() &&
-    app.scope === identity.scope &&
-    app.appName === identity.appName
-  );
+  const matched = findRestrictedAppPolicy(app, [
+    {
+      id: GOOGLE_USAT_FAUCET_POLICY.id,
+      match: identity,
+      allowedCategories: GOOGLE_USAT_FAUCET_POLICY.allowedCategories,
+      allowMock: GOOGLE_USAT_FAUCET_POLICY.allowMock,
+    },
+  ]);
+  return matched !== null;
 }

--- a/packages/mobile-sdk-alpha/src/utils/restrictedApps.ts
+++ b/packages/mobile-sdk-alpha/src/utils/restrictedApps.ts
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import type { SelfApp } from '@selfxyz/common/utils';
+import type { DocumentCategory } from '@selfxyz/common/utils/types';
+
+import { RESTRICTED_APP_REGISTRY, type RestrictedAppPolicy } from '../constants/restrictedApps';
+
+function normalizeEndpoint(value: string | undefined): string {
+  return value?.trim().toLowerCase() ?? '';
+}
+
+/**
+ * Returns the RestrictedAppPolicy whose identity matches the given SelfApp,
+ * or null if none match. Endpoint comparison is trim+lowercase normalized on
+ * both sides; scope and appName are exact (case-sensitive) matches.
+ */
+export function findRestrictedAppPolicy(
+  app: SelfApp,
+  registry: ReadonlyArray<RestrictedAppPolicy> = RESTRICTED_APP_REGISTRY,
+): RestrictedAppPolicy | null {
+  const endpoint = normalizeEndpoint(app.endpoint);
+  for (const policy of registry) {
+    if (
+      endpoint === normalizeEndpoint(policy.match.endpoint) &&
+      app.scope === policy.match.scope &&
+      app.appName === policy.match.appName
+    ) {
+      return policy;
+    }
+  }
+  return null;
+}
+
+export function isRestrictedAppProofRequest(
+  app: SelfApp,
+  registry: ReadonlyArray<RestrictedAppPolicy> = RESTRICTED_APP_REGISTRY,
+): boolean {
+  return findRestrictedAppPolicy(app, registry) !== null;
+}
+
+export function isDocumentEligibleForPolicy(
+  policy: RestrictedAppPolicy,
+  category: DocumentCategory,
+  isMock: boolean | undefined,
+): boolean {
+  if (!policy.allowedCategories.includes(category)) {
+    return false;
+  }
+  if (isMock === true && !policy.allowMock) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Minimal document shape needed for policy eligibility checks. Matches the
+ * shape returned by getAllDocuments() — kept narrow so the SDK doesn't pull
+ * a heavier document type into this surface.
+ */
+export interface PolicyEligibleDocument {
+  data: {
+    documentCategory: DocumentCategory;
+    mock?: boolean;
+  };
+}
+
+/**
+ * Returns true if any document in the map (other than `excludedDocumentId`)
+ * satisfies the policy's eligibility rules.
+ */
+export function hasEligibleAlternativeDocumentForPolicy<TDocument extends PolicyEligibleDocument>(
+  policy: RestrictedAppPolicy,
+  docs: Readonly<Record<string, TDocument>>,
+  excludedDocumentId: string,
+): boolean {
+  for (const [documentId, document] of Object.entries(docs)) {
+    if (documentId === excludedDocumentId) continue;
+    if (isDocumentEligibleForPolicy(policy, document.data.documentCategory, document.data.mock)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/packages/mobile-sdk-alpha/tests/utils/googleUsat.test.ts
+++ b/packages/mobile-sdk-alpha/tests/utils/googleUsat.test.ts
@@ -63,6 +63,20 @@ describe('isGoogleUsatProofRequest', () => {
     expect(isGoogleUsatProofRequest(buildApp({ appName: GOOGLE_USAT_FAUCET_APP_NAME.toUpperCase() }))).toBe(false);
   });
 
+
+  it('normalizes identity endpoint whitespace and case in override comparisons', () => {
+    expect(
+      isGoogleUsatProofRequest(
+        buildApp({ endpoint: 'https://override.example/api' }),
+        {
+          endpoint: '  HTTPS://OVERRIDE.EXAMPLE/API  ',
+          scope: GOOGLE_USAT_FAUCET_SCOPE,
+          appName: GOOGLE_USAT_FAUCET_APP_NAME,
+        },
+      ),
+    ).toBe(true);
+  });
+
   it('accepts a custom identity override', () => {
     const identity = {
       endpoint: 'https://override.example/api',

--- a/packages/mobile-sdk-alpha/tests/utils/googleUsat.test.ts
+++ b/packages/mobile-sdk-alpha/tests/utils/googleUsat.test.ts
@@ -63,17 +63,13 @@ describe('isGoogleUsatProofRequest', () => {
     expect(isGoogleUsatProofRequest(buildApp({ appName: GOOGLE_USAT_FAUCET_APP_NAME.toUpperCase() }))).toBe(false);
   });
 
-
   it('normalizes identity endpoint whitespace and case in override comparisons', () => {
     expect(
-      isGoogleUsatProofRequest(
-        buildApp({ endpoint: 'https://override.example/api' }),
-        {
-          endpoint: '  HTTPS://OVERRIDE.EXAMPLE/API  ',
-          scope: GOOGLE_USAT_FAUCET_SCOPE,
-          appName: GOOGLE_USAT_FAUCET_APP_NAME,
-        },
-      ),
+      isGoogleUsatProofRequest(buildApp({ endpoint: 'https://override.example/api' }), {
+        endpoint: '  HTTPS://OVERRIDE.EXAMPLE/API  ',
+        scope: GOOGLE_USAT_FAUCET_SCOPE,
+        appName: GOOGLE_USAT_FAUCET_APP_NAME,
+      }),
     ).toBe(true);
   });
 

--- a/packages/mobile-sdk-alpha/tests/utils/restrictedApps.test.ts
+++ b/packages/mobile-sdk-alpha/tests/utils/restrictedApps.test.ts
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import type { SelfApp } from '@selfxyz/common/utils';
+import type { DocumentCategory } from '@selfxyz/common/utils/types';
+
+import { GOOGLE_USAT_FAUCET_POLICY, type RestrictedAppPolicy } from '../../src/constants/restrictedApps';
+import {
+  findRestrictedAppPolicy,
+  hasEligibleAlternativeDocumentForPolicy,
+  isDocumentEligibleForPolicy,
+  isRestrictedAppProofRequest,
+} from '../../src/utils/restrictedApps';
+
+const policy: RestrictedAppPolicy = GOOGLE_USAT_FAUCET_POLICY;
+
+function buildApp(overrides: Partial<SelfApp> = {}): SelfApp {
+  return {
+    appName: policy.match.appName,
+    logoBase64: '',
+    scope: policy.match.scope,
+    endpoint: policy.match.endpoint,
+    endpointType: 'celo',
+    header: '',
+    userId: 'u',
+    sessionId: 's',
+    disclosures: {},
+    deeplinkCallback: '',
+    userIdType: 'uuid',
+    version: 2,
+    userDefinedData: '',
+    selfDefinedData: '',
+    devMode: false,
+    chainID: 42220,
+    ...overrides,
+  };
+}
+
+function buildDoc(category: DocumentCategory, mock = false) {
+  return { data: { documentCategory: category, mock } };
+}
+
+describe('findRestrictedAppPolicy', () => {
+  it('returns the policy when identity matches exactly', () => {
+    expect(findRestrictedAppPolicy(buildApp())).toBe(policy);
+  });
+
+  it('normalizes endpoint whitespace and case on both sides', () => {
+    expect(findRestrictedAppPolicy(buildApp({ endpoint: `  ${policy.match.endpoint.toUpperCase()}  ` }))).toBe(policy);
+  });
+
+  it('returns null when scope differs (scope is case-sensitive)', () => {
+    expect(findRestrictedAppPolicy(buildApp({ scope: policy.match.scope.toUpperCase() }))).toBeNull();
+  });
+
+  it('returns null when appName differs (appName is case-sensitive)', () => {
+    expect(findRestrictedAppPolicy(buildApp({ appName: 'Different App' }))).toBeNull();
+  });
+
+  it('accepts a custom registry override', () => {
+    const overridePolicy: RestrictedAppPolicy = {
+      id: 'override',
+      match: { endpoint: 'https://x', scope: 's', appName: 'A' },
+      allowedCategories: ['passport'],
+      allowMock: false,
+    };
+    expect(
+      findRestrictedAppPolicy(buildApp({ endpoint: 'https://x', scope: 's', appName: 'A' }), [overridePolicy]),
+    ).toBe(overridePolicy);
+  });
+});
+
+describe('isRestrictedAppProofRequest', () => {
+  it('is true when a policy matches', () => {
+    expect(isRestrictedAppProofRequest(buildApp())).toBe(true);
+  });
+
+  it('is false when no policy matches', () => {
+    expect(isRestrictedAppProofRequest(buildApp({ appName: 'Nope' }))).toBe(false);
+  });
+});
+
+describe('isDocumentEligibleForPolicy', () => {
+  it('allows categories that are in allowedCategories', () => {
+    expect(isDocumentEligibleForPolicy(policy, 'passport', false)).toBe(true);
+    expect(isDocumentEligibleForPolicy(policy, 'id_card', false)).toBe(true);
+  });
+
+  it('rejects categories not in allowedCategories', () => {
+    expect(isDocumentEligibleForPolicy(policy, 'kyc', false)).toBe(false);
+    expect(isDocumentEligibleForPolicy(policy, 'aadhaar', false)).toBe(false);
+  });
+
+  it('rejects mock documents when allowMock is false', () => {
+    expect(isDocumentEligibleForPolicy(policy, 'passport', true)).toBe(false);
+  });
+
+  it('accepts mock documents when allowMock is true', () => {
+    const lenient: RestrictedAppPolicy = { ...policy, allowMock: true };
+    expect(isDocumentEligibleForPolicy(lenient, 'passport', true)).toBe(true);
+  });
+
+  it('treats undefined mock flag as non-mock', () => {
+    expect(isDocumentEligibleForPolicy(policy, 'passport', undefined)).toBe(true);
+  });
+});
+
+describe('hasEligibleAlternativeDocumentForPolicy', () => {
+  it('returns true when an alternative eligible doc exists', () => {
+    expect(
+      hasEligibleAlternativeDocumentForPolicy(
+        policy,
+        {
+          selected: buildDoc('kyc'),
+          alt: buildDoc('passport'),
+        },
+        'selected',
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false when only ineligible alternatives exist', () => {
+    expect(
+      hasEligibleAlternativeDocumentForPolicy(
+        policy,
+        {
+          selected: buildDoc('kyc'),
+          alt: buildDoc('aadhaar'),
+        },
+        'selected',
+      ),
+    ).toBe(false);
+  });
+
+  it('excludes the named document from consideration', () => {
+    expect(hasEligibleAlternativeDocumentForPolicy(policy, { selected: buildDoc('passport') }, 'selected')).toBe(false);
+  });
+
+  it('skips mock alternatives when allowMock is false', () => {
+    expect(
+      hasEligibleAlternativeDocumentForPolicy(
+        policy,
+        {
+          selected: buildDoc('kyc'),
+          alt: buildDoc('passport', true),
+        },
+        'selected',
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false on empty doc map', () => {
+    expect(hasEligibleAlternativeDocumentForPolicy(policy, {}, 'selected')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Address PR review feedback on #2073/#2074 for the Google USAT gate: stop hard-blocking when an eligible alternative document exists, fix duplicate `loadDocumentCatalog`/`getAllDocuments` calls in the routing hot path, and normalize endpoint comparison on both sides.
- Introduce a minimal `RestrictedAppPolicy` abstraction in the SDK so the gate's eligibility rules (allowed categories, mock policy) are data-driven and extensible to additional partner apps without changing call-site code.
- Backfill direct unit tests for the new SDK helpers and router behavior, keeping the public SDK surface minimal (only the three symbols the app consumes).

## Changes

### React Native app

- `ProvingScreenRouter`: fetch catalog + docs once and pass them into `evaluateGoogleUsatGate({ catalog, docs })` so the gate never refetches; on a `'block'` verdict, check for an eligible non-KYC alternative document and route to `DocumentSelectorForProving` instead of calling `cleanSelfApp` + `goBack`; hard-block (modal + session teardown) is now reserved for the zero-eligible-doc case.
- `googleUsatGate.ts`: accept optional `{ catalog, docs }` context to short-circuit fetching; delegate eligibility to `isDocumentEligibleForPolicy(GOOGLE_USAT_FAUCET_POLICY, …)`; removed the local hardcoded category set and the app-side `hasEligibleGoogleUsatAlternativeDocument` (call sites use the SDK helper directly).

### SDK core

- New `packages/mobile-sdk-alpha/src/constants/restrictedApps.ts`: `RestrictedAppPolicy` type, `GOOGLE_USAT_FAUCET_POLICY`, internal `RESTRICTED_APP_REGISTRY`.
- New `packages/mobile-sdk-alpha/src/utils/restrictedApps.ts`: `findRestrictedAppPolicy`, `isRestrictedAppProofRequest`, `isDocumentEligibleForPolicy`, `hasEligibleAlternativeDocumentForPolicy`. Endpoint comparison is trim+lowercase normalized on both sides — closes the asymmetry in `identity.endpoint` raised in review.
- `utils/googleUsat.ts`: `isGoogleUsatProofRequest` now delegates to the registry; existing call sites and exports are unchanged.
- Public exports trimmed to the three symbols the app actually consumes: `GOOGLE_USAT_FAUCET_POLICY`, `hasEligibleAlternativeDocumentForPolicy`, `isDocumentEligibleForPolicy`. The registry, finder, and policy type stay internal.

### Tests

- New `packages/mobile-sdk-alpha/tests/utils/restrictedApps.test.ts` (17 tests): identity matching with normalization + case sensitivity, custom registry override, category/mock eligibility, alternative-doc detection, empty-map and exclusion semantics.
- `ProvingScreenRouter.test.tsx`: added three cases — `'block'` + alternative routes to selector (no `cleanSelfApp`/`goBack`); `'block'` + no alternative hard-blocks (modal + `cleanSelfApp` + `goBack`); fetch-count regression asserting `loadDocumentCatalog` and `getAllDocuments` each called exactly once per routing pass.
- `googleUsatGate.test.ts`: updated SDK mock to provide the new policy helpers; existing assertions preserved.

## Test Plan

- [ ] `yarn lint && yarn types` passes
- [x] `cd packages/mobile-sdk-alpha && yarn test` — 44 files, 423 tests pass (incl. new `restrictedApps.test.ts`)
- [x] `cd packages/mobile-sdk-alpha && yarn types` — pass
- [x] `cd packages/mobile-sdk-alpha && yarn lint` — pass
- [x] `cd app && yarn jest tests/src/utils/googleUsatGate.test.ts` — 11/11 pass
- [x] `cd app && yarn types` — pass
- [ ] `cd app && yarn jest tests/src/screens/verification/ProvingScreenRouter.test.tsx` — local run hits a pre-existing ESM/jest config issue with `@react-navigation/native` (reproduces with my changes stashed); needs CI verification
- [ ] Manual: scan QR with USAT app while a KYC doc is selected and a passport exists → should land on `DocumentSelectorForProving` without rescanning
- [ ] Manual: same flow with only a KYC doc in wallet → should show gate modal and return to home

### Native Consolidation Checklist

- [ ] CONTRACTS.md reviewed - no unintended contract changes
- [ ] Layer 1 bridge contract tests pass (`cd app && yarn jest:run`)
- [ ] Layer 3 builds pass (app iOS, RN test app iOS, RN test app Android)
- [ ] No new native business logic added (logic belongs in TypeScript)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized restricted-app policy registry and utilities for evaluating document eligibility; Google faucet policy and related eligibility helpers are now public.
* **Bug Fixes**
  * Verification routing checks for eligible alternative documents before hard-blocking, avoids redundant document fetches, and prevents block side effects if routing is aborted.
* **Tests**
  * Expanded coverage for gating, eligibility rules, endpoint normalization, alternative-document behavior, and prefetched-doc reuse.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/selfxyz/self/pull/2074)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->