### PR TITLE
fix(routing): open selector with the eligible alternative's document type

### DIFF
--- a/app/src/screens/verification/ProvingScreenRouter.tsx
+++ b/app/src/screens/verification/ProvingScreenRouter.tsx
@@ -147,6 +147,7 @@ const ProvingScreenRouter: React.FC = () => {
           : false;
 
         let hasAlternativeEligibleValidDocument = false;
+        let alternativeEligibleDocumentType: string | null = null;
         if (hasAlternativeEligibleDocument && selectedDocumentId) {
           const alternativeValidDocuments = validDocuments.filter(
             doc => doc.id !== selectedDocumentId,
@@ -163,6 +164,10 @@ const ProvingScreenRouter: React.FC = () => {
             }
             if (alternativeDocGate === 'allow') {
               hasAlternativeEligibleValidDocument = true;
+              alternativeEligibleDocumentType = getDocumentTypeName(
+                doc.documentCategory,
+                doc.idType,
+              );
               break;
             }
           }
@@ -172,7 +177,7 @@ const ProvingScreenRouter: React.FC = () => {
           // Force selector regardless of skipDocumentSelector so the user can
           // pick the eligible alternative.
           hasRoutedRef.current = true;
-          openDocumentSelector(documentType);
+          openDocumentSelector(alternativeEligibleDocumentType ?? documentType);
           return;
         }
 


### PR DESCRIPTION
## Summary

Fixes the unresolved thread on #2089: when the selected document is ineligible but an alternative is, `ProvingScreenRouter` was opening the selector with the wrong document's type. Now we track the eligible alternative's type during validation and pass it to `openDocumentSelector`, falling back to the prior value when no alternative is found.

## Test plan

- [ ] `yarn lint && yarn types`
- [ ] Manual: with the current doc ineligible and an alternative eligible, the selector opens pre-targeted at the alternative's type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)