### PR TITLE
qa: add Maestro e2e flows for register + disclose-via-playground

### DIFF
--- a/app/tests/e2e/disclose-via-playground.android.flow.yaml
+++ b/app/tests/e2e/disclose-via-playground.android.flow.yaml
@@ -1,0 +1,138 @@
+appId: com.proofofpassportapp
+---
+# Disclosure end-to-end via the on-device playground browser button — the
+# production user flow:
+#
+#   1. Open https://playground.staging.self.xyz in the device's browser.
+#   2. Tap the lower "Open Self app" button (the one with the full
+#      `selfApp=<JSON>` payload — see "Two launcher buttons" below).
+#   3. The Self app receives the deeplink, renders ProveScreen with the
+#      disclosure list, the user scrolls + long-presses verify, the proof
+#      generates and we land back on Home.
+#
+# Preconditions the runner is responsible for:
+#   1. A mock passport is already registered and the on-chain commitment
+#      has settled (a disclose proof generated before the registration
+#      leaf is on-chain fails with [InvalidRoot]).
+#   2. Chrome is open at https://playground.staging.self.xyz/ right before
+#      this flow is invoked. The runner can do this with
+#      `adb shell am start -a android.intent.action.VIEW \
+#                          -d https://playground.staging.self.xyz/ \
+#                          com.android.chrome`.
+#   3. App Links for redirect.self.xyz are approved on this boot. Debug
+#      builds aren't auto-verified — the debug keystore fingerprint isn't
+#      in the production assetlinks.json — so without an explicit
+#      approval Chrome treats redirect.self.xyz as a regular web URL, the
+#      redirect page's 1-second JS fallback fires, and the user lands on
+#      the Play Store. Either run against a release-signed APK, or have
+#      the runner approve App Links after boot:
+#          adb shell pm set-app-links --package com.proofofpassportapp 1 all
+#
+# Two "Open Self app" launcher buttons on the playground:
+#   - Top:    href = https://redirect.self.xyz?sessionId=<uuid>
+#             Relies on a relayer websocket roundtrip pushing the SelfApp
+#             config to the device; on slow or constrained environments
+#             the app lands on "Waiting for app…" indefinitely. Avoid.
+#   - Bottom: href = https://redirect.self.xyz?selfApp=<urlencoded JSON>
+#             Carries the full disclosure payload inline; the deeplink
+#             handler renders ProveScreen directly. Use this one.
+#
+# Selector strategy:
+# - Page scroll: Maestro's scrollUntilVisible doesn't drive Chrome's
+#   WebView reliably. Five explicit swipes parks the lower button at
+#   y≈1864 on a 1080×2400 viewport.
+# - Tap: Maestro's `tapOn { text: "Open Self app", index: 1 }` is flaky
+#   against Chrome's WebView accessibility tree ("Element not found"
+#   trips intermittently even when uiautomator dump shows the element).
+#   A pixel tap on the lower button's stable position (the lowest
+#   interactive element on the page) is more reliable.
+# - ProveScreen scroll: `prove-screen-card` is scrollable=false; the
+#   actual ScrollView is a descendant. `swipe { from: id: "prove-screen-card" }`
+#   is a no-op against the current layout, so we use coordinate swipes
+#   inside the ScrollView's bounds instead.
+
+# 1. Wait for Chrome to render the page header.
+- extendedWaitUntil:
+    visible: "Proof Request Playground"
+    timeout: 60000
+
+# 2. Scroll the page down so the lower launcher button is on screen.
+- swipe:
+    start: 50%, 80%
+    end: 50%, 20%
+    duration: 400
+- swipe:
+    start: 50%, 80%
+    end: 50%, 20%
+    duration: 400
+- swipe:
+    start: 50%, 80%
+    end: 50%, 20%
+    duration: 400
+- swipe:
+    start: 50%, 80%
+    end: 50%, 20%
+    duration: 400
+- swipe:
+    start: 50%, 80%
+    end: 50%, 20%
+    duration: 400
+- waitForAnimationToEnd:
+    timeout: 5000
+
+# 3. Tap the lower "Open Self app" by pixel coords. Bounds on Pixel 6
+#    1080×2400 after the swipe budget above: [126,1794][954,1934]. The
+#    lower button is the lowest interactive element on the page, so the
+#    coordinate is stable against new fields being added higher up.
+- tapOn:
+    point: "540,1864"
+
+# 4. Self app should receive the deeplink and render ProveScreen.
+- extendedWaitUntil:
+    visible:
+      id: "prove-screen-card"
+    timeout: 60000
+
+# 5. Scroll the inner disclosure ScrollView until the verify bar flips
+#    out of "Scroll to read full request". Four swipes covers the current
+#    disclosure budget (nationality + OFAC + excluded-countries); bump
+#    if the disclosure list grows.
+- swipe:
+    start: 50%, 78%
+    end: 50%, 58%
+    duration: 600
+- swipe:
+    start: 50%, 78%
+    end: 50%, 58%
+    duration: 600
+- swipe:
+    start: 50%, 78%
+    end: 50%, 58%
+    duration: 600
+- swipe:
+    start: 50%, 78%
+    end: 50%, 58%
+    duration: 600
+
+# 6. Wait for the bar to be ready, then long-press it. ACTION_TIMER = 600ms
+#    in BottomVerifyBar; Maestro's default longPressOn duration covers that.
+- extendedWaitUntil:
+    visible: "Press and hold to verify"
+    timeout: 30000
+- longPressOn:
+    id: "prove-screen-verify-bar"
+
+# 7. Wait for the disclose proof to complete. Staging proofs typically
+#    finish in 60-180s; the upper bound is generous to absorb slower
+#    renderers.
+- extendedWaitUntil:
+    visible: "Proof Verified"
+    timeout: 600000
+- assertNotVisible: "Proof Failed"
+
+# 8. Dismiss success screen, assert we're back on Home.
+- tapOn: "OK"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen-root"
+    timeout: 30000

