### PR TITLE
fix(qrcode): add dark mode support and bump to 1.0.23

### DIFF
--- a/sdk/qrcode/components/DesktopFooter.tsx
+++ b/sdk/qrcode/components/DesktopFooter.tsx
@@ -27,6 +27,7 @@ import {
 
 interface DesktopFooterProps {
   proofStep: number;
+  darkMode?: boolean;
 }
 
 const INSTRUCTION_STEPS = [
@@ -50,22 +51,22 @@ const getStatusIcon = (proofStep: number) => {
   }
 };
 
-const DesktopFooter = memo(({ proofStep }: DesktopFooterProps) => {
+const DesktopFooter = memo(({ proofStep, darkMode = false }: DesktopFooterProps) => {
   const isInitialState =
     proofStep === QRcodeSteps.DISCONNECTED || proofStep === QRcodeSteps.WAITING_FOR_MOBILE;
 
   if (isInitialState) {
     return (
-      <div style={desktopFooterStyle()}>
+      <div style={desktopFooterStyle(darkMode)}>
         {INSTRUCTION_STEPS.map((step, index) => {
           const Icon = step.icon;
           return (
-            <div key={index} style={desktopStepStyle()}>
+            <div key={index} style={desktopStepStyle(darkMode)}>
               <div style={desktopStepInnerStyle()}>
-                <div style={desktopStepIconStyle()}>
+                <div style={desktopStepIconStyle(darkMode)}>
                   <Icon size={18} />
                 </div>
-                <span style={desktopStepTextStyle()}>{step.text}</span>
+                <span style={desktopStepTextStyle(darkMode)}>{step.text}</span>
               </div>
             </div>
           );
@@ -77,14 +78,14 @@ const DesktopFooter = memo(({ proofStep }: DesktopFooterProps) => {
   const StatusIcon = getStatusIcon(proofStep);
 
   return (
-    <div style={desktopStatusFooterStyle()}>
-      <div style={desktopStatusCardStyle()}>
+    <div style={desktopStatusFooterStyle(darkMode)}>
+      <div style={desktopStatusCardStyle(darkMode)}>
         <div style={desktopStatusContentStyle()}>
           <div style={desktopStatusIconStyle()}>
             <StatusIcon size={34} />
           </div>
           <div style={desktopStatusTextStyle()}>
-            <p style={desktopStatusTitleStyle()}>{getDesktopStatusTitle(proofStep)}</p>
+            <p style={desktopStatusTitleStyle(darkMode)}>{getDesktopStatusTitle(proofStep)}</p>
             <p style={desktopStatusSubtitleStyle()}>{getDesktopStatusSubtitle()}</p>
           </div>
         </div>

--- a/sdk/qrcode/components/DesktopHeader.tsx
+++ b/sdk/qrcode/components/DesktopHeader.tsx
@@ -15,9 +15,10 @@ import { DotsIcon } from './icons.js';
 interface DesktopHeaderProps {
   appName: string;
   appLogo: string;
+  darkMode?: boolean;
 }
 
-const DesktopHeader = memo(({ appName, appLogo }: DesktopHeaderProps) => (
+const DesktopHeader = memo(({ appName, appLogo, darkMode = false }: DesktopHeaderProps) => (
   <div style={desktopHeaderStyle()}>
     <div style={desktopLogoRowStyle()}>
       <img src={appLogo} alt={`${appName} logo`} style={desktopAppLogoStyle()} />
@@ -26,7 +27,7 @@ const DesktopHeader = memo(({ appName, appLogo }: DesktopHeaderProps) => (
         <img src={selfLogo} alt="Self logo" style={desktopSelfLogoImgStyle()} />
       </div>
     </div>
-    <p style={desktopDescriptionStyle()}>{getDesktopDescription(appName)}</p>
+    <p style={desktopDescriptionStyle(darkMode)}>{getDesktopDescription(appName)}</p>
   </div>
 ));
 

--- a/sdk/qrcode/components/DesktopQRcode.tsx
+++ b/sdk/qrcode/components/DesktopQRcode.tsx
@@ -16,14 +16,14 @@ interface DesktopQRcodeProps {
 
 const DesktopQRcode = memo(
   ({ proofStep, qrValue, size, darkMode, selfApp }: DesktopQRcodeProps) => (
-    <div style={desktopCardStyle()} role="img" aria-label="Self authentication QR code">
-      <DesktopHeader appName={selfApp.appName} appLogo={selfApp.logoBase64} />
+    <div style={desktopCardStyle(darkMode)} role="img" aria-label="Self authentication QR code">
+      <DesktopHeader appName={selfApp.appName} appLogo={selfApp.logoBase64} darkMode={darkMode} />
       <div style={desktopQrSectionStyle()}>
-        <div style={desktopQrWrapperStyle(proofStep)}>
+        <div style={desktopQrWrapperStyle(proofStep, darkMode)}>
           <QRCode value={qrValue} size={size} darkMode={darkMode} proofStep={proofStep} />
         </div>
       </div>
-      <DesktopFooter proofStep={proofStep} />
+      <DesktopFooter proofStep={proofStep} darkMode={darkMode} />
     </div>
   )
 );

--- a/sdk/qrcode/components/DesktopQRcode.tsx
+++ b/sdk/qrcode/components/DesktopQRcode.tsx
@@ -20,7 +20,7 @@ const DesktopQRcode = memo(
       <DesktopHeader appName={selfApp.appName} appLogo={selfApp.logoBase64} darkMode={darkMode} />
       <div style={desktopQrSectionStyle()}>
         <div style={desktopQrWrapperStyle(proofStep, darkMode)}>
-          <QRCode value={qrValue} size={size} darkMode={darkMode} proofStep={proofStep} />
+          <QRCode value={qrValue} size={size} proofStep={proofStep} />
         </div>
       </div>
       <DesktopFooter proofStep={proofStep} darkMode={darkMode} />

--- a/sdk/qrcode/components/MobileQRcode.tsx
+++ b/sdk/qrcode/components/MobileQRcode.tsx
@@ -25,6 +25,7 @@ interface MobileQRcodeProps {
   proofStep: number;
   qrValue: string;
   selfApp: SelfApp;
+  darkMode?: boolean;
 }
 
 const MOBILE_STEPS = [
@@ -33,9 +34,9 @@ const MOBILE_STEPS = [
   { icon: ArrowReturnIcon, text: 'Return to this application and click on the button below' },
 ];
 
-const MobileQRcode = memo(({ qrValue, selfApp }: MobileQRcodeProps) => (
-  <div style={mobileCardStyle()} role="region" aria-label="Self authentication">
-    <DesktopHeader appName={selfApp.appName} appLogo={selfApp.logoBase64} />
+const MobileQRcode = memo(({ qrValue, selfApp, darkMode = false }: MobileQRcodeProps) => (
+  <div style={mobileCardStyle(darkMode)} role="region" aria-label="Self authentication">
+    <DesktopHeader appName={selfApp.appName} appLogo={selfApp.logoBase64} darkMode={darkMode} />
     <div style={mobilePhoneSectionWrapperStyle()}>
       <div style={mobilePhoneSectionStyle()}>
         <img src={phoneMockup} alt="Self app preview" style={mobilePhoneImgStyle()} />
@@ -45,18 +46,18 @@ const MobileQRcode = memo(({ qrValue, selfApp }: MobileQRcodeProps) => (
       {MOBILE_STEPS.map((step, index) => {
         const Icon = step.icon;
         return (
-          <div key={index} style={desktopStepStyle()}>
+          <div key={index} style={desktopStepStyle(darkMode)}>
             <div style={desktopStepInnerStyle()}>
-              <div style={desktopStepIconStyle()}>
+              <div style={desktopStepIconStyle(darkMode)}>
                 <Icon size={18} />
               </div>
-              <span style={desktopStepTextStyle()}>{step.text}</span>
+              <span style={desktopStepTextStyle(darkMode)}>{step.text}</span>
             </div>
           </div>
         );
       })}
     </div>
-    <div style={mobileCtaSectionStyle()}>
+    <div style={mobileCtaSectionStyle(darkMode)}>
       <a href={qrValue} style={mobileCtaButtonStyle()}>
         <img src={selfLogo} alt="" style={mobileCtaLogoStyle()} />
         <span style={mobileCtaTextStyle()}>Open Self app</span>

--- a/sdk/qrcode/components/QRCode.tsx
+++ b/sdk/qrcode/components/QRCode.tsx
@@ -11,7 +11,6 @@ const QR_IMAGE_SIZE_RATIO = 0.32;
 interface QRCodeProps {
   value: string;
   size: number;
-  darkMode: boolean;
   proofStep: number;
 }
 

--- a/sdk/qrcode/components/QRCode.tsx
+++ b/sdk/qrcode/components/QRCode.tsx
@@ -15,7 +15,7 @@ interface QRCodeProps {
   proofStep: number;
 }
 
-const QRCode = memo(({ value, size, darkMode, proofStep }: QRCodeProps) => {
+const QRCode = memo(({ value, size, proofStep }: QRCodeProps) => {
   const isInitialState =
     proofStep === QRcodeSteps.DISCONNECTED || proofStep === QRcodeSteps.WAITING_FOR_MOBILE;
 
@@ -27,8 +27,8 @@ const QRCode = memo(({ value, size, darkMode, proofStep }: QRCodeProps) => {
   const showAnimation = !isInitialState;
 
   const statusIcon = getStatusIcon(proofStep);
-  const bgColor = darkMode ? '#000000' : '#ffffff';
-  const fgColor = darkMode ? '#ffffff' : '#000000';
+  const fgColor = '#000000';
+  const bgColor = '#ffffff';
   const imageSize = size * QR_IMAGE_SIZE_RATIO;
 
   return (

--- a/sdk/qrcode/components/SelfQRcode.tsx
+++ b/sdk/qrcode/components/SelfQRcode.tsx
@@ -105,7 +105,14 @@ const SelfQRcode = ({
         });
 
   if (variant === 'mobile') {
-    return <MobileQRcode proofStep={proofStep} qrValue={qrValue} selfApp={selfAppRef.current} />;
+    return (
+      <MobileQRcode
+        proofStep={proofStep}
+        qrValue={qrValue}
+        selfApp={selfAppRef.current}
+        darkMode={darkMode}
+      />
+    );
   }
 
   if (variant === 'desktop') {
@@ -126,7 +133,7 @@ const SelfQRcode = ({
       role="img"
       aria-label="Self authentication QR code"
     >
-      <QRCode value={qrValue} size={size} darkMode={darkMode} proofStep={proofStep} />
+      <QRCode value={qrValue} size={size} proofStep={proofStep} />
       {showStatusText && <StatusBanner proofStep={proofStep} qrSize={size} />}
     </div>
   );

--- a/sdk/qrcode/components/SelfQRcode.tsx
+++ b/sdk/qrcode/components/SelfQRcode.tsx
@@ -122,7 +122,7 @@ const SelfQRcode = ({
 
   return (
     <div
-      style={qrWrapperStyle(proofStep, showBorder)}
+      style={qrWrapperStyle(proofStep, showBorder, darkMode)}
       role="img"
       aria-label="Self authentication QR code"
     >

--- a/sdk/qrcode/package.json
+++ b/sdk/qrcode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@selfxyz/qrcode",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "repository": {
     "type": "git",
     "url": "https://github.com/selfxyz/self"

--- a/sdk/qrcode/utils/styles.ts
+++ b/sdk/qrcode/utils/styles.ts
@@ -2,11 +2,12 @@ import React from 'react';
 
 import { QRcodeSteps } from './utils.js';
 
-const getBorderColor = (step: number): string => {
+const getBorderColor = (step: number, darkMode: boolean = false): string => {
+  const idleColor = darkMode ? '#2A2A2A' : '#E2E8F0';
   switch (step) {
     case QRcodeSteps.DISCONNECTED:
     case QRcodeSteps.WAITING_FOR_MOBILE:
-      return '#E2E8F0';
+      return idleColor;
     case QRcodeSteps.MOBILE_CONNECTED:
     case QRcodeSteps.PROOF_GENERATION_STARTED:
     case QRcodeSteps.PROOF_GENERATED:
@@ -16,7 +17,7 @@ const getBorderColor = (step: number): string => {
     case QRcodeSteps.PROOF_VERIFIED:
       return '#01BFFF';
     default:
-      return '#E2E8F0';
+      return idleColor;
   }
 };
 
@@ -41,11 +42,12 @@ export const desktopDescriptionStyle = (darkMode: boolean = false): React.CSSPro
   margin: 0,
 });
 
-const getDesktopBorderColor = (step: number): string => {
+const getDesktopBorderColor = (step: number, darkMode: boolean = false): string => {
+  const idleColor = darkMode ? '#2A2A2A' : '#E2E8F0';
   switch (step) {
     case QRcodeSteps.DISCONNECTED:
     case QRcodeSteps.WAITING_FOR_MOBILE:
-      return '#E2E8F0';
+      return idleColor;
     case QRcodeSteps.MOBILE_CONNECTED:
     case QRcodeSteps.PROOF_GENERATION_STARTED:
     case QRcodeSteps.PROOF_GENERATED:
@@ -55,7 +57,7 @@ const getDesktopBorderColor = (step: number): string => {
     case QRcodeSteps.PROOF_VERIFIED:
       return '#00FFB6';
     default:
-      return '#E2E8F0';
+      return idleColor;
   }
 };
 
@@ -118,7 +120,7 @@ export const desktopQrWrapperStyle = (
   alignItems: 'center',
   padding: '10px',
   borderRadius: '10px',
-  border: `6px solid ${darkMode ? '#2A2A2A' : getDesktopBorderColor(step)}`,
+  border: `6px solid ${getDesktopBorderColor(step, darkMode)}`,
   backgroundColor: '#FFF',
   transition: 'border-color 0.3s ease',
 });
@@ -227,7 +229,11 @@ export const desktopStepTextStyle = (darkMode: boolean = false): React.CSSProper
 });
 
 // Mobile variant styles
-export const mobileCardStyle = (): React.CSSProperties => baseCardStyle();
+export const mobileCardStyle = (darkMode: boolean = false): React.CSSProperties => ({
+  ...baseCardStyle(),
+  border: `1px solid ${darkMode ? '#2A2A2A' : '#E2E8F0'}`,
+  backgroundColor: darkMode ? '#121212' : '#FFFFFF',
+});
 
 export const mobileCtaButtonStyle = (): React.CSSProperties => ({
   display: 'flex',
@@ -248,13 +254,13 @@ export const mobileCtaLogoStyle = (): React.CSSProperties => ({
   height: '26px',
 });
 
-export const mobileCtaSectionStyle = (): React.CSSProperties => ({
+export const mobileCtaSectionStyle = (darkMode: boolean = false): React.CSSProperties => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
   padding: '16px 20px',
   width: '100%',
-  borderTop: '1px solid #E2E8F0',
+  borderTop: `1px solid ${darkMode ? '#2A2A2A' : '#E2E8F0'}`,
   boxSizing: 'border-box',
 });
 
@@ -331,7 +337,7 @@ export const qrWrapperStyle = (
   gap: '6px',
   padding: '3px',
   borderRadius: '10px',
-  border: showBorder ? `6px solid ${darkMode ? '#2A2A2A' : getBorderColor(step)}` : 'none',
+  border: showBorder ? `6px solid ${getBorderColor(step, darkMode)}` : 'none',
   backgroundColor: '#FFF',
   transition: 'border-color 0.3s ease',
 });

--- a/sdk/qrcode/utils/styles.ts
+++ b/sdk/qrcode/utils/styles.ts
@@ -27,12 +27,16 @@ export const desktopAppLogoStyle = (): React.CSSProperties => ({
   objectFit: 'contain',
 });
 
-export const desktopCardStyle = (): React.CSSProperties => baseCardStyle();
+export const desktopCardStyle = (darkMode: boolean = false): React.CSSProperties => ({
+  ...baseCardStyle(),
+  border: `1px solid ${darkMode ? '#2A2A2A' : '#E2E8F0'}`,
+  backgroundColor: darkMode ? '#121212' : '#FFFFFF',
+});
 
-export const desktopDescriptionStyle = (): React.CSSProperties => ({
+export const desktopDescriptionStyle = (darkMode: boolean = false): React.CSSProperties => ({
   fontSize: '16px',
   lineHeight: 'normal',
-  color: '#000000',
+  color: darkMode ? '#E2E8F0' : '#000000',
   textAlign: 'center',
   margin: 0,
 });
@@ -67,13 +71,13 @@ const baseCardStyle = (): React.CSSProperties => ({
   fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
 });
 
-export const desktopFooterStyle = (): React.CSSProperties => ({
+export const desktopFooterStyle = (darkMode: boolean = false): React.CSSProperties => ({
   display: 'flex',
   flexDirection: 'column',
   gap: '6px',
   width: '100%',
   padding: '20px',
-  borderTop: '1px solid #E2E8F0',
+  borderTop: `1px solid ${darkMode ? '#2A2A2A' : '#E2E8F0'}`,
   boxSizing: 'border-box',
 });
 
@@ -105,13 +109,16 @@ export const desktopQrSectionStyle = (): React.CSSProperties => ({
   boxSizing: 'border-box',
 });
 
-export const desktopQrWrapperStyle = (step: number): React.CSSProperties => ({
+export const desktopQrWrapperStyle = (
+  step: number,
+  darkMode: boolean = false
+): React.CSSProperties => ({
   display: 'inline-flex',
   flexDirection: 'column',
   alignItems: 'center',
   padding: '10px',
   borderRadius: '10px',
-  border: `6px solid ${getDesktopBorderColor(step)}`,
+  border: `6px solid ${darkMode ? '#2A2A2A' : getDesktopBorderColor(step)}`,
   backgroundColor: '#FFF',
   transition: 'border-color 0.3s ease',
 });
@@ -132,8 +139,8 @@ export const desktopSelfLogoImgStyle = (): React.CSSProperties => ({
   height: '20px',
 });
 
-export const desktopStatusCardStyle = (): React.CSSProperties => ({
-  backgroundColor: '#F8FAFC',
+export const desktopStatusCardStyle = (darkMode: boolean = false): React.CSSProperties => ({
+  backgroundColor: darkMode ? '#1E1E1E' : '#F8FAFC',
   borderRadius: '5px',
   padding: '6px 10px',
   width: '100%',
@@ -148,12 +155,12 @@ export const desktopStatusContentStyle = (): React.CSSProperties => ({
   padding: '8px 0',
 });
 
-export const desktopStatusFooterStyle = (): React.CSSProperties => ({
+export const desktopStatusFooterStyle = (darkMode: boolean = false): React.CSSProperties => ({
   display: 'flex',
   flexDirection: 'column',
   width: '100%',
   padding: '20px',
-  borderTop: '1px solid #E2E8F0',
+  borderTop: `1px solid ${darkMode ? '#2A2A2A' : '#E2E8F0'}`,
   boxSizing: 'border-box',
 });
 
@@ -180,20 +187,21 @@ export const desktopStatusTextStyle = (): React.CSSProperties => ({
   textAlign: 'center',
 });
 
-export const desktopStatusTitleStyle = (): React.CSSProperties => ({
+export const desktopStatusTitleStyle = (darkMode: boolean = false): React.CSSProperties => ({
   fontSize: '18px',
   fontWeight: 500,
-  color: '#000000',
+  color: darkMode ? '#E2E8F0' : '#000000',
   margin: 0,
 });
 
-export const desktopStepIconStyle = (): React.CSSProperties => ({
+export const desktopStepIconStyle = (darkMode: boolean = false): React.CSSProperties => ({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
   width: '26px',
   height: '26px',
   flexShrink: 0,
+  ...(darkMode ? { filter: 'invert(1)' } : {}),
 });
 
 export const desktopStepInnerStyle = (): React.CSSProperties => ({
@@ -204,18 +212,18 @@ export const desktopStepInnerStyle = (): React.CSSProperties => ({
   width: '100%',
 });
 
-export const desktopStepStyle = (): React.CSSProperties => ({
-  backgroundColor: '#F8FAFC',
+export const desktopStepStyle = (darkMode: boolean = false): React.CSSProperties => ({
+  backgroundColor: darkMode ? '#2A2A2A' : '#F8FAFC',
   borderRadius: '5px',
   padding: '6px 10px',
   width: '100%',
   boxSizing: 'border-box',
 });
 
-export const desktopStepTextStyle = (): React.CSSProperties => ({
+export const desktopStepTextStyle = (darkMode: boolean = false): React.CSSProperties => ({
   fontSize: '14px',
   lineHeight: 'normal',
-  color: '#0F172A',
+  color: darkMode ? '#94A3B8' : '#0F172A',
 });
 
 // Mobile variant styles
@@ -312,14 +320,18 @@ export const qrContainerStyle = (size: number): React.CSSProperties => ({
   height: size,
 });
 
-export const qrWrapperStyle = (step: number, showBorder: boolean = true): React.CSSProperties => ({
+export const qrWrapperStyle = (
+  step: number,
+  showBorder: boolean = true,
+  darkMode: boolean = false
+): React.CSSProperties => ({
   display: 'inline-flex',
   flexDirection: 'column',
   alignItems: 'center',
   gap: '6px',
   padding: '3px',
   borderRadius: '10px',
-  border: showBorder ? `6px solid ${getBorderColor(step)}` : 'none',
+  border: showBorder ? `6px solid ${darkMode ? '#2A2A2A' : getBorderColor(step)}` : 'none',
   backgroundColor: '#FFF',
   transition: 'border-color 0.3s ease',
 });


### PR DESCRIPTION
Linear: [SELF-797](https://linear.app/selfprotocol/issue/SELF-797/cant-scan-the-qr-code-in-dark-mode)

Supersedes #2034 — same code change, but rebuilt as a single commit on top of `dev` (the original branch had ~90 commits of noisy merge history). Also bumps `@selfxyz/qrcode` to **1.0.23** so the npm-publish workflow actually fires on merge — #2034 was still at 1.0.22, matching `dev`, so it would not have published.

## Summary

Add dark mode support to the QR code SDK component. The QR code itself always renders as standard black-on-white for maximum scanner compatibility (inverted QR codes are unreliable on Android). Dark mode styling is applied to the card/wrapper UI around the QR.

## Test plan

- [x] Desktop variant renders with dark card, light QR — scannable on Android
- [x] Hybrid variant renders with dark border, light QR — scannable on Android
- [x] Light mode unchanged (darkMode=false)
- [x] `yarn build` passes in sdk/qrcode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dark mode added across QR experience: headers, footers, cards, wrappers and step/status visuals now adapt to light/dark themes for desktop and mobile.
  * QR container styling now handles dark backgrounds while the QR graphic itself uses consistent high-contrast colors for readability.

* **Chores**
  * QR package version bumped.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/selfxyz/self/pull/2080)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->