### PR TITLE
refactor(nfc): consolidate help affordances on NFC scan and trouble screens

### DIFF
--- a/app/src/navigation/documents.ts
+++ b/app/src/navigation/documents.ts
@@ -63,7 +63,6 @@ const documentsScreens = {
     options: {
       headerShown: false,
       animation: 'slide_from_bottom',
-      presentation: 'modal',
     } as NativeStackNavigationOptions,
   },
   DocumentNFCMethodSelection: {

--- a/app/src/screens/documents/scanning/DocumentNFCScanScreen.tsx
+++ b/app/src/screens/documents/scanning/DocumentNFCScanScreen.tsx
@@ -20,7 +20,8 @@ import {
 } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import NfcManager from 'react-native-nfc-manager';
-import { Button, Image, XStack } from 'tamagui';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Image } from 'tamagui';
 import { v4 as uuidv4 } from 'uuid';
 import type { RouteProp } from '@react-navigation/native';
 import {
@@ -29,7 +30,6 @@ import {
   useRoute,
 } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { CircleHelp } from '@tamagui/lucide-icons';
 
 import type { PassportData } from '@selfxyz/common/types';
 import {
@@ -61,12 +61,12 @@ import { dinot } from '@selfxyz/mobile-sdk-alpha/constants/fonts';
 
 import passportVerifyAnimation from '@/assets/animations/passport_verify.json';
 import NFC_IMAGE from '@/assets/images/nfc.png';
+import { NavBar } from '@/components/navbar/BaseNavBar';
 import { logNFCEvent } from '@/config/sentry';
 import { useErrorInjection } from '@/hooks/useErrorInjection';
 import { useFeedbackAutoHide } from '@/hooks/useFeedbackAutoHide';
 import useHapticNavigation from '@/hooks/useHapticNavigation';
 import { useKycLauncher } from '@/hooks/useKycLauncher';
-import useOpenSupportForm from '@/hooks/useOpenSupportForm';
 import {
   buttonTap,
   feedbackSuccess,
@@ -83,10 +83,7 @@ import {
   setNfcScanningActive,
   trackNfcEvent,
 } from '@/services/analytics';
-import {
-  SUPPORT_FORM_BUTTON_TEXT,
-  SUPPORT_FORM_MESSAGE,
-} from '@/services/support';
+import { extraYPadding } from '@/utils/styleUtils';
 
 const emitter =
   Platform.OS === 'android'
@@ -111,7 +108,7 @@ type DocumentNFCScanRoute = RouteProp<
 const DocumentNFCScanScreen: React.FC = () => {
   const selfClient = useSelfClient();
   const { trackEvent, useMRZStore } = selfClient;
-  const openSupportForm = useOpenSupportForm();
+  const insets = useSafeAreaInsets();
 
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
@@ -194,10 +191,6 @@ const DocumentNFCScanScreen: React.FC = () => {
     .onStart(() => {
       goToNFCMethodSelection();
     });
-
-  const onReportIssue = useCallback(() => {
-    openSupportForm();
-  }, [openSupportForm]);
 
   const openErrorModal = useCallback(
     (message: string) => {
@@ -573,6 +566,23 @@ const DocumentNFCScanScreen: React.FC = () => {
 
   return (
     <ExpandableBottomLayout.Layout backgroundColor={black}>
+      {!isNfcSheetOpen && (
+        <NavBar.Container
+          style={styles.backNavBar}
+          backgroundColor="transparent"
+          barStyle="light"
+          paddingHorizontal="$4"
+          paddingTop={insets.top + extraYPadding}
+          paddingBottom={10}
+        >
+          <NavBar.LeftAction
+            component="back"
+            color={white}
+            onPress={onCancelPress}
+            aria-label="Back"
+          />
+        </NavBar.Container>
+      )}
       <ExpandableBottomLayout.TopSection roundTop backgroundColor={slate100}>
         <LottieView
           ref={animationRef}
@@ -619,19 +629,7 @@ const DocumentNFCScanScreen: React.FC = () => {
             <TextsContainer>
               <GestureDetector gesture={devModeTap}>
                 <View collapsable={false}>
-                  <XStack
-                    justifyContent="space-between"
-                    alignItems="center"
-                    gap="$1.5"
-                  >
-                    <Title>Verify your ID</Title>
-                    <Button
-                      unstyled
-                      onPress={goToNFCTrouble}
-                      icon={<CircleHelp size={28} color={slate500} />}
-                      aria-label="Help"
-                    />
-                  </XStack>
+                  <Title>Verify your ID</Title>
                 </View>
               </GestureDetector>
               {isNfcEnabled ? (
@@ -656,9 +654,6 @@ const DocumentNFCScanScreen: React.FC = () => {
                   </BodyText>
                 </>
               )}
-              <BodyText style={[styles.disclaimer, { marginTop: 12 }]}>
-                {SUPPORT_FORM_MESSAGE}
-              </BodyText>
             </TextsContainer>
             <ButtonsContainer>
               <PrimaryButton
@@ -676,12 +671,9 @@ const DocumentNFCScanScreen: React.FC = () => {
               </PrimaryButton>
               <SecondaryButton
                 trackEvent={PassportEvents.CANCEL_PASSPORT_NFC}
-                onPress={onCancelPress}
+                onPress={goToNFCTrouble}
               >
-                Cancel
-              </SecondaryButton>
-              <SecondaryButton onPress={onReportIssue}>
-                {SUPPORT_FORM_BUTTON_TEXT}
+                Need help?
               </SecondaryButton>
               {(!isNfcSupported || !isNfcEnabled) && (
                 <SecondaryButton
@@ -702,6 +694,13 @@ const DocumentNFCScanScreen: React.FC = () => {
 export default DocumentNFCScanScreen;
 
 const styles = StyleSheet.create({
+  backNavBar: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 10,
+  },
   title: {
     fontFamily: dinot,
     fontSize: 18,

--- a/app/src/screens/documents/scanning/DocumentNFCTroubleScreen.tsx
+++ b/app/src/screens/documents/scanning/DocumentNFCTroubleScreen.tsx
@@ -5,12 +5,16 @@
 import React, { useCallback, useEffect } from 'react';
 import { View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import { YStack } from 'tamagui';
+import { Button, XStack, YStack } from 'tamagui';
 import { useNavigation } from '@react-navigation/native';
 
 import { useSelfClient } from '@selfxyz/mobile-sdk-alpha';
 import { Caption, SecondaryButton } from '@selfxyz/mobile-sdk-alpha/components';
-import { slate500, slate700 } from '@selfxyz/mobile-sdk-alpha/constants/colors';
+import {
+  blue600,
+  slate500,
+  slate700,
+} from '@selfxyz/mobile-sdk-alpha/constants/colors';
 
 import SupportUuidRow from '@/components/support/SupportUuidRow';
 import type { TipProps } from '@/components/Tips';
@@ -18,13 +22,15 @@ import Tips from '@/components/Tips';
 import { useFeedbackAutoHide } from '@/hooks/useFeedbackAutoHide';
 import useHapticNavigation from '@/hooks/useHapticNavigation';
 import { useKycLauncher } from '@/hooks/useKycLauncher';
-import useOpenSupportForm from '@/hooks/useOpenSupportForm';
 import { selectionChange } from '@/integrations/haptics';
 import SimpleScrolledTitleLayout from '@/layouts/SimpleScrolledTitleLayout';
 import { flushAllAnalytics } from '@/services/analytics';
-import { SUPPORT_FORM_BUTTON_TEXT } from '@/services/support';
 
 const tips: TipProps[] = [
+  {
+    title: 'Lay Your Passport Flat',
+    body: "Open your passport and lay it flat on a stable surface. Place your phone on top of the page with the NFC reader over the chip, and keep both items still. If the read doesn't start, slowly slide the phone around the page to locate the chip — but always keep the passport flat and the phone resting on it.",
+  },
   {
     title: 'Know Your Chip Location',
     body: "Depending on your passport's country of origin, the RFID chip could be in the front cover, back cover, or a specific page. Move your device slowly around these areas to locate the chip.",
@@ -38,21 +44,12 @@ const tips: TipProps[] = [
     body: "Make sure your phone's NFC feature is turned on.",
   },
   {
-    title: 'Fill the Frame',
-    body: 'Make sure the entire ID page is within the camera view, with all edges visible.',
-  },
-  {
     title: 'Hold Steady & Wait',
     body: "Once you sense the phone's reader engaging with the chip, hold the device still for a few seconds to complete the verification process.",
-  },
-  {
-    title: 'Try Different Angles',
-    body: "If the first attempt fails, slowly adjust the angle or position of your phone over the passport—every device's NFC reader can be positioned slightly differently.",
   },
 ];
 
 const DocumentNFCTroubleScreen: React.FC = () => {
-  const openSupportForm = useOpenSupportForm();
   const navigation = useNavigation();
   const handleDismiss = useCallback(() => {
     selectionChange();
@@ -61,6 +58,10 @@ const DocumentNFCTroubleScreen: React.FC = () => {
   const goToNFCMethodSelection = useHapticNavigation(
     'DocumentNFCMethodSelection',
   );
+  const handleOpenNFCOptions = useCallback(() => {
+    selectionChange();
+    goToNFCMethodSelection();
+  }, [goToNFCMethodSelection]);
   const selfClient = useSelfClient();
   const { useMRZStore } = selfClient;
   const { countryCode } = useMRZStore();
@@ -85,19 +86,9 @@ const DocumentNFCTroubleScreen: React.FC = () => {
     <SimpleScrolledTitleLayout
       title="Having trouble verifying your ID?"
       onDismiss={handleDismiss}
-      secondaryButtonText="Open NFC Options"
-      onSecondaryButtonPress={goToNFCMethodSelection}
       footer={
         <YStack gap="$3">
           <SupportUuidRow />
-
-          <SecondaryButton
-            onPress={openSupportForm}
-            textColor={slate700}
-            style={{ marginBottom: 0 }}
-          >
-            {SUPPORT_FORM_BUTTON_TEXT}
-          </SecondaryButton>
 
           <SecondaryButton
             onPress={launchKycVerification}
@@ -130,6 +121,21 @@ const DocumentNFCTroubleScreen: React.FC = () => {
           device supports NFC and that your passport's RFID is functioning
           properly.
         </Caption>
+        <XStack flexWrap="wrap" alignItems="center" gap={4}>
+          <Caption size="large" style={{ color: slate500 }}>
+            Didn't find what you were looking for?
+          </Caption>
+          <Button
+            unstyled
+            onPress={handleOpenNFCOptions}
+            aria-label="Open NFC Options"
+            hitSlop={8}
+          >
+            <Caption size="large" style={{ color: blue600 }}>
+              Open NFC Options
+            </Caption>
+          </Button>
+        </XStack>
       </YStack>
     </SimpleScrolledTitleLayout>
   );


### PR DESCRIPTION
## Summary

Cleans up the two NFC-related screens — the **NFC scan screen** (`DocumentNFCScanScreen.tsx`) and the **NFC trouble screen** (`DocumentNFCTroubleScreen.tsx`) — to give users a single, obvious help affordance, a clear top-left back path, and accurate NFC-specific tips.

### Scan screen (`DocumentNFCScanScreen.tsx`)

- **Removed** the duplicate `?` (CircleHelp) icon next to the "Verify your ID" title.
- **Removed** the `Cancel` SecondaryButton from the action stack.
- **Replaced** the `Send Feedback` SecondaryButton with a single `Need help?` SecondaryButton wired to `goToNFCTrouble`. No new analytics constant introduced — reused the existing `PassportEvents.CANCEL_PASSPORT_NFC` tracking idiom.
- **Added** a top-left back-chevron via `NavBar.LeftAction component="back"` (same pattern as `RegistrationFallbackNFCScreen`), wired to the existing `onCancelPress` (which already shows the KYC-fallback modal). The chevron is hidden while a scan is active (`isNfcSheetOpen === true`).
- **Removed** the now-unused `useOpenSupportForm`, `SUPPORT_FORM_BUTTON_TEXT`, `SUPPORT_FORM_MESSAGE`, and `CircleHelp` imports plus the `SUPPORT_FORM_MESSAGE` disclaimer line.
- **Preserved** the `Try Alternative Verification` SecondaryButton when NFC is unsupported/disabled, plus the active-scan UI and the 5-tap dev gesture.

### Trouble screen (`DocumentNFCTroubleScreen.tsx` + `navigation/documents.ts`)

- **Promoted to full-screen.** Dropped `presentation: 'modal'` from the `DocumentNFCTrouble` route options in `navigation/documents.ts`; kept `animation: 'slide_from_bottom'`. The screen no longer fights between sheet-drag and inner scroll.
- **Tips rewrite.** New first tip `Lay Your Passport Flat` (the single most-impactful NFC instruction, replacing two tips that misled users). Removed `Fill the Frame` (camera-era, irrelevant for NFC) and `Try Different Angles` (encourages the dominant support-ticket failure mode — users waving the phone around). Final order: `Lay Your Passport Flat` → `Know Your Chip Location` → `Remove Any Obstructions` → `Enable NFC` → `Hold Steady & Wait`.
- **Footer cleanup.** Removed the `Send Feedback` SecondaryButton and the `Open NFC Options` SecondaryButton (no `secondaryButtonText`/`onSecondaryButtonPress` props on `SimpleScrolledTitleLayout`). Removed `useOpenSupportForm` import.
- **Inline `Open NFC Options` link.** Added at the end of the scroll area, after the closing caption: *Didn't find what you were looking for? **Open NFC Options*** — styled with `blue600` from `@selfxyz/mobile-sdk-alpha/constants/colors`, fires a `selectionChange` haptic, and navigates to `DocumentNFCMethodSelection`. Power-user path stays available without dominating the screen.
- **Preserved** `Try Alternative Verification`, the `Dismiss` primary button, `SupportUuidRow`, and the 5-tap dev gesture to `DocumentNFCMethodSelection`.

## Out of scope

- No changes to the underlying NFC scanning logic, scan timeout, or analytics events.
- No changes to the alternative-verification (KYC) fallback flow.
- No changes to the web variant (`DocumentNFCScanScreen.web.tsx`).
- No new icon assets, no new analytics events, no new translations infrastructure, no new design tokens.

## Test plan

- [ ] `yarn lint:headers` — SPDX headers preserved.
- [ ] `yarn lint` — no new lint errors on the three modified files.
- [ ] `yarn workspace @selfxyz/mobile-app types` — no new type errors.
- [ ] `yarn workspace @selfxyz/mobile-app test` — Jest passes (incl. `tests/src/services/analytics.test.ts` which references these screens).
- [ ] Maestro E2E (`yarn workspace @selfxyz/mobile-app test:e2e:ios`) on a simulator with the dev-mode mock passport: walk the document-onboarding flow into the NFC scan screen, exercise both `Need help?` and the top-left chevron, scroll the trouble screen, tap the inline `Open NFC Options` link.
- [ ] Manual on-device: confirm the trouble screen renders full-screen (no top inset gap revealing the prior screen), scrolling tips does not trigger a sheet-dismiss gesture, NFC-disabled state still shows `Try Alternative Verification`, and the active-scan state still hides the back chevron and action stack.

Created with [p0 by Purple](https://bepurple.ai) in Spec mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced "Open NFC Options" button allowing users to select alternative document verification methods

* **UI/UX Updates**
  * Added back navigation bar for improved navigation flow in NFC scanning workflow
  * Refreshed NFC troubleshooting tips with clearer step-by-step guidance
  * Replaced help icon with prominent "Need help?" button for direct access to support resources

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/selfxyz/self/pull/2077)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->