--- a/app/tests/e2e/disclose-via-playground.android.flow.yaml
+++ b/app/tests/e2e/disclose-via-playground.android.flow.yaml
@@ -122,13 +122,15 @@ appId: com.proofofpassportapp
 - longPressOn:
     id: "prove-screen-verify-bar"
 
-# 7. Wait for the disclose proof to complete. Staging proofs typically
-#    finish in 60-180s; the upper bound is generous to absorb slower
-#    renderers.
+# 7. Wait for the disclose proof to reach a terminal state — either
+#    "Proof Verified" (success) or "Proof Failed" (error). Watching for
+#    both with a regex lets us fail fast on a genuine error instead of
+#    waiting the full 10-minute success budget. The assertVisible right
+#    after discriminates and turns "Failed" into a flow failure.
 - extendedWaitUntil:
-    visible: "Proof Verified"
+    visible: "Proof (Verified|Failed)"
     timeout: 600000
-- assertNotVisible: "Proof Failed"
+- assertVisible: "Proof Verified"
 
 # 8. Dismiss success screen, assert we're back on Home.
 - tapOn: "OK"

--- a/app/tests/e2e/register-mock-passport.android.flow.yaml
+++ b/app/tests/e2e/register-mock-passport.android.flow.yaml
@@ -20,22 +20,31 @@ appId: com.proofofpassportapp
       id: "home-screen-root"
     timeout: 30000
 
-# 5. Self's react-native-check-version fires async and renders a
-#    "New Version Available" modal. Wait for it to actually render before
-#    tapping the X close icon. Verified coords: (881,800) on 1080×2400.
-#    The X is a plain SVG with no testID and not exposed as a clickable in
-#    the accessibility tree, so the absolute pixel tap is the only path.
-#    Once dismissed, also assert it disappears so we don't race the next step.
-- extendedWaitUntil:
-    visible: "New Version Available"
-    timeout: 20000
-- tapOn:
-    point: "881,800"
-- extendedWaitUntil:
-    notVisible: "New Version Available"
+# 4. Self's react-native-check-version fires async after the app reaches
+#    Home and *may* render a "New Version Available" modal — only if the
+#    installed build is older than the store-advertised version. On the
+#    QA snapshot it currently does; on a release build or a runner with no
+#    network it won't. Treat the dismissal as optional so the flow doesn't
+#    abort when the modal never renders.
+#
+#    Give the async check ~5s to fire (waitForAnimationToEnd returns as
+#    soon as the UI quiesces, so this is a soft upper bound), then use
+#    `runFlow when:` to dismiss conditionally. Verified close-X coords:
+#    (881,800) on 1080×2400 — the X is a plain SVG with no testID, pixel
+#    tap is the only path.
+- waitForAnimationToEnd:
     timeout: 5000
+- runFlow:
+    when:
+      visible: "New Version Available"
+    commands:
+      - tapOn:
+          point: "881,800"
+      - extendedWaitUntil:
+          notVisible: "New Version Available"
+          timeout: 5000
 
-# 6. Open Settings (cog icon, top-right of HomeNavBar). No testID — verified
+# 5. Open Settings (cog icon, top-right of HomeNavBar). No testID — verified
 #    coordinates (989,232) on 1080×2400.
 - tapOn:
     point: "989,232"
@@ -43,7 +52,7 @@ appId: com.proofofpassportapp
     visible: "Manage ID documents"
     timeout: 15000
 
-# 7. Settings → Manage Documents → CreateMock screen.
+# 6. Settings → Manage Documents → CreateMock screen.
 #    Use anchored regex on the button label to avoid matching the on-screen
 #    description text "Generate mock document data" which is a substring match.
 - tapOn: "Manage ID documents"
