### PR TITLE
feat(observability): ANA-13 phase 3 — enforce KnownEventName cap on trackEvent

### DIFF
--- a/app/src/components/VerificationGateModal.tsx
+++ b/app/src/components/VerificationGateModal.tsx
@@ -5,6 +5,7 @@
 import React, { useMemo } from 'react';
 
 import { useSelfClient } from '@selfxyz/mobile-sdk-alpha';
+import type { KnownEventName } from '@selfxyz/mobile-sdk-alpha/constants/analytics';
 import { ProofEvents } from '@selfxyz/mobile-sdk-alpha/constants/analytics';
 
 import AlertModal, { type AlertModalParams } from '@/components/AlertModal';
@@ -18,8 +19,8 @@ interface ReasonCopy {
   titleText: string;
   bodyText: (appName: string) => string;
   buttonText: string;
-  recoverEvent: string;
-  dismissEvent: string;
+  recoverEvent: KnownEventName;
+  dismissEvent: KnownEventName;
 }
 
 const REASON_COPY: Record<VerificationGateReason, ReasonCopy> = {

--- a/app/src/screens/documents/selection/LogoConfirmationScreen.tsx
+++ b/app/src/screens/documents/selection/LogoConfirmationScreen.tsx
@@ -22,6 +22,7 @@ import {
   SecondaryButton,
 } from '@selfxyz/mobile-sdk-alpha/components';
 import {
+  AppEvents,
   KycEvents,
   OnboardingEvents,
 } from '@selfxyz/mobile-sdk-alpha/constants/analytics';
@@ -61,13 +62,13 @@ const LogoConfirmationScreen: React.FC = () => {
 
   const handleConfirm = useCallback(() => {
     buttonTap();
-    trackEvent('App: Logo Confirmation Answered', { answer: 'yes' });
+    trackEvent(AppEvents.LOGO_CONFIRMATION_ANSWERED, { answer: 'yes' });
     navigateToOnboarding();
   }, [navigateToOnboarding, trackEvent]);
 
   const handleNotFound = useCallback(() => {
     buttonTap();
-    trackEvent('App: Logo Confirmation Answered', { answer: 'no' });
+    trackEvent(AppEvents.LOGO_CONFIRMATION_ANSWERED, { answer: 'no' });
     // "No" on the chip-symbol check routes through the KYC provider —
     // update the canonical funnel branch accordingly.
     setOnboardingBranch('kyc');

--- a/packages/mobile-sdk-alpha/src/adapters/browser/analytics.ts
+++ b/packages/mobile-sdk-alpha/src/adapters/browser/analytics.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
+import type { KnownEventName } from '../../constants/analytics';
 import type { NFCScanContext } from '../../proving/internal/logging';
 import type { LogLevel } from '../../types/base';
 import type { AnalyticsAdapter, TrackEventParams } from '../../types/public';
@@ -39,7 +40,7 @@ export function createWebAnalyticsAdapter(options?: WebAnalyticsOptions): Analyt
   }
 
   return {
-    trackEvent(event: string, payload?: TrackEventParams): void {
+    trackEvent(event: KnownEventName, payload?: TrackEventParams): void {
       send({ type: 'event', event, ...payload, timestamp: Date.now() });
     },
 

--- a/packages/mobile-sdk-alpha/src/adapters/react-native/factory.ts
+++ b/packages/mobile-sdk-alpha/src/adapters/react-native/factory.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
+import type { KnownEventName } from '../../constants/analytics';
 import type {
   Adapters,
   AnalyticsAdapter,
@@ -47,7 +48,7 @@ export interface CreateReactNativeAdaptersOptions {
 
 /** No-op analytics adapter that silently drops all events. */
 const noopAnalytics: AnalyticsAdapter = {
-  trackEvent: (_event: string, _payload?: TrackEventParams) => {},
+  trackEvent: (_event: KnownEventName, _payload?: TrackEventParams) => {},
 };
 
 /**

--- a/packages/mobile-sdk-alpha/src/analytics/onboardingFunnel.ts
+++ b/packages/mobile-sdk-alpha/src/analytics/onboardingFunnel.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
+import type { KnownEventName } from '../constants/analytics';
 import { OnboardingEvents } from '../constants/analytics';
 import type { SelfClient } from '../types/public';
 
@@ -193,7 +194,7 @@ export function setOnboardingBranch(branch: OnboardingBranch): void {
 
 export function trackBranchEvent(
   selfClient: Pick<SelfClient, 'trackEvent'>,
-  event: string,
+  event: KnownEventName,
   properties?: Record<string, unknown>,
 ): void {
   if (!currentAttempt) return;
@@ -229,7 +230,7 @@ export function trackOnboardingRetry(
 
 export function trackOnboardingStep(
   selfClient: Pick<SelfClient, 'trackEvent'>,
-  event: string,
+  event: KnownEventName,
   properties?: Record<string, unknown>,
 ): void {
   const attempt = ensureAttempt(selfClient);

--- a/packages/mobile-sdk-alpha/src/client.ts
+++ b/packages/mobile-sdk-alpha/src/client.ts
@@ -4,6 +4,7 @@
 
 import { defaultConfig } from './config/defaults';
 import { mergeConfig } from './config/merge';
+import type { KnownEventName } from './constants/analytics';
 import { notImplemented } from './errors';
 import { extractMRZInfo as parseMRZInfo } from './processing/mrz';
 import type { NFCScanContext, ProofContext } from './proving/internal/logging';
@@ -120,7 +121,7 @@ export function createSelfClient({
     return _adapters.scanner.scan(opts);
   }
 
-  function trackEvent(event: string, payload?: TrackEventParams): void {
+  function trackEvent(event: KnownEventName, payload?: TrackEventParams): void {
     if (!_adapters.analytics) {
       return;
     }

--- a/packages/mobile-sdk-alpha/src/components/buttons/AbstractButton.tsx
+++ b/packages/mobile-sdk-alpha/src/components/buttons/AbstractButton.tsx
@@ -6,6 +6,7 @@ import type React from 'react';
 import type { GestureResponderEvent, LayoutChangeEvent, PressableProps, ViewStyle } from 'react-native';
 import { Platform, Pressable, StyleSheet, Text } from 'react-native';
 
+import type { KnownEventName } from '../../constants/analytics';
 import { dinot } from '../../constants/fonts';
 import { useSelfClient } from '../../context';
 import { pressedStyle } from './pressedStyle';
@@ -13,11 +14,7 @@ import { pressedStyle } from './pressedStyle';
 export interface ButtonProps extends PressableProps {
   children: React.ReactNode;
   animatedComponent?: React.ReactNode;
-  trackEvent?: string;
-  // Emit the event name verbatim (no "Click: " prefix, no category stripping).
-  // Used by canonical funnel events; `trackEvent` remains for the diagnostic
-  // layer so existing dashboards keep working.
-  trackEventRaw?: string;
+  trackEvent?: KnownEventName;
   trackEventProperties?: Record<string, unknown>;
   borderWidth?: number;
   borderColor?: string;
@@ -70,7 +67,6 @@ export default function AbstractButton({
   style,
   animatedComponent,
   trackEvent,
-  trackEventRaw,
   trackEventProperties,
   onPress,
   ...props
@@ -87,15 +83,8 @@ export default function AbstractButton({
   const hasBorder = borderColor != null;
 
   const handlePress = (e: GestureResponderEvent) => {
-    if (trackEventRaw) {
-      selfClient.trackEvent(trackEventRaw, trackEventProperties);
-    } else if (trackEvent) {
-      // attempt to remove event category from click event
-      const parsedEvent = trackEvent?.split(':')?.[1]?.trim();
-      if (parsedEvent) {
-        trackEvent = parsedEvent;
-      }
-      selfClient.trackEvent(`Click: ${trackEvent}`);
+    if (trackEvent) {
+      selfClient.trackEvent(trackEvent, trackEventProperties);
     }
     if (onPress) {
       onPress(e);

--- a/packages/mobile-sdk-alpha/src/constants/analytics.ts
+++ b/packages/mobile-sdk-alpha/src/constants/analytics.ts
@@ -10,24 +10,25 @@ export const AadhaarEvents = {
   QR_SELECTED: 'Aadhaar: QR Selected',
   TIMESTAMP_EXPIRED: 'Aadhaar: Timestamp Expired',
   UPLOAD_STARTED: 'Aadhaar: Upload Started',
-};
+} as const;
 
 export const AppEvents = {
   DISMISS_PRIVACY_DISCLAIMER: 'App: Dismiss Privacy Disclaimer',
   GET_STARTED: 'App: Get Started',
   GET_STARTED_AADHAAR: 'App: Get Started - Aadhaar',
   GET_STARTED_BIOMETRIC: 'App: Get Started - Biometric ID',
+  LOGO_CONFIRMATION_ANSWERED: 'App: Logo Confirmation Answered',
   SUPPORTED_BIOMETRIC_IDS: 'App: Supported Biometric IDs',
   UPDATE_MODAL_CLOSED: 'App: Update Modal Closed',
   UPDATE_MODAL_OPENED: 'App: Update Modal Opened',
   UPDATE_STARTED: 'App: Update Started',
-};
+} as const;
 
 export const AuthEvents = {
   BIOMETRIC_LOGIN_CANCELLED: 'Auth: Biometric Login Cancelled',
   BIOMETRIC_LOGIN_FAILED: 'Auth: Biometric Login Failed',
   BIOMETRIC_LOGIN_SUCCESS: 'Auth: Biometric Login Success',
-};
+} as const;
 
 export const BackupEvents = {
   ACCOUNT_RECOVERY_COMPLETED: 'Backup: Account Recovery Completed',
@@ -47,7 +48,7 @@ export const BackupEvents = {
   TURNKEY_RESTORE_FAILED: 'Backup: Turnkey Restore Failed',
   CREATE_NEW_ACCOUNT: 'Backup: Create New Account',
   MANUAL_RECOVERY_SELECTED: 'Backup: Manual Recovery Selected',
-};
+} as const;
 
 export const BiometricEvents = {
   DOCUMENT_PARSED: 'Biometric: Document Parsed',
@@ -59,7 +60,7 @@ export const BiometricEvents = {
 
   NFC_RESPONSE_PARSE_FAILED: 'Passport: Parsing NFC Response Unsuccessful',
   NFC_SCAN_FAILED: 'Passport: NFC Scan Failed',
-};
+} as const;
 
 export const DocumentEvents = {
   COUNTRY_HELP_TAPPED: 'Document: Country Help Tapped',
@@ -75,7 +76,7 @@ export const DocumentEvents = {
   PASSPORT_INFO_OPENED: 'Document: Passport Info Screen Opened',
   PASSPORT_METADATA_LOADED: 'Document: Passport Metadata Loaded',
   VALIDATE_DOCUMENT_FAILED: 'Document: Validate Document Failed',
-};
+} as const;
 
 export const KycEvents = {
   PROVIDER_CLOSED: 'KYC: Provider Closed',
@@ -83,13 +84,13 @@ export const KycEvents = {
   RETRY_TRIGGERED: 'KYC: Retry Triggered',
   SESSION_CREATED: 'KYC: Session Created',
   SESSION_REQUESTED: 'KYC: Session Requested',
-};
+} as const;
 
 export const IDDataEvents = {
   PERKS_VIEWED: 'ID Data: Perks Viewed',
   PERK_TAPPED: 'ID Data: Perk Tapped',
   PERK_OUTLINK_OPEN_FAILED: 'ID Data: Perk Outlink Open Failed',
-};
+} as const;
 
 export const MockDataEvents = {
   CANCEL_GENERATION: 'Mock Data: Cancel Generation',
@@ -106,12 +107,12 @@ export const MockDataEvents = {
   SELECT_COUNTRY: 'Mock Data: Select Country',
   SELECT_DOCUMENT_TYPE: 'Mock Data: Select Document Type',
   TOGGLE_OFAC_LIST: 'Mock Data: Toggle OFAC List',
-};
+} as const;
 
 export const NotificationEvents = {
   BACKGROUND_NOTIFICATION_OPENED: 'Notification: Background Notification Opened',
   COLD_START_NOTIFICATION_OPENED: 'Notification: Cold Start Notification Opened',
-};
+} as const;
 
 export const OnboardingEvents = {
   STARTED: 'Onboarding: Started',
@@ -125,7 +126,7 @@ export const OnboardingEvents = {
   RECOVERED: 'Onboarding: Recovered',
   FAILED: 'Onboarding: Failed',
   STEP_RETRIED: 'Onboarding: Step Retried',
-};
+} as const;
 
 export const PointEvents = {
   HOME_POINT_EARN_POINTS_OPENED: 'Points: Home Earn Points Opened',
@@ -142,7 +143,7 @@ export const PointEvents = {
   EARN_NOTIFICATION_FAILED: 'Points: Earn with Notification Failed',
   EARN_NOTIFICATION_SUCCESS: 'Points: Earn with Notification Success',
   REFRESH_HISTORY: 'Points: Refresh History',
-};
+} as const;
 
 export const ProofEvents = {
   ALREADY_REGISTERED: 'Proof: Already Registered',
@@ -209,16 +210,36 @@ export const ProofEvents = {
   VALIDATION_SUCCESS: 'Proof: Validation Succeeded',
   WS_HELLO_ACK: 'Proof: WS Hello Acknowledged',
   WS_HELLO_SENT: 'Proof: WS Hello Sent',
-};
+} as const;
 
 export const RegistrationPickerEvents = {
   VIEWED: 'registration_id_picker_viewed',
   SELECTED: 'registration_id_picker_selected',
   UNSUPPORTED_TAPPED: 'registration_id_picker_unsupported_tapped',
-};
+} as const;
 
 export const SettingsEvents = {
   CONNECTION_MODAL_CLOSED: 'Settings: Connection Modal Closed',
   CONNECTION_MODAL_OPENED: 'Settings: Connection Modal Opened',
   CONNECTION_SETTINGS_OPENED: 'Settings: Connection Settings Opened',
-};
+} as const;
+
+const _AllEvents = {
+  ...AadhaarEvents,
+  ...AppEvents,
+  ...AuthEvents,
+  ...BackupEvents,
+  ...BiometricEvents,
+  ...DocumentEvents,
+  ...KycEvents,
+  ...IDDataEvents,
+  ...MockDataEvents,
+  ...NotificationEvents,
+  ...OnboardingEvents,
+  ...PointEvents,
+  ...ProofEvents,
+  ...RegistrationPickerEvents,
+  ...SettingsEvents,
+} as const;
+
+export type KnownEventName = (typeof _AllEvents)[keyof typeof _AllEvents];

--- a/packages/mobile-sdk-alpha/src/constants/analytics.ts
+++ b/packages/mobile-sdk-alpha/src/constants/analytics.ts
@@ -224,22 +224,21 @@ export const SettingsEvents = {
   CONNECTION_SETTINGS_OPENED: 'Settings: Connection Settings Opened',
 } as const;
 
-const _AllEvents = {
-  ...AadhaarEvents,
-  ...AppEvents,
-  ...AuthEvents,
-  ...BackupEvents,
-  ...BiometricEvents,
-  ...DocumentEvents,
-  ...KycEvents,
-  ...IDDataEvents,
-  ...MockDataEvents,
-  ...NotificationEvents,
-  ...OnboardingEvents,
-  ...PointEvents,
-  ...ProofEvents,
-  ...RegistrationPickerEvents,
-  ...SettingsEvents,
-} as const;
-
-export type KnownEventName = (typeof _AllEvents)[keyof typeof _AllEvents];
+// Union per-group so collisions on shared keys (e.g. STARTED, FAILED) across
+// groups can't silently drop event names from the cap.
+export type KnownEventName =
+  | (typeof AadhaarEvents)[keyof typeof AadhaarEvents]
+  | (typeof AppEvents)[keyof typeof AppEvents]
+  | (typeof AuthEvents)[keyof typeof AuthEvents]
+  | (typeof BackupEvents)[keyof typeof BackupEvents]
+  | (typeof BiometricEvents)[keyof typeof BiometricEvents]
+  | (typeof DocumentEvents)[keyof typeof DocumentEvents]
+  | (typeof IDDataEvents)[keyof typeof IDDataEvents]
+  | (typeof KycEvents)[keyof typeof KycEvents]
+  | (typeof MockDataEvents)[keyof typeof MockDataEvents]
+  | (typeof NotificationEvents)[keyof typeof NotificationEvents]
+  | (typeof OnboardingEvents)[keyof typeof OnboardingEvents]
+  | (typeof PointEvents)[keyof typeof PointEvents]
+  | (typeof ProofEvents)[keyof typeof ProofEvents]
+  | (typeof RegistrationPickerEvents)[keyof typeof RegistrationPickerEvents]
+  | (typeof SettingsEvents)[keyof typeof SettingsEvents];

--- a/packages/mobile-sdk-alpha/src/constants/index.ts
+++ b/packages/mobile-sdk-alpha/src/constants/index.ts
@@ -15,6 +15,7 @@ export {
   PointEvents,
   ProofEvents,
 } from './analytics';
+export type { KnownEventName } from './analytics';
 
 export { NFC_IMAGE } from './images';
 

--- a/packages/mobile-sdk-alpha/src/index.ts
+++ b/packages/mobile-sdk-alpha/src/index.ts
@@ -50,6 +50,8 @@ export type { DocumentData, DocumentMetadata, PassportCameraProps, ScreenProps }
 
 export type { HapticOptions, HapticType } from './haptic/shared';
 
+export type { KnownEventName } from './constants/analytics';
+
 export type { MRZScanOptions } from './mrz';
 
 export type { OnboardingBranch, OnboardingFailureStage, OnboardingStage } from './analytics/onboardingFunnel';

--- a/packages/mobile-sdk-alpha/src/types/public.ts
+++ b/packages/mobile-sdk-alpha/src/types/public.ts
@@ -6,6 +6,7 @@ import type { create } from 'zustand';
 
 import type { DocumentCatalog, IDDocument, PassportData } from '@selfxyz/common';
 
+import type { KnownEventName } from '../constants/analytics';
 import type { NFCScanContext, ProofContext } from '../proving/internal/logging';
 import type { ProvingState } from '../proving/provingMachine';
 import type { MRZState } from '../stores/mrzStore';
@@ -185,7 +186,7 @@ export interface AnalyticsAdapter {
    * completion. Implementations should debounce repeated calls triggered by
    * retries.
    */
-  trackEvent?(event: string, payload?: TrackEventParams): void;
+  trackEvent?(event: KnownEventName, payload?: TrackEventParams): void;
   /**
    * Structured metrics specific to NFC scanning. Consumers can enrich the
    * payload to correlate with hardware models or OS versions.
@@ -396,7 +397,7 @@ export interface SelfClient {
    * Convenience wrapper around {@link AnalyticsAdapter.trackEvent}. Calls are
    * no-ops when an analytics adapter was not provided.
    */
-  trackEvent(event: string, payload?: TrackEventParams): void;
+  trackEvent(event: KnownEventName, payload?: TrackEventParams): void;
   /** Mirrors {@link AnalyticsAdapter.trackNfcEvent}. */
   trackNfcEvent(name: string, properties?: Record<string, unknown>): void;
   /** Mirrors {@link AnalyticsAdapter.logNFCEvent}. */

--- a/packages/mobile-sdk-alpha/tests/adapters/browser/analytics.test.ts
+++ b/packages/mobile-sdk-alpha/tests/adapters/browser/analytics.test.ts
@@ -5,6 +5,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createWebAnalyticsAdapter } from '../../../src/adapters/browser/analytics';
+import { AppEvents, OnboardingEvents } from '../../../src/constants/analytics';
 
 describe('createWebAnalyticsAdapter', () => {
   beforeEach(() => {
@@ -14,7 +15,7 @@ describe('createWebAnalyticsAdapter', () => {
   it('should call trackEvent without throwing', () => {
     const adapter = createWebAnalyticsAdapter();
     // Should not throw — fire-and-forget
-    expect(() => adapter.trackEvent!('page_view', { reason: 'test' })).not.toThrow();
+    expect(() => adapter.trackEvent!(OnboardingEvents.STARTED, { reason: 'test' })).not.toThrow();
   });
 
   it('should call trackNfcEvent without throwing', () => {
@@ -31,15 +32,18 @@ describe('createWebAnalyticsAdapter', () => {
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const adapter = createWebAnalyticsAdapter({ debug: true });
 
-    adapter.trackEvent!('test_event');
-    expect(spy).toHaveBeenCalledWith('[Analytics]', expect.objectContaining({ type: 'event', event: 'test_event' }));
+    adapter.trackEvent!(AppEvents.GET_STARTED);
+    expect(spy).toHaveBeenCalledWith(
+      '[Analytics]',
+      expect.objectContaining({ type: 'event', event: AppEvents.GET_STARTED }),
+    );
   });
 
   it('should POST to endpoint when configured', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response());
     const adapter = createWebAnalyticsAdapter({ endpoint: 'https://analytics.example.com/events' });
 
-    adapter.trackEvent!('test_event', { reason: 'test' });
+    adapter.trackEvent!(AppEvents.GET_STARTED, { reason: 'test' });
 
     // fetch is called async, give it a tick
     await new Promise(resolve => setTimeout(resolve, 0));
@@ -58,7 +62,7 @@ describe('createWebAnalyticsAdapter', () => {
     const adapter = createWebAnalyticsAdapter({ endpoint: 'https://analytics.example.com/events' });
 
     // Should not throw
-    expect(() => adapter.trackEvent!('test_event')).not.toThrow();
+    expect(() => adapter.trackEvent!(AppEvents.GET_STARTED)).not.toThrow();
 
     // Give the rejected promise time to settle
     await new Promise(resolve => setTimeout(resolve, 0));

--- a/packages/mobile-sdk-alpha/tests/client.test.ts
+++ b/packages/mobile-sdk-alpha/tests/client.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import type { CryptoAdapter, DocumentsAdapter, NetworkAdapter, NFCScannerAdapter } from '../src';
+import { AppEvents, BackupEvents } from '../src/constants/analytics';
 import { createListenersMap, createSelfClient, SdkEvents } from '../src/index';
 import type { AuthAdapter, NavigationAdapter } from '../src/types/public';
 
@@ -160,11 +161,11 @@ describe('createSelfClient', () => {
         listeners: new Map(),
       });
 
-      client.trackEvent('test_event');
+      client.trackEvent(AppEvents.GET_STARTED);
       expect(trackEvent).toHaveBeenCalledOnce();
-      expect(trackEvent).toHaveBeenCalledWith('test_event', undefined);
-      client.trackEvent('another_event', { foo: 'bar' });
-      expect(trackEvent).toHaveBeenCalledWith('another_event', { foo: 'bar' });
+      expect(trackEvent).toHaveBeenCalledWith(AppEvents.GET_STARTED, undefined);
+      client.trackEvent(BackupEvents.CLOUD_BACKUP_STARTED, { foo: 'bar' });
+      expect(trackEvent).toHaveBeenCalledWith(BackupEvents.CLOUD_BACKUP_STARTED, { foo: 'bar' });
     });
   });
   describe('when auth adapter is given', () => {

--- a/packages/mobile-sdk-alpha/tests/components/buttons/AbstractButton.test.tsx
+++ b/packages/mobile-sdk-alpha/tests/components/buttons/AbstractButton.test.tsx
@@ -8,6 +8,7 @@ import { Platform } from 'react-native';
 import { describe, expect, it, vi } from 'vitest';
 
 import AbstractButton from '../../../src/components/buttons/AbstractButton';
+import { AppEvents } from '../../../src/constants/analytics';
 import { SelfClientProvider } from '../../../src/index';
 import { mockAdapters } from '../../utils/testHelpers';
 
@@ -162,25 +163,9 @@ describe('AbstractButton', () => {
 
   describe('event tracking', () => {
     it('should call trackEvent when trackEvent prop is provided', () => {
-      // This test verifies the trackEvent functionality exists
-      // The actual implementation is tested through the SelfClient
       const { container } = render(
         <TestWrapper>
-          <AbstractButton bgColor="black" color="white" trackEvent="Test Button Click">
-            Test Button
-          </AbstractButton>
-        </TestWrapper>,
-      );
-
-      const button = container.querySelector('button');
-      expect(button).toBeTruthy();
-    });
-
-    it('should parse event category from trackEvent string', () => {
-      // Tests that "Category: Event" format gets parsed to "Event"
-      const { container } = render(
-        <TestWrapper>
-          <AbstractButton bgColor="black" color="white" trackEvent="Category: Button Click">
+          <AbstractButton bgColor="black" color="white" trackEvent={AppEvents.GET_STARTED}>
             Test Button
           </AbstractButton>
         </TestWrapper>,


### PR DESCRIPTION
## Summary

Phase 3 of [ANA-13](./specs/projects/sdk/workstreams/analytics/plans/ANA-13-observability-migration.md). Phases 1 and 2 shipped in #2057.

- Adds a typed `KnownEventName` union derived from the existing `*Events` constants in `packages/mobile-sdk-alpha/src/constants/analytics.ts`.
- Narrows `selfClient.trackEvent`, `AnalyticsAdapter.trackEvent`, `trackOnboardingStep`, and `trackBranchEvent` to accept only that union. Adding a new Mixpanel event now requires registering it in `constants/analytics.ts` — any other string fails `yarn types` / CI.
- Drops `AbstractButton`'s `Click: ${X}` synthesis and the unused `trackEventRaw` prop. The button now emits the literal `KnownEventName` from the typed `trackEvent` prop. Net effect on Mixpanel: the previously-unrecognized `Click: …` events stop firing; the underlying canonical `Category: …` event fires in their place.
- Registers the pre-existing `App: Logo Confirmation Answered` straggler as `AppEvents.LOGO_CONFIRMATION_ANSWERED`.

## Why this matters

The spec calls Phase 3 the "hard cap" — types stop new Mixpanel events from sneaking in without an explicit consumer documented in `analytics.ts`. Without it, the Phase 1+2 volume reduction will drift back up over time.

## Validation

```bash
cd packages/mobile-sdk-alpha && yarn types && yarn test  # 444/444 pass, types clean
cd app && yarn types && yarn test                        # types clean, 52/52 tests pass
cd packages/mobile-sdk-alpha && yarn lint                # clean
```

Manual probe matches the spec's Phase 3 acceptance test — `trackEvent('Foo: Bar')` fails TypeScript with `Argument of type '"Foo: Bar"' is not assignable to parameter of type 'KnownEventName'`.

## Test plan

- [ ] CI types/lint/tests pass on `dev`.
- [ ] Diff a Mixpanel "Click: …" event volume drop after merge — should approach zero within one release cycle.
- [ ] Confirm `LogoConfirmationScreen` still fires `App: Logo Confirmation Answered` on staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Tightened analytics event handling across the SDK and app to a constrained set of known event identifiers and exported that type for the public SDK surface, improving consistency and developer experience without changing runtime behavior.
* **Tests**
  * Updated analytics tests to validate against the standardized event references, improving test accuracy and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/selfxyz/self/pull/2093?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->