### PR TITLE
polish NFC scan UX: chevron back, contextual help, hide NFC Options

### DIFF
--- a/app/jest.setup.js
+++ b/app/jest.setup.js
@@ -435,14 +435,18 @@ jest.mock('react-native/Libraries/StyleSheet/StyleSheet', () => ({
 }));
 
 // Mock NativeDeviceInfo specs for both main app and mobile-sdk-alpha
-jest.mock('react-native/src/private/specs/modules/NativeDeviceInfo', () => ({
-  getConstants: jest.fn(() => ({
-    Dimensions: {
-      window: { width: 375, height: 667, scale: 2 },
-      screen: { width: 375, height: 667, scale: 2 },
-    },
-  })),
-}));
+jest.mock(
+  'react-native/src/private/specs/modules/NativeDeviceInfo',
+  () => ({
+    getConstants: jest.fn(() => ({
+      Dimensions: {
+        window: { width: 375, height: 667, scale: 2 },
+        screen: { width: 375, height: 667, scale: 2 },
+      },
+    })),
+  }),
+  { virtual: true },
+);
 
 // Mock NativeStatusBarManagerIOS for react-native-edge-to-edge SystemBars
 jest.mock(
@@ -452,6 +456,7 @@ jest.mock(
     setHidden: jest.fn(),
     setNetworkActivityIndicatorVisible: jest.fn(),
   }),
+  { virtual: true },
 );
 
 // Mock react-native-gesture-handler to prevent getConstants errors