@@ -52,7 +61,7 @@ appId: com.proofofpassportapp
     timeout: 15000
 - tapOn: "^Generate Mock Document$"
 
-# 8. CreateMock screen. The Generate button is below the fold on a 1080×2400
+# 7. CreateMock screen. The Generate button is below the fold on a 1080×2400
 #    screen — scroll to it explicitly, then tap.
 - extendedWaitUntil:
     visible: "Mock Document Parameters"
@@ -64,19 +73,19 @@ appId: com.proofofpassportapp
     timeout: 15000
 - tapOn: "^Generate Mock Document$"
 
-# 9. Generation takes ~20-30s on swiftshader, then routes to
+# 8. Generation takes ~20-30s on swiftshader, then routes to
 #    ConfirmBelonging which shows a "Confirm" primary button next to a
 #    "Confirm your identity" title. Wait for that to appear.
 - extendedWaitUntil:
     visible: "Confirm your identity"
     timeout: 90000
 
-# 10. Confirm ownership → emits DOCUMENT_OWNERSHIP_CONFIRMED → app navigates
-#     to Loading screen, which runs ZK proof generation. Tap Confirm.
-#     selfClientProvider listens for the event and routes to 'Loading'.
+# 9. Confirm ownership → emits DOCUMENT_OWNERSHIP_CONFIRMED → app navigates
+#    to Loading screen, which runs ZK proof generation. Tap Confirm.
+#    selfClientProvider listens for the event and routes to 'Loading'.
 - tapOn: "^Confirm$"
 
-# 11. Wait for the ZK proof to complete. On swiftshader_indirect this can take
+# 10. Wait for the ZK proof to complete. On swiftshader_indirect this can take
 #     anywhere from 90s to 5+ min depending on circuit + passport algorithm.
 #     On success the app emits PROVING_ACCOUNT_VERIFIED_SUCCESS and routes to
 #     AccountVerifiedSuccessScreen which shows "ID Verified" + Continue button.
@@ -84,10 +93,10 @@ appId: com.proofofpassportapp
     visible: "ID Verified"
     timeout: 600000
 
-# 12. Tap Continue to return to Home.
+# 11. Tap Continue to return to Home.
 - tapOn: "Continue"
 
-# 13. Final assertion: we're back on the home screen with a registered doc.
+# 12. Final assertion: we're back on the home screen with a registered doc.
 - extendedWaitUntil:
     visible:
       id: "home-screen-root"

--- a/app/tests/e2e/register-mock-passport.android.flow.yaml
+++ b/app/tests/e2e/register-mock-passport.android.flow.yaml
@@ -1,0 +1,94 @@
+appId: com.proofofpassportapp
+---
+# 1. Reset app state so the disclaimer is shown fresh on launch.
+#    System UI ANR dismissal is handled by the harness (run-maestro.sh) before
+#    screenrecord starts, so it doesn't appear in the captured video.
+- clearState
+
+# 2. Launch the app from a clean state.
+- launchApp
+
+# 3. Disclaimer → Home (proven path; testIDs from the Self codebase).
+- extendedWaitUntil:
+    visible:
+      id: "disclaimer-screen-root"
+    timeout: 120000
+- tapOn:
+    id: "disclaimer-dismiss-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen-root"
+    timeout: 30000
+
+# 5. Self's react-native-check-version fires async and renders a
+#    "New Version Available" modal. Wait for it to actually render before
+#    tapping the X close icon. Verified coords: (881,800) on 1080×2400.
+#    The X is a plain SVG with no testID and not exposed as a clickable in
+#    the accessibility tree, so the absolute pixel tap is the only path.
+#    Once dismissed, also assert it disappears so we don't race the next step.
+- extendedWaitUntil:
+    visible: "New Version Available"
+    timeout: 20000
+- tapOn:
+    point: "881,800"
+- extendedWaitUntil:
+    notVisible: "New Version Available"
+    timeout: 5000
+
+# 6. Open Settings (cog icon, top-right of HomeNavBar). No testID — verified
+#    coordinates (989,232) on 1080×2400.
+- tapOn:
+    point: "989,232"
+- extendedWaitUntil:
+    visible: "Manage ID documents"
+    timeout: 15000
+
+# 7. Settings → Manage Documents → CreateMock screen.
+#    Use anchored regex on the button label to avoid matching the on-screen
+#    description text "Generate mock document data" which is a substring match.
+- tapOn: "Manage ID documents"
+- extendedWaitUntil:
+    visible: "Available Documents"
+    timeout: 15000
+- tapOn: "^Generate Mock Document$"
+
+# 8. CreateMock screen. The Generate button is below the fold on a 1080×2400
+#    screen — scroll to it explicitly, then tap.
+- extendedWaitUntil:
+    visible: "Mock Document Parameters"
+    timeout: 15000
+- scrollUntilVisible:
+    element:
+      text: "^Generate Mock Document$"
+    direction: DOWN
+    timeout: 15000
+- tapOn: "^Generate Mock Document$"
+
+# 9. Generation takes ~20-30s on swiftshader, then routes to
+#    ConfirmBelonging which shows a "Confirm" primary button next to a
+#    "Confirm your identity" title. Wait for that to appear.
+- extendedWaitUntil:
+    visible: "Confirm your identity"
+    timeout: 90000
+
+# 10. Confirm ownership → emits DOCUMENT_OWNERSHIP_CONFIRMED → app navigates
+#     to Loading screen, which runs ZK proof generation. Tap Confirm.
+#     selfClientProvider listens for the event and routes to 'Loading'.
+- tapOn: "^Confirm$"
+
+# 11. Wait for the ZK proof to complete. On swiftshader_indirect this can take
+#     anywhere from 90s to 5+ min depending on circuit + passport algorithm.
+#     On success the app emits PROVING_ACCOUNT_VERIFIED_SUCCESS and routes to
+#     AccountVerifiedSuccessScreen which shows "ID Verified" + Continue button.
+- extendedWaitUntil:
+    visible: "ID Verified"
+    timeout: 600000
+
+# 12. Tap Continue to return to Home.
+- tapOn: "Continue"
+
+# 13. Final assertion: we're back on the home screen with a registered doc.
+- extendedWaitUntil:
+    visible:
+      id: "home-screen-root"
+    timeout: 30000


