### PR TITLE
SELF-2975: allow aadhaar for usat

### DIFF
--- a/app/tests/src/utils/googleUsatGate.test.ts
+++ b/app/tests/src/utils/googleUsatGate.test.ts
@@ -165,7 +165,7 @@ describe('evaluateGoogleUsatGate', () => {
     );
   });
 
-  it('blocks Google USAT when selected document is aadhaar', async () => {
+  it('allows Google USAT when selected document is aadhaar', async () => {
     mockIsGoogleUsatProofRequest.mockReturnValue(true);
     selfClient.loadDocumentCatalog.mockResolvedValue({
       selectedDocumentId: 'a',
@@ -175,7 +175,7 @@ describe('evaluateGoogleUsatGate', () => {
       b: { data: { documentCategory: 'passport', mock: false } } as any,
     });
     await expect(evaluateGoogleUsatGate(selfClient, app)).resolves.toBe(
-      'block',
+      'allow',
     );
   });
 

--- a/app/tests/src/utils/googleUsatGate.test.ts
+++ b/app/tests/src/utils/googleUsatGate.test.ts
@@ -21,7 +21,8 @@ jest.mock('@selfxyz/mobile-sdk-alpha', () => {
       scope: 'celo-mainnet-tether-usat',
       appName: 'Google Cloud Web3 Portal',
     },
-    allowedCategories: ['passport', 'id_card'],
+    // Mirror GOOGLE_USAT_FAUCET_POLICY defaults to avoid drift.
+    allowedCategories: ['passport', 'id_card', 'aadhaar'],
     allowMock: false,
   };
   return {
@@ -165,7 +166,7 @@ describe('evaluateGoogleUsatGate', () => {
     );
   });
 
-  it('allows Google USAT when selected document is aadhaar', async () => {
+  it('allows Google USAT when selected real document is aadhaar', async () => {
     mockIsGoogleUsatProofRequest.mockReturnValue(true);
     selfClient.loadDocumentCatalog.mockResolvedValue({
       selectedDocumentId: 'a',

--- a/packages/mobile-sdk-alpha/src/constants/restrictedApps.ts
+++ b/packages/mobile-sdk-alpha/src/constants/restrictedApps.ts
@@ -37,7 +37,7 @@ export const GOOGLE_USAT_FAUCET_POLICY: RestrictedAppPolicy = {
     scope: GOOGLE_USAT_FAUCET_SCOPE,
     appName: GOOGLE_USAT_FAUCET_APP_NAME,
   },
-  allowedCategories: ['passport', 'id_card'],
+  allowedCategories: ['passport', 'id_card', 'aadhaar'],
   allowMock: false,
 };
 

--- a/packages/mobile-sdk-alpha/tests/utils/restrictedApps.test.ts
+++ b/packages/mobile-sdk-alpha/tests/utils/restrictedApps.test.ts
@@ -85,11 +85,11 @@ describe('isDocumentEligibleForPolicy', () => {
   it('allows categories that are in allowedCategories', () => {
     expect(isDocumentEligibleForPolicy(policy, 'passport', false)).toBe(true);
     expect(isDocumentEligibleForPolicy(policy, 'id_card', false)).toBe(true);
+    expect(isDocumentEligibleForPolicy(policy, 'aadhaar', false)).toBe(true);
   });
 
   it('rejects categories not in allowedCategories', () => {
     expect(isDocumentEligibleForPolicy(policy, 'kyc', false)).toBe(false);
-    expect(isDocumentEligibleForPolicy(policy, 'aadhaar', false)).toBe(false);
   });
 
   it('rejects mock documents when allowMock is false', () => {
@@ -126,7 +126,7 @@ describe('hasEligibleAlternativeDocumentForPolicy', () => {
         policy,
         {
           selected: buildDoc('kyc'),
-          alt: buildDoc('aadhaar'),
+          alt: buildDoc('kyc'),
         },
         'selected',
       ),


### PR DESCRIPTION
## Summary

- Add `aadhaar` to the allowed document categories for the Google USAT faucet policy so Aadhaar holders can complete the faucet flow.
- Update the Google USAT gate test and restricted-apps tests to reflect the new policy.

## Changes

### SDK core

- `GOOGLE_USAT_FAUCET_POLICY.allowedCategories` now includes `aadhaar` alongside `passport` and `id_card`.

### Tests

- `evaluateGoogleUsatGate` test flipped from blocking to allowing when the selected document is Aadhaar.
- `isDocumentEligibleForPolicy` tests updated so `aadhaar` is asserted as allowed; the rejection case now uses `kyc` for the alternative-document path.

## Test Plan

- [ ] `yarn lint && yarn types` passes
- [ ] `cd packages/mobile-sdk-alpha && yarn test`
- [ ] `cd app && yarn jest:run` (covers `googleUsatGate` test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Aadhaar documents are now supported for document verification alongside existing identity document options.

* **Tests**
  * Test suites updated to reflect Aadhaar being allowed by the verification policy and adjusted cases for alternative-document evaluations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/selfxyz/self/pull/2079)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->