### PR TITLE
fix(qrcode): disable darkMode in wrapper, keep prop for back-compat

### DIFF
--- a/sdk/qrcode/components/SelfQRcode.tsx
+++ b/sdk/qrcode/components/SelfQRcode.tsx
@@ -18,6 +18,10 @@ interface SelfQRcodeProps {
   type?: 'websocket' | 'deeplink';
   websocketUrl?: string;
   size?: number;
+  /**
+   * Currently a no-op. The prop is kept for backward compatibility so existing
+   * integrations don't break, but the wrapper always renders in light mode.
+   */
   darkMode?: boolean;
   showBorder?: boolean;
   showStatusText?: boolean;
@@ -43,11 +47,14 @@ const SelfQRcode = ({
   type = 'websocket',
   websocketUrl = WS_DB_RELAYER,
   size = 300,
-  darkMode = false,
+  // darkMode is intentionally accepted but ignored — see SelfQRcodeProps.
+  darkMode: _darkMode = false,
   showBorder = true,
   showStatusText = true,
   variant = 'hybrid',
 }: SelfQRcodeProps) => {
+  // Force light mode regardless of the caller-provided flag.
+  const darkMode = false;
   const [proofStep, setProofStep] = useState(QRcodeSteps.WAITING_FOR_MOBILE);
   const [sessionId, setSessionId] = useState('');
   const socketRef = useRef<ReturnType<typeof initWebSocket> | null>(null);

--- a/sdk/qrcode/package.json
+++ b/sdk/qrcode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@selfxyz/qrcode",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "repository": {
     "type": "git",
     "url": "https://github.com/selfxyz/self"


### PR DESCRIPTION
## Summary
- Always render `SelfQRcode`/`SelfQRcodeWrapper` in light mode regardless of the `darkMode` prop, so customers currently passing `darkMode={true}` get the light UI without their integration breaking.
- Keep `darkMode?: boolean` in the public props (now documented as a no-op) so the change is fully backward-compatible — no caller has to update types or call sites.
- Leave the underlying dark-mode styles and per-component `darkMode` plumbing in place so we can re-enable later without re-doing the work.
- Bump `@selfxyz/qrcode` to `1.0.24`.

## Test plan
- [ ] Consumer using `<SelfQRcodeWrapper darkMode={true} />` renders the light UI (hybrid / desktop / mobile variants).
- [ ] Consumer using `<SelfQRcodeWrapper darkMode={false} />` and no `darkMode` prop also renders the light UI.
- [ ] No TypeScript breakage for existing integrations (`darkMode` still typed as `boolean | undefined`).
- [ ] `yarn types` passes in `sdk/qrcode`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * QR code display now consistently renders in light mode, ensuring reliable visual appearance regardless of configuration settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/selfxyz/self/pull/2081)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->