### PR DESCRIPTION
## Summary

Adds two Android Maestro flows for end-to-end QA of the mock-passport register + disclose path:

- `register-mock-passport.android.flow.yaml` — disclaimer → home → settings → Generate Mock Document → confirm → ZK proof → return to home (~2m 30s on lavapipe).
- `disclose-via-playground.android.flow.yaml` — Chrome at `playground.staging.self.xyz` → tap the lower **Open Self app** button → ProveScreen → long-press verify → Proof Verified → home (~45s after the registration commitment has settled on-chain).

Paired, they give us a full register+disclose recording in a single run (~3m 14s end-to-end).

## Why two YAMLs, not one combined flow

`appId` is fixed per Maestro YAML and the disclose half needs to drive Chrome before bouncing into the app — splitting also lets register run standalone as a smoke flow, and lets the disclose flow be invoked against any already-registered state.

## Runner responsibilities (documented in YAML headers)

- A mock passport is registered and the on-chain commitment has settled (a disclose proof generated before the registration leaf is on-chain fails with `[InvalidRoot]`).
- Chrome is open at `https://playground.staging.self.xyz/` immediately before invoking the disclose flow.
- App Links for `redirect.self.xyz` are approved on the boot. Debug builds aren't auto-verified (the debug keystore fingerprint isn't in the production `assetlinks.json`), so without an approval Chrome falls back to the Play Store. Either run against a release-signed APK, or approve at runtime: `adb shell pm set-app-links --package com.proofofpassportapp 1 all`.

## Notes on selector choices (in YAML comments)

- Pixel taps where no testID exists: `(881,800)` for the New Version Available close-X, `(989,232)` for the settings cog, `(540,1864)` for the lower Open Self app button. All verified against 1080×2400 (Pixel 6 AVD); will need parameterising for other profiles.
- Maestro's text-based selectors are flaky against Chrome's WebView accessibility tree (intermittent "Element not found" for elements that uiautomator dump shows); the disclose flow uses a pixel tap on the playground's lower launcher.
- `prove-screen-card` is `scrollable=false`; the real ScrollView is a descendant, so `swipe { from: id: "prove-screen-card" }` is a no-op — explicit coordinate swipes inside the card's bounds are used to step through disclosures.

## Test plan

- [x] Validated on local QA VM (Pixel 6 AVD, 1080×2400, `-gpu lavapipe`, Maestro 2.4.0). Full register + 90s on-chain settle + disclose passes end-to-end with both JUnit results `status="SUCCESS"`.
- [ ] CI runs Maestro 1.41 — YAML syntax used here is 1.41-compatible (`tapOn point`, `extendedWaitUntil`, `swipe start/end`, `longPressOn`, `assertNotVisible`) but unverified on 1.41.
- [ ] Disclose flow assumes `-gpu lavapipe` (or any non-segfaulting renderer) on the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end test to validate disclosing proofs via the on-device playground browser and verifying successful proof verification.
  * Updated an end-to-end test to deterministically cover mock passport registration, identity confirmation, and completion of verification back to the Home screen.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/selfxyz/self/pull/2078)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->