@@ -1037,6 +1042,9 @@ jest.mock('react-native-app-auth', () => ({
 // Mock @robinbobin/react-native-google-drive-api-wrapper
 jest.mock('@robinbobin/react-native-google-drive-api-wrapper', () => {
   class MockUploader {
+    constructor() {
+      this.execute = jest.fn();
+    }
     setData() {
       return this;
     }
@@ -1046,21 +1054,24 @@ jest.mock('@robinbobin/react-native-google-drive-api-wrapper', () => {
     setRequestBody() {
       return this;
     }
-    execute = jest.fn();
   }
 
   class MockFiles {
+    constructor() {
+      this.list = jest.fn().mockResolvedValue({ files: [] });
+      this.delete = jest.fn();
+      this.getText = jest.fn().mockResolvedValue('');
+    }
     newMultipartUploader() {
       return new MockUploader();
     }
-    list = jest.fn().mockResolvedValue({ files: [] });
-    delete = jest.fn();
-    getText = jest.fn().mockResolvedValue('');
   }
 
   class GDrive {
-    accessToken = '';
-    files = new MockFiles();
+    constructor() {
+      this.accessToken = '';
+      this.files = new MockFiles();
+    }
   }
 
   return {
@@ -1246,17 +1257,19 @@ jest.mock('react-native-biometrics', () => {
   class MockReactNativeBiometrics {
     constructor(options) {
       // Constructor accepts options but doesn't need to do anything
+      this.isSensorAvailable = jest.fn().mockResolvedValue({
+        available: true,
+        biometryType: 'TouchID',
+      });
+      this.createKeys = jest
+        .fn()
+        .mockResolvedValue({ publicKey: 'mock-public-key' });
+      this.deleteKeys = jest.fn().mockResolvedValue(true);
+      this.createSignature = jest
+        .fn()
+        .mockResolvedValue({ signature: 'mock-signature' });
+      this.simplePrompt = jest.fn().mockResolvedValue({ success: true });
     }
-    isSensorAvailable = jest.fn().mockResolvedValue({
-      available: true,
-      biometryType: 'TouchID',
-    });
-    createKeys = jest.fn().mockResolvedValue({ publicKey: 'mock-public-key' });
-    deleteKeys = jest.fn().mockResolvedValue(true);
-    createSignature = jest
-      .fn()
-      .mockResolvedValue({ signature: 'mock-signature' });
-    simplePrompt = jest.fn().mockResolvedValue({ success: true });
   }
   return {
     __esModule: true,

--- a/app/src/screens/documents/scanning/DocumentNFCScanScreen.tsx
+++ b/app/src/screens/documents/scanning/DocumentNFCScanScreen.tsx
@@ -20,6 +20,7 @@ import {
 } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import NfcManager from 'react-native-nfc-manager';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Button, Image, XStack } from 'tamagui';
 import { v4 as uuidv4 } from 'uuid';
 import type { RouteProp } from '@react-navigation/native';
@@ -29,7 +30,7 @@ import {
   useRoute,
 } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { CircleHelp } from '@tamagui/lucide-icons';
+import { ChevronLeft, CircleHelp } from '@tamagui/lucide-icons';
 
 import type { PassportData } from '@selfxyz/common/types';
 import {
@@ -66,7 +67,6 @@ import { useErrorInjection } from '@/hooks/useErrorInjection';
 import { useFeedbackAutoHide } from '@/hooks/useFeedbackAutoHide';
 import useHapticNavigation from '@/hooks/useHapticNavigation';
 import { useKycLauncher } from '@/hooks/useKycLauncher';
-import useOpenSupportForm from '@/hooks/useOpenSupportForm';
 import {
   buttonTap,
   feedbackSuccess,
@@ -83,10 +83,7 @@ import {
   setNfcScanningActive,
   trackNfcEvent,
 } from '@/services/analytics';
-import {
-  SUPPORT_FORM_BUTTON_TEXT,
-  SUPPORT_FORM_MESSAGE,
-} from '@/services/support';
+import { useNfcTroubleStore } from '@/stores/nfcTroubleStore';
 
 const emitter =
   Platform.OS === 'android'
@@ -111,7 +108,8 @@ type DocumentNFCScanRoute = RouteProp<
 const DocumentNFCScanScreen: React.FC = () => {
   const selfClient = useSelfClient();
   const { trackEvent, useMRZStore } = selfClient;
-  const openSupportForm = useOpenSupportForm();
+  const insets = useSafeAreaInsets();
+  const revealNfcOptions = useNfcTroubleStore(state => state.revealOptions);
 
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
@@ -194,10 +192,6 @@ const DocumentNFCScanScreen: React.FC = () => {
     .onStart(() => {
       goToNFCMethodSelection();
     });
-
-  const onReportIssue = useCallback(() => {
-    openSupportForm();
-  }, [openSupportForm]);
 
   const openErrorModal = useCallback(
     (message: string) => {
@@ -305,6 +299,7 @@ const DocumentNFCScanScreen: React.FC = () => {
           ...baseContext,
           stage: 'timeout',
         });
+        revealNfcOptions();
         openErrorModal('Scan timed out. Please try again.');
         setIsNfcSheetOpen(false);
         logNFCEvent('info', 'sheet_close', {
@@ -333,6 +328,7 @@ const DocumentNFCScanScreen: React.FC = () => {
           ...baseContext,
           stage: 'timeout',
         });
+        revealNfcOptions();
         openErrorModal('Scan timed out. Please try again.');
         setIsNfcSheetOpen(false);
         logNFCEvent('info', 'sheet_close', {
@@ -419,15 +415,16 @@ const DocumentNFCScanScreen: React.FC = () => {
           passportData = parseScanResponse(scanResponse);
         } catch (e: unknown) {
           console.error('Parsing NFC Response Unsuccessful');
-          const errMsg = sanitizeErrorMessage(
-            e instanceof Error ? e.message : String(e),
-          );
+          const rawMessage = e instanceof Error ? e.message : String(e);
+          const sanitized = sanitizeErrorMessage(rawMessage);
           trackEvent(PassportEvents.NFC_RESPONSE_PARSE_FAILED, {
-            error: errMsg,
+            error: sanitized,
           });
           trackNfcEvent(PassportEvents.NFC_RESPONSE_PARSE_FAILED, {
-            error: errMsg,
+            error: sanitized,
           });
+          revealNfcOptions();
+          openErrorModal(rawMessage);
           return;
         }
         if (passportData) {
@@ -461,6 +458,7 @@ const DocumentNFCScanScreen: React.FC = () => {
           error: sanitized,
           duration_seconds: parseFloat(scanDurationSeconds),
         });
+        revealNfcOptions();
         openErrorModal(message);
         // We deliberately avoid opening any external feedback widgets here;
         // users can request support via the support form action in the modal.
@@ -495,6 +493,7 @@ const DocumentNFCScanScreen: React.FC = () => {
     selfClient,
     trackEvent,
     shouldInjectError,
+    revealNfcOptions,
   ]);
 
   const navigateToHome = useHapticNavigation('Home', {
@@ -588,6 +587,19 @@ const DocumentNFCScanScreen: React.FC = () => {
           cacheComposition={true}
           renderMode="HARDWARE"
         />
+        {!isNfcSheetOpen && (
+          <Button
+            unstyled
+            onPress={onCancelPress}
+            position="absolute"
+            top={Math.max(insets.top, 12) + 4}
+            left={12}
+            padding={8}
+            hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+            aria-label="Back"
+            icon={<ChevronLeft size={30} color={black} />}
+          />
+        )}
       </ExpandableBottomLayout.TopSection>
       <ExpandableBottomLayout.BottomSection backgroundColor={white}>
         {isNfcSheetOpen ? (
@@ -645,20 +657,12 @@ const DocumentNFCScanScreen: React.FC = () => {
                     Place your phone against the chip and keep it still until
                     the sensor reads it.
                   </BodyText>
-                  <BodyText style={[styles.disclaimer, { marginTop: 16 }]}>
-                    SELF DOES NOT STORE THIS INFORMATION.
-                  </BodyText>
                 </>
               ) : (
-                <>
-                  <BodyText style={[styles.disclaimer, { marginTop: 16 }]}>
-                    {dialogMessage}
-                  </BodyText>
-                </>
+                <BodyText style={[styles.disclaimer, { marginTop: 16 }]}>
+                  {dialogMessage}
+                </BodyText>
               )}
-              <BodyText style={[styles.disclaimer, { marginTop: 12 }]}>
-                {SUPPORT_FORM_MESSAGE}
-              </BodyText>
             </TextsContainer>
             <ButtonsContainer>
               <PrimaryButton
@@ -674,14 +678,8 @@ const DocumentNFCScanScreen: React.FC = () => {
                   ? 'Start Scan'
                   : 'Open settings'}
               </PrimaryButton>
-              <SecondaryButton
-                trackEvent={PassportEvents.CANCEL_PASSPORT_NFC}
-                onPress={onCancelPress}
-              >
-                Cancel
-              </SecondaryButton>
-              <SecondaryButton onPress={onReportIssue}>
-                {SUPPORT_FORM_BUTTON_TEXT}
+              <SecondaryButton onPress={goToNFCTrouble}>
+                Need help?
               </SecondaryButton>
               {(!isNfcSupported || !isNfcEnabled) && (
                 <SecondaryButton

--- a/app/src/screens/documents/scanning/DocumentNFCScanScreen.tsx
+++ b/app/src/screens/documents/scanning/DocumentNFCScanScreen.tsx
@@ -415,8 +415,9 @@ const DocumentNFCScanScreen: React.FC = () => {
           passportData = parseScanResponse(scanResponse);
         } catch (e: unknown) {
           console.error('Parsing NFC Response Unsuccessful');
-          const rawMessage = e instanceof Error ? e.message : String(e);
-          const sanitized = sanitizeErrorMessage(rawMessage);
+          const sanitized = sanitizeErrorMessage(
+            e instanceof Error ? e.message : String(e),
+          );
           trackEvent(PassportEvents.NFC_RESPONSE_PARSE_FAILED, {
             error: sanitized,
           });
@@ -424,7 +425,7 @@ const DocumentNFCScanScreen: React.FC = () => {
             error: sanitized,
           });
           revealNfcOptions();
-          openErrorModal(rawMessage);
+          openErrorModal(sanitized);
           return;
         }
         if (passportData) {
@@ -501,6 +502,7 @@ const DocumentNFCScanScreen: React.FC = () => {
   });
 
   const onCancelPress = () => {
+    trackEvent(PassportEvents.CANCEL_PASSPORT_NFC);
     flushAllAnalytics();
     logNFCEvent('info', 'scan_cancelled', { ...baseContext, stage: 'cancel' });
     if (isNfcSupported && isNfcEnabled) {

--- a/app/src/screens/documents/scanning/DocumentNFCTroubleScreen.tsx
+++ b/app/src/screens/documents/scanning/DocumentNFCTroubleScreen.tsx
@@ -18,16 +18,15 @@ import Tips from '@/components/Tips';
 import { useFeedbackAutoHide } from '@/hooks/useFeedbackAutoHide';
 import useHapticNavigation from '@/hooks/useHapticNavigation';
 import { useKycLauncher } from '@/hooks/useKycLauncher';
-import useOpenSupportForm from '@/hooks/useOpenSupportForm';
 import { selectionChange } from '@/integrations/haptics';
 import SimpleScrolledTitleLayout from '@/layouts/SimpleScrolledTitleLayout';
 import { flushAllAnalytics } from '@/services/analytics';
-import { SUPPORT_FORM_BUTTON_TEXT } from '@/services/support';
+import { useNfcTroubleStore } from '@/stores/nfcTroubleStore';
 
 const tips: TipProps[] = [
   {
     title: 'Know Your Chip Location',
-    body: "Depending on your passport's country of origin, the RFID chip could be in the front cover, back cover, or a specific page. Move your device slowly around these areas to locate the chip.",
+    body: 'The RFID chip is usually embedded in the photo page or the front or back cover of your passport — look for a small rectangular symbol that resembles a camera. Rest your phone flat against that area and move it slowly in small increments until the scan engages.',
   },
   {
     title: 'Remove Any Obstructions',
@@ -52,7 +51,6 @@ const tips: TipProps[] = [
 ];
 
 const DocumentNFCTroubleScreen: React.FC = () => {
-  const openSupportForm = useOpenSupportForm();
   const navigation = useNavigation();
   const handleDismiss = useCallback(() => {
     selectionChange();
@@ -67,6 +65,7 @@ const DocumentNFCTroubleScreen: React.FC = () => {
   const { launchKycVerification, isLoading } = useKycLauncher({
     countryCode,
   });
+  const nfcOptionsRevealed = useNfcTroubleStore(state => state.optionsRevealed);
   useFeedbackAutoHide();
 
   // error screen, flush analytics
@@ -85,19 +84,13 @@ const DocumentNFCTroubleScreen: React.FC = () => {
     <SimpleScrolledTitleLayout
       title="Having trouble verifying your ID?"
       onDismiss={handleDismiss}
-      secondaryButtonText="Open NFC Options"
-      onSecondaryButtonPress={goToNFCMethodSelection}
+      secondaryButtonText={nfcOptionsRevealed ? 'Open NFC Options' : undefined}
+      onSecondaryButtonPress={
+        nfcOptionsRevealed ? goToNFCMethodSelection : undefined
+      }
       footer={
         <YStack gap="$3">
           <SupportUuidRow />
-
-          <SecondaryButton
-            onPress={openSupportForm}
-            textColor={slate700}
-            style={{ marginBottom: 0 }}
-          >
-            {SUPPORT_FORM_BUTTON_TEXT}
-          </SecondaryButton>
 
           <SecondaryButton
             onPress={launchKycVerification}

--- a/app/src/stores/nfcTroubleStore.ts
+++ b/app/src/stores/nfcTroubleStore.ts
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { create } from 'zustand';
+
+interface NfcTroubleState {
+  optionsRevealed: boolean;
+  revealOptions: () => void;
+  reset: () => void;
+}
+
+// Tracks whether "Open NFC Options" should be visible on the
+// "Having trouble verifying your ID?" sheet. Hidden on first scan attempt,
+// revealed after the first failure, and persists for the rest of the
+// process session.
+export const useNfcTroubleStore = create<NfcTroubleState>(set => ({
+  optionsRevealed: false,
+  revealOptions: () => set({ optionsRevealed: true }),
+  reset: () => set({ optionsRevealed: false }),
+}));

--- a/app/src/stores/nfcTroubleStore.ts
+++ b/app/src/stores/nfcTroubleStore.ts
@@ -7,6 +7,7 @@ import { create } from 'zustand';
 interface NfcTroubleState {
   optionsRevealed: boolean;
   revealOptions: () => void;
+  reset: () => void;
 }
 
 // Tracks whether "Open NFC Options" should be visible on the
@@ -16,4 +17,5 @@ interface NfcTroubleState {
 export const useNfcTroubleStore = create<NfcTroubleState>(set => ({
   optionsRevealed: false,
   revealOptions: () => set({ optionsRevealed: true }),
+  reset: () => set({ optionsRevealed: false }),
 }));

--- a/app/src/stores/nfcTroubleStore.ts
+++ b/app/src/stores/nfcTroubleStore.ts
@@ -7,7 +7,6 @@ import { create } from 'zustand';
 interface NfcTroubleState {
   optionsRevealed: boolean;
   revealOptions: () => void;
-  reset: () => void;
 }
 
 // Tracks whether "Open NFC Options" should be visible on the
@@ -17,5 +16,4 @@ interface NfcTroubleState {
 export const useNfcTroubleStore = create<NfcTroubleState>(set => ({
   optionsRevealed: false,
   revealOptions: () => set({ optionsRevealed: true }),
-  reset: () => set({ optionsRevealed: false }),
 }));

--- a/app/tests/src/screens/documents/scanning/DocumentNFCTroubleScreen.test.tsx
+++ b/app/tests/src/screens/documents/scanning/DocumentNFCTroubleScreen.test.tsx
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+
+import DocumentNFCTroubleScreen from '@/screens/documents/scanning/DocumentNFCTroubleScreen';
+import { useNfcTroubleStore } from '@/stores/nfcTroubleStore';
+
+const mockGoBack = jest.fn();
+const mockGoToNfcMethodSelection = jest.fn();
+const mockLaunchKycVerification = jest.fn();
+
+let capturedLayoutProps: any;
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: jest.fn(() => ({ goBack: mockGoBack })),
+}));
+
+jest.mock('@selfxyz/mobile-sdk-alpha', () => ({
+  useSelfClient: jest.fn(() => ({
+    useMRZStore: () => ({ countryCode: 'US' }),
+  })),
+}));
+
+jest.mock('@selfxyz/mobile-sdk-alpha/components', () => ({
+  Caption: ({ children }: any) => <>{children}</>,
+  SecondaryButton: ({ children, onPress, disabled }: any) => (
+    <mock-secondary-button onPress={onPress} disabled={disabled}>
+      {children}
+    </mock-secondary-button>
+  ),
+}));
+
+jest.mock('react-native-gesture-handler', () => ({
+  Gesture: {
+    Tap: () => ({
+      numberOfTaps: () => ({
+        onStart: () => null,
+      }),
+    }),
+  },
+  GestureDetector: ({ children }: any) => children,
+}));
+
+jest.mock('tamagui', () => ({
+  YStack: ({ children }: any) => <>{children}</>,
+}));
+
+jest.mock('@/components/support/SupportUuidRow', () => {
+  const MockSupportUuidRow = () => <mock-support-row />;
+  return MockSupportUuidRow;
+});
+jest.mock('@/components/Tips', () => {
+  const MockTips = ({ items }: any) => <mock-tips count={items.length} />;
+  return MockTips;
+});
+jest.mock('@/hooks/useFeedbackAutoHide', () => ({
+  useFeedbackAutoHide: jest.fn(),
+}));
+
+jest.mock('@/hooks/useHapticNavigation', () => ({
+  __esModule: true,
+  default: jest.fn((routeName: string) => {
+    if (routeName === 'DocumentNFCMethodSelection') {
+      return mockGoToNfcMethodSelection;
+    }
+    return jest.fn();
+  }),
+}));
+
+jest.mock('@/hooks/useKycLauncher', () => ({
+  useKycLauncher: jest.fn(() => ({
+    launchKycVerification: mockLaunchKycVerification,
+    isLoading: false,
+  })),
+}));
+
+jest.mock('@/integrations/haptics', () => ({ selectionChange: jest.fn() }));
+jest.mock('@/services/analytics', () => ({ flushAllAnalytics: jest.fn() }));
+
+jest.mock('@/layouts/SimpleScrolledTitleLayout', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    capturedLayoutProps = props;
+    return (
+      <>
+        {props.children}
+        {props.footer}
+      </>
+    );
+  },
+}));
+
+describe('DocumentNFCTroubleScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedLayoutProps = undefined;
+    useNfcTroubleStore.getState().reset();
+  });
+
+  it('hides "Open NFC Options" until options are revealed', () => {
+    render(<DocumentNFCTroubleScreen />);
+
+    expect(capturedLayoutProps.secondaryButtonText).toBeUndefined();
+    expect(capturedLayoutProps.onSecondaryButtonPress).toBeUndefined();
+  });
+
+  it('shows "Open NFC Options" and wires action after reveal', () => {
+    useNfcTroubleStore.getState().revealOptions();
+
+    render(<DocumentNFCTroubleScreen />);
+
+    expect(capturedLayoutProps.secondaryButtonText).toBe('Open NFC Options');
+    expect(typeof capturedLayoutProps.onSecondaryButtonPress).toBe('function');
+
+    capturedLayoutProps.onSecondaryButtonPress();
+    expect(mockGoToNfcMethodSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it('always renders alternative verification button and triggers launcher', () => {
+    const { UNSAFE_getByType } = render(<DocumentNFCTroubleScreen />);
+    fireEvent.press(UNSAFE_getByType('mock-secondary-button'));
+
+    expect(mockLaunchKycVerification).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/tests/src/stores/nfcTroubleStore.test.ts
+++ b/app/tests/src/stores/nfcTroubleStore.test.ts
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { useNfcTroubleStore } from '@/stores/nfcTroubleStore';
+
+describe('useNfcTroubleStore', () => {
+  beforeEach(() => {
+    useNfcTroubleStore.getState().reset();
+  });
+
+  it('starts with options hidden', () => {
+    expect(useNfcTroubleStore.getState().optionsRevealed).toBe(false);
+  });
+
+  it('reveals options after revealOptions is called', () => {
+    useNfcTroubleStore.getState().revealOptions();
+    expect(useNfcTroubleStore.getState().optionsRevealed).toBe(true);
+  });
+
+  it('resets options to hidden after reset is called', () => {
+    useNfcTroubleStore.getState().revealOptions();
+    expect(useNfcTroubleStore.getState().optionsRevealed).toBe(true);
+
+    useNfcTroubleStore.getState().reset();
+    expect(useNfcTroubleStore.getState().optionsRevealed).toBe(false);
+  });
+
+  it('keeps options revealed across multiple reveal calls', () => {
+    useNfcTroubleStore.getState().revealOptions();
+    useNfcTroubleStore.getState().revealOptions();
+    expect(useNfcTroubleStore.getState().optionsRevealed).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Replace the `Cancel` button with a chevron-back in the top-left of the NFC scan screen, and swap `Send feedback` for a `Need help?` button that opens the trouble sheet.
- Remove the "SELF DOES NOT STORE THIS INFORMATION" and feedback-form disclaimer copy from the scan screen, and remove the `Send feedback` button from the trouble sheet.
- Hide `Open NFC Options` on the trouble sheet by default; reveal it (and persist for the session) after the first scan failure via a new `nfcTroubleStore`.
- Rewrite the "Know Your Chip Location" tip with clearer guidance on where the RFID chip sits on a passport.

## Changes

### React Native app

- `DocumentNFCScanScreen.tsx`: add chevron back button using safe-area insets, replace feedback CTA with `Need help?`, drop legal/feedback copy, call `revealOptions()` on every scan failure path (timeout, parse failure, generic error), and surface the raw parse error in the error modal.
- `DocumentNFCTroubleScreen.tsx`: remove `Send feedback` button and `useOpenSupportForm`, conditionally render `Open NFC Options` based on `nfcOptionsRevealed`, update the chip-location tip copy.
- New `stores/nfcTroubleStore.ts`: small Zustand store tracking `optionsRevealed` with `revealOptions` / `reset` actions for cross-screen visibility state.

## Linear Issues

- Closes [SELF-2979](https://linear.app/selfprotocol/issue/SELF-2979/nfc-scan-flow-ux-polish-chevron-back-contextual-help-hide-nfc-options) — NFC scan flow UX polish — chevron back, contextual help, hide NFC Options

## Test Plan

- [ ] `yarn lint && yarn types` passes
- [ ] Start ID verification → scan screen shows chevron back, `Start Scan`, and `Need help?`; no disclaimer/feedback copy
- [ ] Tap `Need help?` → trouble sheet opens with new chip-location copy, no `Send feedback`, no `Open NFC Options`
- [ ] Trigger a failed scan → reopen trouble sheet → `Open NFC Options` is visible and remains visible for the rest of the session
- [ ] `Open NFC Options` still opens system NFC settings

### Native Consolidation Checklist

- [ ] CONTRACTS.md reviewed - no unintended contract changes
- [ ] Layer 1 bridge contract tests pass (`cd app && yarn jest:run` / `yarn workspace @selfxyz/rn-sdk-test-app test`)
- [ ] Layer 3 builds pass (app iOS, RN test app iOS, RN test app Android)
- [ ] Layer 4 manual smoke test signed off (if consolidation PR)
- [ ] No new native business logic added (logic belongs in TypeScript)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Open NFC Options" button appears after NFC options are revealed to guide troubleshooting
  * Back button now accessible and properly positioned during NFC scanning
  * "Need help?" secondary action routes to the NFC troubleshooting flow
  * NFC trouble state can be reset during a session

* **Bug Fixes**
  * Improved NFC failure handling: sanitized error tracking and clearer modal messages
  * Disabled-state disclaimer displayed consistently
  * Updated instructions for locating the document RFID chip

* **Tests / Mocks**
  * Added tests for NFC trouble state and UI; updated test mocks for native modules and integrations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/selfxyz/self/pull/2086?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->