### PR TITLE
add homescreen ID card perks indicator

### DIFF
--- a/app/metro.config.cjs
+++ b/app/metro.config.cjs
@@ -415,6 +415,7 @@ const config = {
         '@react-native-masked-view/masked-view',
         '@react-native-firebase/analytics',
         'react-native-b4a',
+        'expo-updates',
       ];
 
       if (optionalPeerDependencies.includes(moduleName)) {

--- a/app/src/components/homescreen/IdCard.tsx
+++ b/app/src/components/homescreen/IdCard.tsx
@@ -18,6 +18,7 @@ import {
 } from '@selfxyz/common/utils/types';
 import { WarningTriangleIcon } from '@selfxyz/euclid/dist/components/icons/WarningTriangleIcon';
 import {
+  getPerkRailContent,
   getPerkRecordsForIdType,
   useSelfClient,
 } from '@selfxyz/mobile-sdk-alpha';
@@ -26,11 +27,11 @@ import { HomescreenEvents } from '@selfxyz/mobile-sdk-alpha/constants/analytics'
 import {
   black,
   red600,
+  slate100,
   white,
   yellow500,
 } from '@selfxyz/mobile-sdk-alpha/constants/colors';
 import { dinot } from '@selfxyz/mobile-sdk-alpha/constants/fonts';
-import GoogleLogo from '@selfxyz/mobile-sdk-alpha/svgs/icons/google.svg';
 
 import CardBackgroundId1 from '@/assets/images/card_background_id1.png';
 import CardBackgroundId2 from '@/assets/images/card_background_id2.png';
@@ -54,10 +55,6 @@ import { getCountryDemonym } from '@/utils/countryDemonyms';
 import { getDocumentAttributes } from '@/utils/documentAttributes';
 import { idTypeForDocumentCategory } from '@/utils/idType';
 import { registerModalCallbacks } from '@/utils/modalCallbackRegistry';
-
-const PERK_LOGO_BY_ID: Record<string, () => React.ReactNode> = {
-  google_cloud_faucet: () => <GoogleLogo width={20} height={20} />,
-};
 
 const CARD_BACKGROUNDS = [
   CardBackgroundId1,
@@ -149,6 +146,10 @@ const IdCardLayout: FC<IdCardLayoutAttributes> = ({
   );
   const perkRecords = useMemo(
     () => (idType ? getPerkRecordsForIdType(idType) : []),
+    [idType],
+  );
+  const perkRailContent = useMemo(
+    () => (idType ? getPerkRailContent(idType) : null),
     [idType],
   );
   const primaryPerk = perkRecords[0] ?? null;
@@ -356,10 +357,10 @@ const IdCardLayout: FC<IdCardLayoutAttributes> = ({
         borderRadius={borderRadius}
         overflow="hidden"
         shadowColor={black}
-        shadowOffset={{ width: 0, height: 4 }}
+        shadowOffset={{ width: 0, height: 24 }}
         shadowOpacity={0.25}
-        shadowRadius={14}
-        elevation={8}
+        shadowRadius={34}
+        elevation={16}
         marginBottom={8}
       >
         <YStack
@@ -480,11 +481,12 @@ const IdCardLayout: FC<IdCardLayoutAttributes> = ({
               </YStack>
             ))}
         </YStack>
-        {perksVisible && primaryPerk && (
-          <YStack backgroundColor={white}>
+        {perksVisible && primaryPerk && perkRailContent && (
+          <YStack backgroundColor={slate100}>
             <PerkRail
               variant="dense"
-              logos={[(PERK_LOGO_BY_ID[primaryPerk.id] ?? (() => null))()]}
+              logos={perkRailContent.logos}
+              label={perkRailContent.label.toUpperCase()}
               onPress={handlePerkPress}
             />
           </YStack>

--- a/app/src/components/homescreen/IdCard.tsx
+++ b/app/src/components/homescreen/IdCard.tsx
@@ -151,6 +151,7 @@ const IdCardLayout: FC<IdCardLayoutAttributes> = ({
     () => (idType ? getPerkRecordsForIdType(idType) : []),
     [idType],
   );
+  const primaryPerk = perkRecords[0] ?? null;
   const documentViewKey = useMemo(() => {
     if (!idDocument || !idType) {
       return null;
@@ -193,27 +194,26 @@ const IdCardLayout: FC<IdCardLayoutAttributes> = ({
   }, [perksVisible, idType, documentViewKey, perkRecords.length, trackEvent]);
 
   const handlePerkPress = useCallback(async () => {
-    const first = perkRecords[0];
-    if (!first) {
+    if (!primaryPerk || !idType) {
       return;
     }
     trackEvent(HomescreenEvents.ID_CARD_PERK_TAPPED, {
       id_type: idType,
-      perk_id: first.id,
-      has_outlink: Boolean(first.outlinkUrl),
+      perk_id: primaryPerk.id,
+      has_outlink: Boolean(primaryPerk.outlinkUrl),
     });
-    if (!first.outlinkUrl) {
+    if (!primaryPerk.outlinkUrl) {
       return;
     }
     try {
-      await Linking.openURL(first.outlinkUrl);
+      await Linking.openURL(primaryPerk.outlinkUrl);
     } catch {
       trackEvent(HomescreenEvents.ID_CARD_PERK_OUTLINK_OPEN_FAILED, {
         id_type: idType,
-        perk_id: first.id,
+        perk_id: primaryPerk.id,
       });
     }
-  }, [perkRecords, idType, trackEvent]);
+  }, [primaryPerk, idType, trackEvent]);
 
   if (!idDocument) {
     return null;
@@ -480,14 +480,11 @@ const IdCardLayout: FC<IdCardLayoutAttributes> = ({
               </YStack>
             ))}
         </YStack>
-        {perksVisible && (
+        {perksVisible && primaryPerk && (
           <YStack backgroundColor={white}>
             <PerkRail
               variant="dense"
-              logos={perkRecords.map(record => {
-                const factory = PERK_LOGO_BY_ID[record.id];
-                return factory ? factory() : null;
-              })}
+              logos={[(PERK_LOGO_BY_ID[primaryPerk.id] ?? (() => null))()]}
               onPress={handlePerkPress}
             />
           </YStack>

--- a/app/src/components/homescreen/IdCard.tsx
+++ b/app/src/components/homescreen/IdCard.tsx
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
-import React, { type FC, useCallback } from 'react';
-import { Image, Pressable, StyleSheet } from 'react-native';
+import React, { type FC, useCallback, useEffect, useMemo, useRef } from 'react';
+import { Image, Linking, Pressable, StyleSheet } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 import { Text, XStack, YStack } from 'tamagui';
 import { useNavigation } from '@react-navigation/native';
@@ -17,7 +17,12 @@ import {
   isMRZDocument,
 } from '@selfxyz/common/utils/types';
 import { WarningTriangleIcon } from '@selfxyz/euclid/dist/components/icons/WarningTriangleIcon';
-import { RoundFlag } from '@selfxyz/mobile-sdk-alpha/components';
+import {
+  getPerkRecordsForIdType,
+  useSelfClient,
+} from '@selfxyz/mobile-sdk-alpha';
+import { PerkRail, RoundFlag } from '@selfxyz/mobile-sdk-alpha/components';
+import { HomescreenEvents } from '@selfxyz/mobile-sdk-alpha/constants/analytics';
 import {
   black,
   red600,
@@ -25,6 +30,7 @@ import {
   yellow500,
 } from '@selfxyz/mobile-sdk-alpha/constants/colors';
 import { dinot } from '@selfxyz/mobile-sdk-alpha/constants/fonts';
+import GoogleLogo from '@selfxyz/mobile-sdk-alpha/svgs/icons/google.svg';
 
 import CardBackgroundId1 from '@/assets/images/card_background_id1.png';
 import CardBackgroundId2 from '@/assets/images/card_background_id2.png';
@@ -46,7 +52,12 @@ import { useCardDimensions } from '@/hooks/useCardDimensions';
 import { getBackgroundIndex } from '@/utils/cardBackgroundSelector';
 import { getCountryDemonym } from '@/utils/countryDemonyms';
 import { getDocumentAttributes } from '@/utils/documentAttributes';
+import { idTypeForDocumentCategory } from '@/utils/idType';
 import { registerModalCallbacks } from '@/utils/modalCallbackRegistry';
+
+const PERK_LOGO_BY_ID: Record<string, () => React.ReactNode> = {
+  google_cloud_faucet: () => <GoogleLogo width={20} height={20} />,
+};
 
 const CARD_BACKGROUNDS = [
   CardBackgroundId1,
@@ -66,6 +77,7 @@ interface IdCardLayoutAttributes {
   selected: boolean;
   hidden: boolean;
   isInactive?: boolean;
+  showPerks?: boolean;
 }
 
 /**
@@ -81,8 +93,10 @@ const IdCardLayout: FC<IdCardLayoutAttributes> = ({
   selected,
   hidden,
   isInactive = false,
+  showPerks = true,
 }) => {
   const navigation = useNavigation();
+  const { trackEvent } = useSelfClient();
   const navigateToDocumentOnboarding = useCallback(() => {
     switch (idDocument?.documentCategory) {
       case 'passport':
@@ -125,6 +139,82 @@ const IdCardLayout: FC<IdCardLayoutAttributes> = ({
     fontSize,
   } = useCardDimensions(selected);
 
+  const isMockDocument = Boolean(idDocument?.mock);
+  const idType = useMemo(
+    () =>
+      idDocument && !isMockDocument
+        ? idTypeForDocumentCategory(idDocument.documentCategory)
+        : null,
+    [idDocument, isMockDocument],
+  );
+  const perkRecords = useMemo(
+    () => (idType ? getPerkRecordsForIdType(idType) : []),
+    [idType],
+  );
+  const documentViewKey = useMemo(() => {
+    if (!idDocument || !idType) {
+      return null;
+    }
+    if (isMRZDocument(idDocument)) {
+      return `${idType}:${idDocument.mrz}`;
+    }
+    if (isAadhaarDocument(idDocument)) {
+      return `${idType}:${idDocument.qrData}`;
+    }
+    return `${idType}:${idDocument.documentCategory}`;
+  }, [idDocument, idType]);
+
+  const perksVisible =
+    showPerks &&
+    selected &&
+    hidden &&
+    !isInactive &&
+    !isMockDocument &&
+    perkRecords.length > 0 &&
+    idDocument != null &&
+    !isKycDocument(idDocument);
+
+  const viewedDocumentKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (
+      !perksVisible ||
+      !idType ||
+      !documentViewKey ||
+      viewedDocumentKeyRef.current === documentViewKey
+    ) {
+      return;
+    }
+    viewedDocumentKeyRef.current = documentViewKey;
+    trackEvent(HomescreenEvents.ID_CARD_VIEWED, {
+      id_type: idType,
+      has_perks: true,
+      perk_count: perkRecords.length,
+    });
+  }, [perksVisible, idType, documentViewKey, perkRecords.length, trackEvent]);
+
+  const handlePerkPress = useCallback(async () => {
+    const first = perkRecords[0];
+    if (!first) {
+      return;
+    }
+    trackEvent(HomescreenEvents.ID_CARD_PERK_TAPPED, {
+      id_type: idType,
+      perk_id: first.id,
+      has_outlink: Boolean(first.outlinkUrl),
+    });
+    if (!first.outlinkUrl) {
+      return;
+    }
+    try {
+      await Linking.openURL(first.outlinkUrl);
+    } catch {
+      trackEvent(HomescreenEvents.ID_CARD_PERK_OUTLINK_OPEN_FAILED, {
+        id_type: idType,
+        perk_id: first.id,
+      });
+    }
+  }, [perkRecords, idType, trackEvent]);
+
   if (!idDocument) {
     return null;
   }
@@ -157,9 +247,6 @@ const IdCardLayout: FC<IdCardLayoutAttributes> = ({
   // Get deterministic background based on document data
   const backgroundIndex = getBackgroundIndex(idDocument);
   const cardBackground = CARD_BACKGROUNDS[backgroundIndex - 1];
-
-  // Check if this is a mock/dev document
-  const isMockDocument = Boolean(idDocument.mock);
 
   // Determine document type label
   const getDocumentTypeLabel = (): string => {
@@ -266,130 +353,145 @@ const IdCardLayout: FC<IdCardLayoutAttributes> = ({
       )}
       <YStack
         width={cardWidth}
-        height={cardHeight}
         borderRadius={borderRadius}
         overflow="hidden"
-        backgroundColor={black}
         shadowColor={black}
         shadowOffset={{ width: 0, height: 4 }}
         shadowOpacity={0.25}
         shadowRadius={14}
         elevation={8}
         marginBottom={8}
-        alignItems="stretch"
       >
-        {/* Header Section - Dark gradient */}
-        <CardHeader
-          variant="gradient"
-          title={headerTitle}
-          subtitle={subtitleText}
-          headerHeight={headerHeight}
-          figmaPadding={figmaPadding}
-          headerGap={headerGap}
-          fontSize={fontSize}
-          logo={
-            isMockDocument ? (
+        <YStack
+          height={cardHeight}
+          backgroundColor={black}
+          alignItems="stretch"
+        >
+          {/* Header Section - Dark gradient */}
+          <CardHeader
+            variant="gradient"
+            title={headerTitle}
+            subtitle={subtitleText}
+            headerHeight={headerHeight}
+            figmaPadding={figmaPadding}
+            headerGap={headerGap}
+            fontSize={fontSize}
+            logo={
+              isMockDocument ? (
+                <YStack
+                  width={logoSize}
+                  height={logoSize}
+                  borderRadius={logoSize / 2}
+                  backgroundColor={DEV_LOGO_BG}
+                  alignItems="center"
+                  justifyContent="center"
+                  overflow="hidden"
+                >
+                  <DevCardLogo width={logoSize} height={logoSize} />
+                </YStack>
+              ) : (
+                <RoundFlag countryCode={nationalityCode} size={logoSize} />
+              )
+            }
+            rightElement={
+              isMockDocument ? (
+                <YStack width={85 * scale} height={19 * scale} />
+              ) : (
+                <SelfLogoPending width={logoSize} height={logoSize} />
+              )
+            }
+          />
+
+          {/* Gradient divider line for dev cards - dark edges, light middle */}
+          {isMockDocument && selected && (
+            <LinearGradient
+              colors={['#3a3a3a', '#747474', '#3a3a3a']}
+              start={{ x: 0, y: 0 }}
+              end={{ x: 1, y: 0 }}
+              style={{ height: 2, width: '100%' }}
+            />
+          )}
+
+          {/* Body Section - Dark gradient with wave pattern */}
+          {selected &&
+            (isMockDocument ? (
+              // Dev card body - solid indigo background with wave pattern (exact Figma)
               <YStack
-                width={logoSize}
-                height={logoSize}
-                borderRadius={logoSize / 2}
-                backgroundColor={DEV_LOGO_BG}
-                alignItems="center"
-                justifyContent="center"
-                overflow="hidden"
+                style={[
+                  cardStyles.body,
+                  { backgroundColor: DEV_BODY_COLOR, height: bodyHeight },
+                ]}
               >
-                <DevCardLogo width={logoSize} height={logoSize} />
+                {/* Wave pattern - exact Figma asset with exact positioning */}
+                {/* Figma insets: top -10.53%, right 5.62%, bottom -57.11%, left -44.43% */}
+                <YStack
+                  position="absolute"
+                  top={`${-10.53}%`}
+                  right={`${5.62}%`}
+                  bottom={`${-57.11}%`}
+                  left={`${-44.43}%`}
+                >
+                  <DevCardWave
+                    width="100%"
+                    height="100%"
+                    preserveAspectRatio="none"
+                  />
+                </YStack>
               </YStack>
             ) : (
-              <RoundFlag countryCode={nationalityCode} size={logoSize} />
-            )
-          }
-          rightElement={
-            isMockDocument ? (
-              <YStack width={85 * scale} height={19 * scale} />
-            ) : (
-              <SelfLogoPending width={logoSize} height={logoSize} />
-            )
-          }
-        />
+              // Real document body - gradient background with wave overlay
+              <YStack style={cardStyles.body}>
+                {/* Gradient background */}
+                <Image
+                  source={cardBackground}
+                  style={cardStyles.backgroundImage}
+                  resizeMode="cover"
+                />
+                {/* Wave pattern overlay */}
+                <Image
+                  source={WaveOverlay}
+                  style={styles.waveOverlay}
+                  resizeMode="contain"
+                />
 
-        {/* Gradient divider line for dev cards - dark edges, light middle */}
-        {isMockDocument && selected && (
-          <LinearGradient
-            colors={['#3a3a3a', '#747474', '#3a3a3a']}
-            start={{ x: 0, y: 0 }}
-            end={{ x: 1, y: 0 }}
-            style={{ height: 2, width: '100%' }}
-          />
-        )}
-
-        {/* Body Section - Dark gradient with wave pattern */}
-        {selected &&
-          (isMockDocument ? (
-            // Dev card body - solid indigo background with wave pattern (exact Figma)
-            <YStack
-              style={[
-                cardStyles.body,
-                { backgroundColor: DEV_BODY_COLOR, height: bodyHeight },
-              ]}
-            >
-              {/* Wave pattern - exact Figma asset with exact positioning */}
-              {/* Figma insets: top -10.53%, right 5.62%, bottom -57.11%, left -44.43% */}
-              <YStack
-                position="absolute"
-                top={`${-10.53}%`}
-                right={`${5.62}%`}
-                bottom={`${-57.11}%`}
-                left={`${-44.43}%`}
-              >
-                <DevCardWave
-                  width="100%"
-                  height="100%"
-                  preserveAspectRatio="none"
+                {/* Bottom content: Left text + Right badge (real documents only) */}
+                <CardBottomContent
+                  truncatedId={truncatedId}
+                  bottomLabel={bottomLabel}
+                  badges={[
+                    ...(isInactive
+                      ? [
+                          {
+                            text: 'INACTIVE',
+                            backgroundColor: red600,
+                            textColor: white,
+                          },
+                        ]
+                      : []),
+                    {
+                      text: securityBadgeLabel,
+                      backgroundColor: 'rgba(0, 0, 0, 0.5)',
+                      textColor: white,
+                    },
+                  ]}
+                  padding={padding}
+                  fontSize={fontSize}
                 />
               </YStack>
-            </YStack>
-          ) : (
-            // Real document body - gradient background with wave overlay
-            <YStack style={cardStyles.body}>
-              {/* Gradient background */}
-              <Image
-                source={cardBackground}
-                style={cardStyles.backgroundImage}
-                resizeMode="cover"
-              />
-              {/* Wave pattern overlay */}
-              <Image
-                source={WaveOverlay}
-                style={styles.waveOverlay}
-                resizeMode="contain"
-              />
-
-              {/* Bottom content: Left text + Right badge (real documents only) */}
-              <CardBottomContent
-                truncatedId={truncatedId}
-                bottomLabel={bottomLabel}
-                badges={[
-                  ...(isInactive
-                    ? [
-                        {
-                          text: 'INACTIVE',
-                          backgroundColor: red600,
-                          textColor: white,
-                        },
-                      ]
-                    : []),
-                  {
-                    text: securityBadgeLabel,
-                    backgroundColor: 'rgba(0, 0, 0, 0.5)',
-                    textColor: white,
-                  },
-                ]}
-                padding={padding}
-                fontSize={fontSize}
-              />
-            </YStack>
-          ))}
+            ))}
+        </YStack>
+        {perksVisible && (
+          <YStack backgroundColor={white}>
+            <PerkRail
+              variant="dense"
+              logos={perkRecords.map(record => {
+                const factory = PERK_LOGO_BY_ID[record.id];
+                return factory ? factory() : null;
+              })}
+              onPress={handlePerkPress}
+            />
+          </YStack>
+        )}
       </YStack>
     </YStack>
   );

--- a/app/src/screens/documents/management/IdDetailsScreen.tsx
+++ b/app/src/screens/documents/management/IdDetailsScreen.tsx
@@ -30,6 +30,7 @@ import IdCardLayout from '@/components/homescreen/IdCard';
 import { usePassport } from '@/providers/passportDataProvider';
 import { ProofHistoryList } from '@/screens/home/ProofHistoryList';
 import useUserStore from '@/stores/userStore';
+import { idTypeForDocumentCategory } from '@/utils/idType';
 
 const IdDetailsScreen: React.FC = () => {
   const { idDetailsDocumentId } = useUserStore();
@@ -149,7 +150,12 @@ const IdDetailsScreen: React.FC = () => {
 
   const ListHeader = (
     <YStack padding={20} paddingBottom={0}>
-      <IdCardLayout idDocument={document} selected={true} hidden={isHidden} />
+      <IdCardLayout
+        idDocument={document}
+        selected={true}
+        hidden={isHidden}
+        showPerks={false}
+      />
       <XStack marginTop={'$3'} justifyContent="flex-start" gap={'$4'}>
         <Button
           onPress={() => setIsHidden(!isHidden)}
@@ -235,20 +241,5 @@ const IdDetailsScreen: React.FC = () => {
     </YStack>
   );
 };
-
-function idTypeForDocumentCategory(
-  category: IDDocument['documentCategory'],
-): string | null {
-  switch (category) {
-    case 'passport':
-      return 'p';
-    case 'id_card':
-      return 'i';
-    case 'aadhaar':
-      return 'a';
-    default:
-      return null;
-  }
-}
 
 export default IdDetailsScreen;

--- a/app/src/utils/idType.ts
+++ b/app/src/utils/idType.ts
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import type { IDDocument } from '@selfxyz/common/utils/types';
+
+export function idTypeForDocumentCategory(
+  category: IDDocument['documentCategory'],
+): string | null {
+  switch (category) {
+    case 'passport':
+      return 'p';
+    case 'id_card':
+      return 'i';
+    case 'aadhaar':
+      return 'a';
+    default:
+      return null;
+  }
+}

--- a/app/tests/src/components/homescreen/IdCard.test.tsx
+++ b/app/tests/src/components/homescreen/IdCard.test.tsx
@@ -399,6 +399,41 @@ describe('IdCardLayout perks footer', () => {
     expect(MockTrackEvent).not.toHaveBeenCalled();
   });
 
+  it('renders a single-CTA rail and targets the first perk even if multiple are returned', async () => {
+    MockGetPerkRecordsForIdType.mockReturnValueOnce([
+      {
+        id: 'google_cloud_faucet',
+        label: 'Google Cloud Faucet',
+        isNew: true,
+        outlinkUrl: 'https://example.test/perk',
+      },
+      {
+        id: 'second_perk',
+        label: 'Second',
+        isNew: false,
+        outlinkUrl: 'https://example.test/second',
+      },
+    ]);
+    MockOpenURL.mockResolvedValueOnce(undefined);
+    render(
+      <IdCardLayout idDocument={passportDoc} selected={true} hidden={true} />,
+    );
+    expect(MockPerkRailProps.logos).toHaveLength(1);
+    await act(async () => {
+      await MockPerkRailProps.onPress?.();
+    });
+    expect(MockTrackEvent).toHaveBeenCalledWith(
+      'Homescreen: ID Card Perk Tapped',
+      {
+        id_type: 'p',
+        perk_id: 'google_cloud_faucet',
+        has_outlink: true,
+      },
+    );
+    expect(MockOpenURL).toHaveBeenCalledWith('https://example.test/perk');
+    expect(MockOpenURL).toHaveBeenCalledTimes(1);
+  });
+
   it('suppresses footer when selected=false (collapsed)', () => {
     render(
       <IdCardLayout idDocument={passportDoc} selected={false} hidden={true} />,

--- a/app/tests/src/components/homescreen/IdCard.test.tsx
+++ b/app/tests/src/components/homescreen/IdCard.test.tsx
@@ -21,10 +21,27 @@ const MockGetPerkRecordsForIdType = jest.fn((idType: string) =>
         },
       ],
 );
+const MockGetPerkRailContent = jest.fn((idType: string) =>
+  idType === 'none'
+    ? null
+    : {
+        perks: [
+          {
+            id: 'google_cloud_faucet',
+            label: 'Google Cloud Faucet',
+            isNew: true,
+            renderLogos: () => ['google-logo', 'usat-logo'],
+          },
+        ],
+        logos: ['google-logo', 'usat-logo'],
+        label: 'Eligible for 1 perk',
+      },
+);
 let MockPerkRailProps: {
   onPress?: () => void;
   logos?: unknown[];
   variant?: string;
+  label?: string;
 } = {};
 
 function perkRailRendered(): boolean {
@@ -81,6 +98,7 @@ jest.mock('@selfxyz/mobile-sdk-alpha', () => ({
   useSelfClient: () => ({ trackEvent: MockTrackEvent }),
   getPerkRecordsForIdType: (idType: string) =>
     MockGetPerkRecordsForIdType(idType),
+  getPerkRailContent: (idType: string) => MockGetPerkRailContent(idType),
 }));
 
 jest.mock('@selfxyz/mobile-sdk-alpha/components', () => ({
@@ -114,11 +132,6 @@ jest.mock('@selfxyz/mobile-sdk-alpha/constants/fonts', () => ({
   __esModule: true,
   dinot: 'DINOT',
 }));
-
-jest.mock(
-  '@selfxyz/mobile-sdk-alpha/svgs/icons/google.svg',
-  () => 'GoogleLogo',
-);
 
 jest.mock('@selfxyz/common/utils/types', () => ({
   __esModule: true,
@@ -248,6 +261,23 @@ describe('IdCardLayout perks footer', () => {
             },
           ],
     );
+    MockGetPerkRailContent.mockClear();
+    MockGetPerkRailContent.mockImplementation((idType: string) =>
+      idType === 'none'
+        ? null
+        : {
+            perks: [
+              {
+                id: 'google_cloud_faucet',
+                label: 'Google Cloud Faucet',
+                isNew: true,
+                renderLogos: () => ['google-logo', 'usat-logo'],
+              },
+            ],
+            logos: ['google-logo', 'usat-logo'],
+            label: 'Eligible for 1 perk',
+          },
+    );
     MockPerkRailProps = {};
   });
 
@@ -257,8 +287,8 @@ describe('IdCardLayout perks footer', () => {
     );
     expect(perkRailRendered()).toBe(true);
     expect(MockPerkRailProps.variant).toBe('dense');
-    expect(MockPerkRailProps.logos).toHaveLength(1);
-    expect(MockPerkRailProps.logos?.[0]).not.toBeNull();
+    expect(MockPerkRailProps.logos).toHaveLength(2);
+    expect(MockPerkRailProps.label).toBe('ELIGIBLE FOR 1 PERK');
   });
 
   it('fires ID_CARD_VIEWED exactly once on mount', () => {
@@ -359,6 +389,7 @@ describe('IdCardLayout perks footer', () => {
 
   it('suppresses footer when the perks catalog is empty', () => {
     MockGetPerkRecordsForIdType.mockReturnValueOnce([]);
+    MockGetPerkRailContent.mockReturnValueOnce(null);
     render(
       <IdCardLayout idDocument={passportDoc} selected={true} hidden={true} />,
     );
@@ -418,7 +449,7 @@ describe('IdCardLayout perks footer', () => {
     render(
       <IdCardLayout idDocument={passportDoc} selected={true} hidden={true} />,
     );
-    expect(MockPerkRailProps.logos).toHaveLength(1);
+    expect(MockPerkRailProps.logos).toHaveLength(2);
     await act(async () => {
       await MockPerkRailProps.onPress?.();
     });

--- a/app/tests/src/components/homescreen/IdCard.test.tsx
+++ b/app/tests/src/components/homescreen/IdCard.test.tsx
@@ -1,0 +1,409 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import React from 'react';
+import { act, render } from '@testing-library/react-native';
+
+import IdCardLayout from '@/components/homescreen/IdCard';
+
+const MockOpenURL = jest.fn();
+const MockTrackEvent = jest.fn();
+const MockGetPerkRecordsForIdType = jest.fn((idType: string) =>
+  idType === 'none'
+    ? []
+    : [
+        {
+          id: 'google_cloud_faucet',
+          label: 'Google Cloud Faucet',
+          isNew: true,
+          outlinkUrl: 'https://example.test/perk',
+        },
+      ],
+);
+let MockPerkRailProps: {
+  onPress?: () => void;
+  logos?: unknown[];
+  variant?: string;
+} = {};
+
+function perkRailRendered(): boolean {
+  return Object.keys(MockPerkRailProps).length > 0;
+}
+
+jest.mock('react-native', () => ({
+  __esModule: true,
+  Image: ({ ...props }: any) => <mock-image {...props} />,
+  Linking: { openURL: (...args: any[]) => MockOpenURL(...args) },
+  Platform: { OS: 'ios', select: jest.fn() },
+  Pressable: ({ children, onPress, ...props }: any) => (
+    <mock-pressable {...props} onClick={onPress}>
+      {children}
+    </mock-pressable>
+  ),
+  StyleSheet: {
+    create: (styles: any) => styles,
+    flatten: (style: any) => style,
+  },
+}));
+
+jest.mock('react-native-linear-gradient', () => ({
+  __esModule: true,
+  default: ({ children, ...props }: any) => (
+    <mock-linear-gradient {...props}>{children}</mock-linear-gradient>
+  ),
+}));
+
+jest.mock('tamagui', () => {
+  const Pass = ({ children, ...props }: any) => (
+    <div {...props}>{children}</div>
+  );
+  return {
+    __esModule: true,
+    Text: ({ children, ...props }: any) => <span {...props}>{children}</span>,
+    XStack: Pass,
+    YStack: Pass,
+  };
+});
+
+jest.mock('@react-navigation/native', () => ({
+  __esModule: true,
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+jest.mock('@selfxyz/euclid/dist/components/icons/WarningTriangleIcon', () => ({
+  __esModule: true,
+  WarningTriangleIcon: () => <mock-warning-icon />,
+}));
+
+jest.mock('@selfxyz/mobile-sdk-alpha', () => ({
+  __esModule: true,
+  useSelfClient: () => ({ trackEvent: MockTrackEvent }),
+  getPerkRecordsForIdType: (idType: string) =>
+    MockGetPerkRecordsForIdType(idType),
+}));
+
+jest.mock('@selfxyz/mobile-sdk-alpha/components', () => ({
+  __esModule: true,
+  PerkRail: (props: any) => {
+    MockPerkRailProps = props;
+    return <mock-perk-rail />;
+  },
+  RoundFlag: () => <mock-round-flag />,
+}));
+
+jest.mock('@selfxyz/mobile-sdk-alpha/constants/analytics', () => ({
+  __esModule: true,
+  HomescreenEvents: {
+    ID_CARD_VIEWED: 'Homescreen: ID Card Viewed',
+    ID_CARD_PERK_TAPPED: 'Homescreen: ID Card Perk Tapped',
+    ID_CARD_PERK_OUTLINK_OPEN_FAILED:
+      'Homescreen: ID Card Perk Outlink Open Failed',
+  },
+}));
+
+jest.mock('@selfxyz/mobile-sdk-alpha/constants/colors', () => ({
+  __esModule: true,
+  black: '#000',
+  red600: '#dc2626',
+  white: '#fff',
+  yellow500: '#eab308',
+}));
+
+jest.mock('@selfxyz/mobile-sdk-alpha/constants/fonts', () => ({
+  __esModule: true,
+  dinot: 'DINOT',
+}));
+
+jest.mock(
+  '@selfxyz/mobile-sdk-alpha/svgs/icons/google.svg',
+  () => 'GoogleLogo',
+);
+
+jest.mock('@selfxyz/common/utils/types', () => ({
+  __esModule: true,
+  isAadhaarDocument: (d: any) => d?.documentCategory === 'aadhaar',
+  isKycDocument: (d: any) => d?.documentCategory === 'kyc',
+  isMRZDocument: (d: any) =>
+    d?.documentCategory === 'passport' || d?.documentCategory === 'id_card',
+}));
+
+jest.mock('@/assets/images/card_background_id1.png', () => 'bg1');
+jest.mock('@/assets/images/card_background_id2.png', () => 'bg2');
+jest.mock('@/assets/images/card_background_id3.png', () => 'bg3');
+jest.mock('@/assets/images/card_background_id4.png', () => 'bg4');
+jest.mock('@/assets/images/card_background_id5.png', () => 'bg5');
+jest.mock('@/assets/images/card_background_id6.png', () => 'bg6');
+jest.mock('@/assets/images/dev_card_logo.svg', () => 'DevLogo');
+jest.mock('@/assets/images/dev_card_wave.svg', () => 'DevWave');
+jest.mock('@/assets/images/self_logo_pending.svg', () => 'SelfPending');
+jest.mock('@/assets/images/wave_overlay.png', () => 'WaveOverlay');
+
+jest.mock('@/components/homescreen/CardBottomContent', () => ({
+  __esModule: true,
+  default: () => <mock-card-bottom />,
+}));
+jest.mock('@/components/homescreen/CardHeader', () => ({
+  __esModule: true,
+  default: () => <mock-card-header />,
+}));
+jest.mock('@/components/homescreen/IdCardRevealed', () => ({
+  __esModule: true,
+  default: () => <mock-id-card-revealed />,
+}));
+jest.mock('@/components/homescreen/KycIdCard', () => ({
+  __esModule: true,
+  default: () => <mock-kyc-id-card />,
+}));
+jest.mock('@/components/homescreen/cardSecurityBadge', () => ({
+  __esModule: true,
+  getSecurityBadgeLabel: () => 'HI-SECURITY',
+}));
+
+jest.mock('@/hooks/useCardDimensions', () => ({
+  __esModule: true,
+  useCardDimensions: () => ({
+    cardWidth: 300,
+    cardHeight: 200,
+    borderRadius: 10,
+    scale: 1,
+    headerHeight: 60,
+    figmaPadding: 12,
+    logoSize: 32,
+    headerGap: 8,
+    expandedAspectRatio: 1.5,
+    collapsedAspectRatio: 5,
+    fontSize: {
+      header: 18,
+      subtitle: 7,
+      badge: 10,
+      bottomLabel: 15,
+      bottomId: 10,
+      button: 16,
+    },
+  }),
+}));
+
+jest.mock('@/utils/cardBackgroundSelector', () => ({
+  __esModule: true,
+  getBackgroundIndex: () => 1,
+}));
+jest.mock('@/utils/countryDemonyms', () => ({
+  __esModule: true,
+  getCountryDemonym: () => 'AMERICAN',
+}));
+jest.mock('@/utils/documentAttributes', () => ({
+  __esModule: true,
+  getDocumentAttributes: () => ({ nationalitySlice: 'USA' }),
+}));
+jest.mock('@/utils/modalCallbackRegistry', () => ({
+  __esModule: true,
+  registerModalCallbacks: () => 'cb-id',
+}));
+
+const passportDoc = {
+  documentCategory: 'passport' as const,
+  mrz: 'P<USA',
+  mock: false,
+} as any;
+
+const secondPassportDoc = {
+  documentCategory: 'passport' as const,
+  mrz: 'P<GBR',
+  mock: false,
+} as any;
+
+const aadhaarDoc = {
+  documentCategory: 'aadhaar' as const,
+  qrData: 'aadhaar-qr-1',
+  mock: false,
+  extractedFields: { aadhaarLast4Digits: '1234' },
+} as any;
+
+const kycDoc = {
+  documentCategory: 'kyc' as const,
+  mock: false,
+} as any;
+
+const mockDoc = {
+  documentCategory: 'passport' as const,
+  mrz: 'P<USA',
+  mock: true,
+} as any;
+
+describe('IdCardLayout perks footer', () => {
+  beforeEach(() => {
+    MockOpenURL.mockReset();
+    MockTrackEvent.mockReset();
+    MockGetPerkRecordsForIdType.mockClear();
+    MockGetPerkRecordsForIdType.mockImplementation((idType: string) =>
+      idType === 'none'
+        ? []
+        : [
+            {
+              id: 'google_cloud_faucet',
+              label: 'Google Cloud Faucet',
+              isNew: true,
+              outlinkUrl: 'https://example.test/perk',
+            },
+          ],
+    );
+    MockPerkRailProps = {};
+  });
+
+  it('renders the perk rail for selected hidden non-mock passport', () => {
+    render(
+      <IdCardLayout idDocument={passportDoc} selected={true} hidden={true} />,
+    );
+    expect(perkRailRendered()).toBe(true);
+    expect(MockPerkRailProps.variant).toBe('dense');
+    expect(MockPerkRailProps.logos).toHaveLength(1);
+    expect(MockPerkRailProps.logos?.[0]).not.toBeNull();
+  });
+
+  it('fires ID_CARD_VIEWED exactly once on mount', () => {
+    const { rerender } = render(
+      <IdCardLayout idDocument={passportDoc} selected={true} hidden={true} />,
+    );
+    expect(MockTrackEvent).toHaveBeenCalledWith('Homescreen: ID Card Viewed', {
+      id_type: 'p',
+      has_perks: true,
+      perk_count: 1,
+    });
+    expect(MockTrackEvent).toHaveBeenCalledTimes(1);
+    rerender(
+      <IdCardLayout idDocument={passportDoc} selected={true} hidden={true} />,
+    );
+    expect(MockTrackEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-fires ID_CARD_VIEWED when the document type changes', () => {
+    const { rerender } = render(
+      <IdCardLayout idDocument={passportDoc} selected={true} hidden={true} />,
+    );
+    expect(MockTrackEvent).toHaveBeenCalledTimes(1);
+    rerender(
+      <IdCardLayout idDocument={aadhaarDoc} selected={true} hidden={true} />,
+    );
+    expect(MockTrackEvent).toHaveBeenCalledTimes(2);
+    expect(MockTrackEvent).toHaveBeenLastCalledWith(
+      'Homescreen: ID Card Viewed',
+      { id_type: 'a', has_perks: true, perk_count: 1 },
+    );
+  });
+
+  it('re-fires ID_CARD_VIEWED when a same-type document changes', () => {
+    const { rerender } = render(
+      <IdCardLayout idDocument={passportDoc} selected={true} hidden={true} />,
+    );
+    expect(MockTrackEvent).toHaveBeenCalledTimes(1);
+    rerender(
+      <IdCardLayout
+        idDocument={secondPassportDoc}
+        selected={true}
+        hidden={true}
+      />,
+    );
+    expect(MockTrackEvent).toHaveBeenCalledTimes(2);
+    expect(MockTrackEvent).toHaveBeenLastCalledWith(
+      'Homescreen: ID Card Viewed',
+      { id_type: 'p', has_perks: true, perk_count: 1 },
+    );
+  });
+
+  it('fires ID_CARD_PERK_TAPPED and opens the outlink on rail press', async () => {
+    MockOpenURL.mockResolvedValueOnce(undefined);
+    render(
+      <IdCardLayout idDocument={passportDoc} selected={true} hidden={true} />,
+    );
+    await act(async () => {
+      await MockPerkRailProps.onPress?.();
+    });
+    expect(MockTrackEvent).toHaveBeenCalledWith(
+      'Homescreen: ID Card Perk Tapped',
+      {
+        id_type: 'p',
+        perk_id: 'google_cloud_faucet',
+        has_outlink: true,
+      },
+    );
+    expect(MockOpenURL).toHaveBeenCalledWith('https://example.test/perk');
+  });
+
+  it('fires ID_CARD_PERK_OUTLINK_OPEN_FAILED when openURL rejects', async () => {
+    MockOpenURL.mockRejectedValueOnce(new Error('blocked'));
+    render(
+      <IdCardLayout idDocument={passportDoc} selected={true} hidden={true} />,
+    );
+    await act(async () => {
+      await MockPerkRailProps.onPress?.();
+    });
+    expect(MockTrackEvent).toHaveBeenCalledWith(
+      'Homescreen: ID Card Perk Outlink Open Failed',
+      { id_type: 'p', perk_id: 'google_cloud_faucet' },
+    );
+  });
+
+  it('suppresses footer when showPerks=false', () => {
+    render(
+      <IdCardLayout
+        idDocument={passportDoc}
+        selected={true}
+        hidden={true}
+        showPerks={false}
+      />,
+    );
+    expect(perkRailRendered()).toBe(false);
+    expect(MockTrackEvent).not.toHaveBeenCalled();
+  });
+
+  it('suppresses footer when the perks catalog is empty', () => {
+    MockGetPerkRecordsForIdType.mockReturnValueOnce([]);
+    render(
+      <IdCardLayout idDocument={passportDoc} selected={true} hidden={true} />,
+    );
+    expect(perkRailRendered()).toBe(false);
+    expect(MockTrackEvent).not.toHaveBeenCalled();
+  });
+
+  it('suppresses footer when isInactive', () => {
+    render(
+      <IdCardLayout
+        idDocument={passportDoc}
+        selected={true}
+        hidden={true}
+        isInactive={true}
+      />,
+    );
+    expect(perkRailRendered()).toBe(false);
+    expect(MockTrackEvent).not.toHaveBeenCalled();
+  });
+
+  it('suppresses footer for mock documents', () => {
+    render(<IdCardLayout idDocument={mockDoc} selected={true} hidden={true} />);
+    expect(perkRailRendered()).toBe(false);
+    expect(MockTrackEvent).not.toHaveBeenCalled();
+  });
+
+  it('does not render the dark layout footer for KYC documents', () => {
+    render(<IdCardLayout idDocument={kycDoc} selected={true} hidden={true} />);
+    expect(perkRailRendered()).toBe(false);
+    expect(MockTrackEvent).not.toHaveBeenCalled();
+  });
+
+  it('suppresses footer when hidden=false (reveal state)', () => {
+    render(
+      <IdCardLayout idDocument={passportDoc} selected={true} hidden={false} />,
+    );
+    expect(perkRailRendered()).toBe(false);
+    expect(MockTrackEvent).not.toHaveBeenCalled();
+  });
+
+  it('suppresses footer when selected=false (collapsed)', () => {
+    render(
+      <IdCardLayout idDocument={passportDoc} selected={false} hidden={true} />,
+    );
+    expect(perkRailRendered()).toBe(false);
+    expect(MockTrackEvent).not.toHaveBeenCalled();
+  });
+});

--- a/app/tests/src/screens/documents/management/IdDetailsScreen.test.tsx
+++ b/app/tests/src/screens/documents/management/IdDetailsScreen.test.tsx
@@ -88,6 +88,7 @@ jest.mock('react-native', () => ({
 const mockLinking = jest.requireMock('react-native').Linking as jest.Mocked<{
   openURL: jest.Mock;
 }>;
+let mockIdCardProps: any = null;
 
 jest.mock('@selfxyz/mobile-sdk-alpha/constants/colors', () => ({
   black: '#000',
@@ -100,7 +101,10 @@ jest.mock('@selfxyz/mobile-sdk-alpha/constants/colors', () => ({
 
 jest.mock('@/components/homescreen/IdCard', () => ({
   __esModule: true,
-  default: () => <mock-stack testID="id-card" />,
+  default: (props: any) => {
+    mockIdCardProps = props;
+    return <mock-stack testID="id-card" />;
+  },
 }));
 
 jest.mock('@/screens/home/ProofHistoryList', () => ({
@@ -160,6 +164,7 @@ describe('IdDetailsScreen', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIdCardProps = null;
 
     useNavigation.mockReturnValue({ navigate: jest.fn() });
     useSelfClient.mockReturnValue({ trackEvent });
@@ -198,6 +203,17 @@ describe('IdDetailsScreen', () => {
       perk_count: 1,
       perk_ids: ['google_cloud_faucet'],
     });
+  });
+
+  it('disables the ID card footer perks while keeping the details perks card', async () => {
+    const { UNSAFE_root } = render(<IdDetailsScreen />);
+
+    await waitFor(() => UNSAFE_root.findByType('mock-perks-card' as never));
+
+    expect(mockIdCardProps?.showPerks).toBe(false);
+    expect(UNSAFE_root.findAllByType('mock-perks-card' as never)).toHaveLength(
+      1,
+    );
   });
 
   it('opens the perk outlink URL and fires the perk-tapped analytics event', async () => {

--- a/packages/mobile-sdk-alpha/src/constants/analytics.ts
+++ b/packages/mobile-sdk-alpha/src/constants/analytics.ts
@@ -92,6 +92,12 @@ export const IDDataEvents = {
   PERK_OUTLINK_OPEN_FAILED: 'ID Data: Perk Outlink Open Failed',
 } as const;
 
+export const HomescreenEvents = {
+  ID_CARD_VIEWED: 'Homescreen: ID Card Viewed',
+  ID_CARD_PERK_TAPPED: 'Homescreen: ID Card Perk Tapped',
+  ID_CARD_PERK_OUTLINK_OPEN_FAILED: 'Homescreen: ID Card Perk Outlink Open Failed',
+} as const;
+
 export const MockDataEvents = {
   CANCEL_GENERATION: 'Mock Data: Cancel Generation',
   CREATE_DEEP_LINK: 'Mock Data: Create Deep Link',
@@ -233,6 +239,7 @@ export type KnownEventName =
   | (typeof BackupEvents)[keyof typeof BackupEvents]
   | (typeof BiometricEvents)[keyof typeof BiometricEvents]
   | (typeof DocumentEvents)[keyof typeof DocumentEvents]
+  | (typeof HomescreenEvents)[keyof typeof HomescreenEvents]
   | (typeof IDDataEvents)[keyof typeof IDDataEvents]
   | (typeof KycEvents)[keyof typeof KycEvents]
   | (typeof MockDataEvents)[keyof typeof MockDataEvents]

--- a/packages/mobile-sdk-alpha/src/flows/onboarding/id-selection-screen.tsx
+++ b/packages/mobile-sdk-alpha/src/flows/onboarding/id-selection-screen.tsx
@@ -19,9 +19,9 @@ import { OnboardingEvents, RegistrationPickerEvents } from '../../constants/anal
 import { useSelfClient } from '../../context';
 import { buttonTap } from '../../haptic';
 import { SdkEvents } from '../../types/events';
-import { getDocumentBadgeLabel, getDocumentPerkLabel } from './badges';
+import { getDocumentBadgeLabel } from './badges';
 import { getDocumentDisplaySubtitle, getDocumentDisplayTitle } from './documentCardCopy';
-import { getPerksForIdType } from './perks';
+import { getPerkRailContent, getPerksForIdType } from './perks';
 
 const KYC_DOC_TYPE = 'kyc';
 
@@ -63,11 +63,8 @@ type DocumentCardProps = {
 
 const DocumentCard: React.FC<DocumentCardProps> = ({ docType, countryCode, onPress }) => {
   const subtitle = getDocumentDisplaySubtitle(docType, countryCode);
-  const perks = getPerksForIdType(docType);
-  const perkLabel = getDocumentPerkLabel(docType);
-  const hasPerks = perkLabel !== null;
+  const perkRailContent = getPerkRailContent(docType);
   const useFlag = docType !== KYC_DOC_TYPE;
-  const perkLogos = perks.flatMap(p => p.renderLogos?.() ?? []);
 
   return (
     <View style={styles.cardOuter}>
@@ -87,11 +84,11 @@ const DocumentCard: React.FC<DocumentCardProps> = ({ docType, countryCode, onPre
           </RNView>
         </Pressable>
       </RNView>
-      {hasPerks && (
+      {perkRailContent && (
         <PerkRail
-          variant={perkLogos.length > 1 ? 'dense' : 'minimal'}
-          logos={perkLogos}
-          label={perkLabel ?? undefined}
+          variant={perkRailContent.logos.length > 1 ? 'dense' : 'minimal'}
+          logos={perkRailContent.logos}
+          label={perkRailContent.label}
           onPress={onPress}
         />
       )}

--- a/packages/mobile-sdk-alpha/src/flows/onboarding/perks.tsx
+++ b/packages/mobile-sdk-alpha/src/flows/onboarding/perks.tsx
@@ -44,3 +44,23 @@ export function getPerksForIdType(idType: string): Perk[] {
     .map(perk => PERKS[perk.id])
     .filter((perk): perk is Perk => Boolean(perk?.renderLogos));
 }
+
+export interface PerkRailContent {
+  perks: Perk[];
+  logos: React.ReactNode[];
+  label: string;
+}
+
+/**
+ * Shared resolver for PerkRail inputs. Returns null when the ID type has no
+ * renderable perks so callers can hide the rail. Counts *perks*, not logos —
+ * one perk with multiple brand marks (e.g. Google + USAT) is still one perk.
+ */
+export function getPerkRailContent(idType: string): PerkRailContent | null {
+  const perks = getPerksForIdType(idType);
+  if (perks.length === 0) {
+    return null;
+  }
+  const logos = perks.flatMap(perk => perk.renderLogos?.() ?? []);
+  return { perks, logos, label: getPerkRailLabel(perks) };
+}

--- a/packages/mobile-sdk-alpha/src/index.ts
+++ b/packages/mobile-sdk-alpha/src/index.ts
@@ -62,13 +62,16 @@ export type { ProvingStateType } from './proving/provingMachine';
 
 export type { RecoveryValidationResult } from './proving/recoveryValidation';
 
+export type { Perk, PerkRailContent } from './flows/onboarding/perks';
+
 export type { SDKEvent, SDKEventMap } from './types/events';
 export type { SdkErrorCategory } from './errors';
 
 export type { provingMachineCircuitType } from './proving/provingMachine';
-export { DelayedLottieView } from './components/DelayedLottieView';
 
+export { DelayedLottieView } from './components/DelayedLottieView';
 export { ExpandableBottomLayout } from './layouts/ExpandableBottomLayout';
+
 export {
   GOOGLE_USAT_FAUCET_APP_NAME,
   GOOGLE_USAT_FAUCET_ENDPOINT,
@@ -87,16 +90,14 @@ export {
   notImplemented,
   sdkError,
 } from './errors';
-
 export { default as LogoConfirmationScreen } from './flows/onboarding/logo-confirmation-screen';
 export { NFCScannerScreen } from './components/screens/NFCScannerScreen';
 export { QRCodeScreen } from './components/screens/QRCodeScreen';
 export { PERKS as SHARED_PERKS, getPerkRecordsForIdType } from './data/perks';
 export { SdkEvents } from './types/events';
-
 export { SelfClientContext, SelfClientProvider, useSelfClient } from './context';
-export { advercase, dinot, dinotBold, plexMono } from './constants/fonts';
 
+export { advercase, dinot, dinotBold, plexMono } from './constants/fonts';
 export {
   buttonTap,
   cancelTap,
@@ -165,7 +166,6 @@ export { extractNameFromMRZ, formatDateToYYMMDD, parseMRZBirthDate, parseMRZExpi
 export { finalizeRecoveredDocumentRegistration, validateRecoverySecretForDocument } from './proving/recoveryValidation';
 
 export { generateMockDocument, signatureAlgorithmToStrictSignatureAlgorithm } from './mock/generator';
-export { getEligiblePerksForIdType } from './flows/onboarding/perks';
 export { hasEligibleAlternativeDocumentForPolicy, isDocumentEligibleForPolicy } from './utils/restrictedApps';
 export { isGoogleUsatProofRequest } from './utils/googleUsat';
 

--- a/packages/mobile-sdk-alpha/src/index.ts
+++ b/packages/mobile-sdk-alpha/src/index.ts
@@ -57,12 +57,12 @@ export type { MRZScanOptions } from './mrz';
 export type { OnboardingBranch, OnboardingFailureStage, OnboardingStage } from './analytics/onboardingFunnel';
 
 export type { PassportValidationCallbacks } from './validation/document';
+export type { Perk, PerkRailContent } from './flows/onboarding/perks';
 export type { PerkId, PerkRecord } from './data/perks';
+
 export type { ProvingStateType } from './proving/provingMachine';
 
 export type { RecoveryValidationResult } from './proving/recoveryValidation';
-
-export type { Perk, PerkRailContent } from './flows/onboarding/perks';
 
 export type { SDKEvent, SDKEventMap } from './types/events';
 export type { SdkErrorCategory } from './errors';
@@ -92,6 +92,13 @@ export {
 } from './errors';
 export { default as LogoConfirmationScreen } from './flows/onboarding/logo-confirmation-screen';
 export { NFCScannerScreen } from './components/screens/NFCScannerScreen';
+export {
+  PERKS,
+  getEligiblePerksForIdType,
+  getPerkRailContent,
+  getPerkRailLabel,
+  getPerksForIdType,
+} from './flows/onboarding/perks';
 export { QRCodeScreen } from './components/screens/QRCodeScreen';
 export { PERKS as SHARED_PERKS, getPerkRecordsForIdType } from './data/perks';
 export { SdkEvents } from './types/events';

--- a/packages/mobile-sdk-alpha/tests/flows/onboarding/perks.test.ts
+++ b/packages/mobile-sdk-alpha/tests/flows/onboarding/perks.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { getPerkRailLabel, getPerksForIdType } from '../../../src/flows/onboarding/perks';
+import { getPerkRailContent, getPerkRailLabel, getPerksForIdType } from '../../../src/flows/onboarding/perks';
 
 describe('onboarding perks', () => {
   it('filters perks to entries that have renderLogos', () => {
@@ -19,5 +19,18 @@ describe('onboarding perks', () => {
     expect(getPerkRailLabel([{ id: 'google_cloud_faucet', label: 'Google Cloud Faucet', renderLogos: () => [] }])).toBe(
       'Eligible for 1 perk',
     );
+  });
+
+  it('returns null content when an id type has no renderable perks', () => {
+    expect(getPerkRailContent('unknown')).toBeNull();
+  });
+
+  it('counts perks (not logos) so multi-logo perks stay singular', () => {
+    const content = getPerkRailContent('p');
+
+    expect(content).not.toBeNull();
+    expect(content!.perks).toHaveLength(1);
+    expect(content!.logos.length).toBeGreaterThanOrEqual(2);
+    expect(content!.label).toBe('Eligible for 1 perk');
   });
 });

--- a/specs/projects/sdk/workstreams/analytics/SPEC.md
+++ b/specs/projects/sdk/workstreams/analytics/SPEC.md
@@ -54,16 +54,16 @@ Four observability layers, three in Mixpanel, one in Sentry:
 
 Every event carries `attempt_id`, `initial_branch`, `current_branch` plus the additional properties below. Implementation details (file paths, fire-site line numbers, helper code) live in the plan that introduced or modified the event — see ANA-01 for v1, ANA-11 for the post-deployment bug fixes.
 
-| Event                                    | Fires when                                                                                       | Additional properties                       |
-| ---------------------------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------- |
-| `Onboarding: Started`                    | Helper-bootstrapped when the first canonical step event reaches an attempt-less state            | — (branches `pending`)                      |
-| `Onboarding: Country Selected`           | User confirms a country                                                                          | `country_code`                              |
-| `Onboarding: Document Type Selected`     | User confirms a document type. Locks `initial_branch`.                                           | `document_type`, `country_code`             |
-| `Onboarding: Document Scan Started`      | Camera open (biometric), KYC modal launch, or Aadhaar QR picker open                             | —                                           |
-| `Onboarding: Document Scan Succeeded`    | MRZ+NFC committed, provider returns success, or upload accepted                                  | `duration_seconds`                          |
-| `Onboarding: Proof Generation Started`   | Proving machine enters `proving` with `circuitType === 'register'`                               | —                                           |
-| `Onboarding: Proof Generation Succeeded` | Proving machine reaches `completed` with `circuitType === 'register' && didNewRegistrationProof` | `duration_seconds`                          |
-| `Onboarding: Completed`                  | Same gate as PROOF_SUCCEEDED, post-proof wrap-up done                                            | `duration_seconds` (total), `used_fallback` |
+| Event                                    | Fires when                                                                                                                                                                                    | Additional properties                                                        |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `Onboarding: Started`                    | Helper-bootstrapped when the first canonical step event reaches an attempt-less state                                                                                                         | — (branches `pending`)                                                       |
+| `Onboarding: Country Selected`           | User confirms a country                                                                                                                                                                       | `country_code`                                                               |
+| `Onboarding: Document Type Selected`     | User confirms a document type. Locks `initial_branch`.                                                                                                                                        | `document_type`, `country_code`                                              |
+| `Onboarding: Document Scan Started`      | Camera open (biometric), KYC modal launch, or Aadhaar QR picker open                                                                                                                          | —                                                                            |
+| `Onboarding: Document Scan Succeeded`    | MRZ+NFC committed, provider returns success, or upload accepted                                                                                                                               | `duration_seconds`                                                           |
+| `Onboarding: Proof Generation Started`   | Proving machine enters `proving` with `circuitType === 'register'`                                                                                                                            | —                                                                            |
+| `Onboarding: Proof Generation Succeeded` | Proving machine reaches `completed` with `circuitType === 'register' && didNewRegistrationProof`                                                                                              | `duration_seconds`                                                           |
+| `Onboarding: Completed`                  | Same gate as PROOF_SUCCEEDED, post-proof wrap-up done                                                                                                                                         | `duration_seconds` (total), `used_fallback`                                  |
 | `Onboarding: Recovered`                  | Proving machine reaches `completed` via `ALREADY_REGISTERED` shortcut (user re-scanned a doc already on-chain — account recovery, not new registration). Mutually exclusive with `Completed`. | `duration_seconds` (total), `used_fallback`, `country_code`, `document_type` |
 
 Supporting events on the same stream:
@@ -117,18 +117,18 @@ The branch split tells you _what happened_ (initial intent vs final outcome) but
 
 ## Backlog
 
-| ID     | Title                                                                       | Status      | Priority | Depends on             | Plan                                                            |
-| ------ | --------------------------------------------------------------------------- | ----------- | -------- | ---------------------- | --------------------------------------------------------------- |
-| ANA-01 | Canonical onboarding funnel events + dead-zone fixes                        | **Done**    | —        | —                      | [plan](./plans/ANA-01-canonical-onboarding-funnel.md)           |
-| ANA-11 | Canonical funnel bug fixes (post-ANA-01 production findings)                | In Review   | High     | ANA-01                 | [plan](./plans/ANA-11-canonical-funnel-bug-fixes.md) — PR #2048 |
-| ANA-12 | Branch-specific funnel events (Biometric / KYC / Aadhaar)                   | Ready       | High     | ANA-01, ANA-11         | [plan](./plans/ANA-12-branch-specific-funnel-events.md)         |
-| ANA-13 | Observability migration — Mixpanel diet, Sentry breadcrumbs, Session Replay | Ready       | High     | ANA-01, ANA-11, ANA-12 | [plan](./plans/ANA-13-observability-migration.md)               |
-| ANA-14 | Suppress all analytics events from mock passport flow                       | In Progress | High     | ANA-01                 | [plan](./plans/ANA-14-suppress-mock-analytics.md)               |
+| ID     | Title                                                                         | Status      | Priority | Depends on             | Plan                                                            |
+| ------ | ----------------------------------------------------------------------------- | ----------- | -------- | ---------------------- | --------------------------------------------------------------- |
+| ANA-01 | Canonical onboarding funnel events + dead-zone fixes                          | **Done**    | —        | —                      | [plan](./plans/ANA-01-canonical-onboarding-funnel.md)           |
+| ANA-11 | Canonical funnel bug fixes (post-ANA-01 production findings)                  | In Review   | High     | ANA-01                 | [plan](./plans/ANA-11-canonical-funnel-bug-fixes.md) — PR #2048 |
+| ANA-12 | Branch-specific funnel events (Biometric / KYC / Aadhaar)                     | Ready       | High     | ANA-01, ANA-11         | [plan](./plans/ANA-12-branch-specific-funnel-events.md)         |
+| ANA-13 | Observability migration — Mixpanel diet, Sentry breadcrumbs, Session Replay   | Ready       | High     | ANA-01, ANA-11, ANA-12 | [plan](./plans/ANA-13-observability-migration.md)               |
+| ANA-14 | Suppress all analytics events from mock passport flow                         | In Progress | High     | ANA-01                 | [plan](./plans/ANA-14-suppress-mock-analytics.md)               |
 | ANA-15 | Per-attempt support reference (attempt_id footer) on onboarding error screens | Ready       | Medium   | ANA-01, ANA-13         | [plan](./plans/ANA-15-attempt-id-on-error-screens.md)           |
-| ANA-05 | Fallback decision events and fallback-offer mini-funnel                     | Ready       | Medium   | ANA-01, ANA-12         | —                                                               |
-| ANA-08 | Explicit abandonment events on app background                               | Ready       | Low      | ANA-01                 | —                                                               |
-| ANA-02 | Investigation: internal/TestFlight traffic filtering                        | Ready       | Medium   | —                      | —                                                               |
-| ANA-04 | Investigation: native NFC analytics channel                                 | Ready       | Low      | ANA-13                 | —                                                               |
+| ANA-05 | Fallback decision events and fallback-offer mini-funnel                       | Ready       | Medium   | ANA-01, ANA-12         | —                                                               |
+| ANA-08 | Explicit abandonment events on app background                                 | Ready       | Low      | ANA-01                 | —                                                               |
+| ANA-02 | Investigation: internal/TestFlight traffic filtering                          | Ready       | Medium   | —                      | —                                                               |
+| ANA-04 | Investigation: native NFC analytics channel                                   | Ready       | Low      | ANA-13                 | —                                                               |
 
 Allowed statuses: `Ready`, `In Progress`, `In Review`, `Blocked`, `Done`.
 

--- a/specs/projects/sdk/workstreams/analytics/plans/ANA-12-branch-specific-funnel-events.md
+++ b/specs/projects/sdk/workstreams/analytics/plans/ANA-12-branch-specific-funnel-events.md
@@ -117,12 +117,12 @@ Every branch event is stamped with `attempt_id` / `initial_branch` / `current_br
 
 Follows [Mixpanel's recommended convention](https://mixpanel.com/blog/community-tip-naming-conventions-to-stay-organized/): Title Case event names with past-tense verbs, snake_case properties, Object-Action structure, namespace prefix for lexicon clustering.
 
-| Pattern | Example | Notes |
-| --- | --- | --- |
-| Constant group | `BiometricEvents`, `KycEvents`, `AadhaarEvents` | Mirror the canonical `OnboardingEvents` group format. TS identifier, not the wire string — Title Case is fine even for acronyms in the constant name. |
-| Event name (wire string) | `'Biometric: MRZ Captured'` | `<Namespace>: <Noun> <PastVerb>` — Title Case, past tense, one noun, one verb. Use the domain verb when it's natural (`Captured`, `Parsed`, `Stored`, `Created`); fall back to `Started` / `Succeeded` / `Failed` / `Cancelled` when no clean domain verb exists. **Never double up**: `MRZ Started` not `MRZ Capture Started`; `MRZ Restarted` not `MRZ Capture Restarted`. The noun already implies the action. |
-| Acronyms in event names | `'KYC: Session Requested'`, `'API Called'` | Acronyms are ALL CAPS in the wire string, not Title Case. `'KYC: ...'` not `'Kyc: ...'`. Applies to the namespace prefix and to any acronym inside the event body. |
-| Mandatory properties | `attempt_id`, `initial_branch`, `current_branch` | snake_case (Mixpanel property convention). Same triple as canonical events. Stamp via a small shared helper, not hand-written per call site. |
+| Pattern                  | Example                                          | Notes                                                                                                                                                                                                                                                                                                                                                                                                             |
+| ------------------------ | ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Constant group           | `BiometricEvents`, `KycEvents`, `AadhaarEvents`  | Mirror the canonical `OnboardingEvents` group format. TS identifier, not the wire string — Title Case is fine even for acronyms in the constant name.                                                                                                                                                                                                                                                             |
+| Event name (wire string) | `'Biometric: MRZ Captured'`                      | `<Namespace>: <Noun> <PastVerb>` — Title Case, past tense, one noun, one verb. Use the domain verb when it's natural (`Captured`, `Parsed`, `Stored`, `Created`); fall back to `Started` / `Succeeded` / `Failed` / `Cancelled` when no clean domain verb exists. **Never double up**: `MRZ Started` not `MRZ Capture Started`; `MRZ Restarted` not `MRZ Capture Restarted`. The noun already implies the action. |
+| Acronyms in event names  | `'KYC: Session Requested'`, `'API Called'`       | Acronyms are ALL CAPS in the wire string, not Title Case. `'KYC: ...'` not `'Kyc: ...'`. Applies to the namespace prefix and to any acronym inside the event body.                                                                                                                                                                                                                                                |
+| Mandatory properties     | `attempt_id`, `initial_branch`, `current_branch` | snake_case (Mixpanel property convention). Same triple as canonical events. Stamp via a small shared helper, not hand-written per call site.                                                                                                                                                                                                                                                                      |
 
 ### Event helper
 
@@ -146,14 +146,14 @@ If a new event would help product but requires a forbidden field, the answer is 
 
 ### Biometric (passport + biometric ID)
 
-| Constant | Event name | Fire site | Additional properties |
-| --- | --- | --- | --- |
-| `BiometricEvents.MRZ_STARTED` | `Biometric: MRZ Started` | `app/src/screens/documents/scanning/DocumentCameraScreen.tsx` on camera mount | `document_type` |
-| `BiometricEvents.MRZ_CAPTURED` | `Biometric: MRZ Captured` | `useReadMRZ` success callback, when the camera returns a parseable MRZ. The MRZ contents themselves are NEVER fired — `document_type` is the document category enum, `duration_seconds` is wall-clock from camera mount. | `document_type`, `duration_seconds` |
-| `BiometricEvents.NFC_STARTED` | `Biometric: NFC Started` | `DocumentNFCScanScreen.tsx` on NFC begin | `document_type`, `nfc_method` (`'BAC' \| 'PACE'`) |
-| `BiometricEvents.NFC_SUCCEEDED` | `Biometric: NFC Succeeded` | Same screen on chip read complete | `document_type`, `duration_seconds` |
-| `BiometricEvents.DOCUMENT_PARSED` | `Biometric: Document Parsed` | `provingMachine.ts` `validating_document` state on successful parse | `document_type`, `country_code`, `signature_algorithm`, `csca_hash_algorithm` |
-| `BiometricEvents.DOCUMENT_UNSUPPORTED` | `Biometric: Document Unsupported` | `provingMachine.ts` when `checkDocumentSupported` returns non-supported | `document_type`, `country_code`, `signature_algorithm`, `unsupported_reason` (`'unknown_dsc' \| 'unsupported_algo' \| 'country_not_in_list'`) |
+| Constant                               | Event name                        | Fire site                                                                                                                                                                                                                | Additional properties                                                                                                                         |
+| -------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `BiometricEvents.MRZ_STARTED`          | `Biometric: MRZ Started`          | `app/src/screens/documents/scanning/DocumentCameraScreen.tsx` on camera mount                                                                                                                                            | `document_type`                                                                                                                               |
+| `BiometricEvents.MRZ_CAPTURED`         | `Biometric: MRZ Captured`         | `useReadMRZ` success callback, when the camera returns a parseable MRZ. The MRZ contents themselves are NEVER fired — `document_type` is the document category enum, `duration_seconds` is wall-clock from camera mount. | `document_type`, `duration_seconds`                                                                                                           |
+| `BiometricEvents.NFC_STARTED`          | `Biometric: NFC Started`          | `DocumentNFCScanScreen.tsx` on NFC begin                                                                                                                                                                                 | `document_type`, `nfc_method` (`'BAC' \| 'PACE'`)                                                                                             |
+| `BiometricEvents.NFC_SUCCEEDED`        | `Biometric: NFC Succeeded`        | Same screen on chip read complete                                                                                                                                                                                        | `document_type`, `duration_seconds`                                                                                                           |
+| `BiometricEvents.DOCUMENT_PARSED`      | `Biometric: Document Parsed`      | `provingMachine.ts` `validating_document` state on successful parse                                                                                                                                                      | `document_type`, `country_code`, `signature_algorithm`, `csca_hash_algorithm`                                                                 |
+| `BiometricEvents.DOCUMENT_UNSUPPORTED` | `Biometric: Document Unsupported` | `provingMachine.ts` when `checkDocumentSupported` returns non-supported                                                                                                                                                  | `document_type`, `country_code`, `signature_algorithm`, `unsupported_reason` (`'unknown_dsc' \| 'unsupported_algo' \| 'country_not_in_list'`) |
 
 The signature-algorithm and country properties on `DOCUMENT_PARSED` and `DOCUMENT_UNSUPPORTED` are the actual product-prioritization signal — the dashboard query "top 10 (country, sig_algo) combinations failing the support check" tells the team which DSCs to add next.
 
@@ -161,12 +161,12 @@ The signature-algorithm and country properties on `DOCUMENT_PARSED` and `DOCUMEN
 
 The `document_type` property name is the same on all six biometric events, but the underlying source differs by event — by design. Each source answers a different question, and collapsing them would erase information.
 
-| Event | `document_type` source | Question it answers |
-| --- | --- | --- |
-| `MRZ_STARTED` | User's IDPicker selection (`selectedDocumentType` → `resolveOnboardingBranch`) | **Intent** — what did the user say they had? |
-| `MRZ_CAPTURED` | First character of the OCR'd MRZ (line 1 of the document itself) | **Ground truth** — what does the physical document say it is? |
-| `NFC_STARTED` / `NFC_SUCCEEDED` | MRZ store, normalized after parse | **Pipeline state at NFC time** |
-| `DOCUMENT_PARSED` / `DOCUMENT_UNSUPPORTED` | `passportData.documentCategory` from the proving machine after full parse | **Confirmed state post-validation** |
+| Event                                      | `document_type` source                                                         | Question it answers                                           |
+| ------------------------------------------ | ------------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| `MRZ_STARTED`                              | User's IDPicker selection (`selectedDocumentType` → `resolveOnboardingBranch`) | **Intent** — what did the user say they had?                  |
+| `MRZ_CAPTURED`                             | First character of the OCR'd MRZ (line 1 of the document itself)               | **Ground truth** — what does the physical document say it is? |
+| `NFC_STARTED` / `NFC_SUCCEEDED`            | MRZ store, normalized after parse                                              | **Pipeline state at NFC time**                                |
+| `DOCUMENT_PARSED` / `DOCUMENT_UNSUPPORTED` | `passportData.documentCategory` from the proving machine after full parse      | **Confirmed state post-validation**                           |
 
 The disagreements across these sources are signal, not noise:
 
@@ -178,13 +178,13 @@ Dashboards must be deliberate about which source they query. For "what types of 
 
 ### KYC
 
-| Constant | Event name | Fire site | Additional properties |
-| --- | --- | --- | --- |
-| `KycEvents.SESSION_REQUESTED` | `KYC: Session Requested` | `app/src/hooks/useKycLauncher.ts` immediately before `createKycSession` | `provider` (provider id string) |
-| `KycEvents.SESSION_CREATED` | `KYC: Session Created` | Same hook, after `createKycSession` resolves | `provider`, `duration_seconds` |
-| `KycEvents.PROVIDER_OPENED` | `KYC: Provider Opened` | Immediately before `startKycVerification` | `provider` |
-| `KycEvents.PROVIDER_CLOSED` | `KYC: Provider Closed` | Same hook, single event for all three provider terminal `type`s | `provider`, `outcome` (`'completed' \| 'cancelled' \| 'failed'`), `error_code` (when `outcome === 'failed'`), `duration_seconds` |
-| `KycEvents.RETRY_TRIGGERED` | `KYC: Retry Triggered` | `KycFailureScreen.tsx` retry button | `provider`, `attempt_count` (sourced from `incrementAttemptRetryCount('kyc')` — counter lives on the funnel attempt, NOT a `useRef` on the screen, since the screen unmounts on navigation) |
+| Constant                      | Event name               | Fire site                                                               | Additional properties                                                                                                                                                                       |
+| ----------------------------- | ------------------------ | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `KycEvents.SESSION_REQUESTED` | `KYC: Session Requested` | `app/src/hooks/useKycLauncher.ts` immediately before `createKycSession` | `provider` (provider id string)                                                                                                                                                             |
+| `KycEvents.SESSION_CREATED`   | `KYC: Session Created`   | Same hook, after `createKycSession` resolves                            | `provider`, `duration_seconds`                                                                                                                                                              |
+| `KycEvents.PROVIDER_OPENED`   | `KYC: Provider Opened`   | Immediately before `startKycVerification`                               | `provider`                                                                                                                                                                                  |
+| `KycEvents.PROVIDER_CLOSED`   | `KYC: Provider Closed`   | Same hook, single event for all three provider terminal `type`s         | `provider`, `outcome` (`'completed' \| 'cancelled' \| 'failed'`), `error_code` (when `outcome === 'failed'`), `duration_seconds`                                                            |
+| `KycEvents.RETRY_TRIGGERED`   | `KYC: Retry Triggered`   | `KycFailureScreen.tsx` retry button                                     | `provider`, `attempt_count` (sourced from `incrementAttemptRetryCount('kyc')` — counter lives on the funnel attempt, NOT a `useRef` on the screen, since the screen unmounts on navigation) |
 
 `provider` is stamped from day one with the configured KYC provider id so we can A/B different providers later without renaming events.
 
@@ -192,15 +192,15 @@ Dashboards must be deliberate about which source they query. For "what types of 
 
 Curate the existing 25-event `AadhaarEvents` group down to 7. **Delete the rest** from Mixpanel emission (their useful counterparts move to Sentry breadcrumbs in ANA-13).
 
-| Constant | Event name | Fire site | Additional properties |
-| --- | --- | --- | --- |
-| `AadhaarEvents.UPLOAD_STARTED` | `Aadhaar: Upload Started` | `app/src/screens/documents/aadhaar/AadhaarUploadScreen.tsx` on photo library tap | — |
-| `AadhaarEvents.PHOTO_PERMISSION_DENIED` | `Aadhaar: Photo Permission Denied` | Same screen when permission denied | — |
-| `AadhaarEvents.QR_SELECTED` | `Aadhaar: QR Selected` | After photo picker returns image | — |
-| `AadhaarEvents.QR_PARSE_FAILED` | `Aadhaar: QR Parse Failed` | Replace `QR_CODE_PARSE_FAILED` + `QR_CODE_INVALID_FORMAT` + `QR_CODE_MISSING_FIELDS` | `reason` (`'parse_error' \| 'invalid_format' \| 'missing_fields'`) |
-| `AadhaarEvents.TIMESTAMP_EXPIRED` | `Aadhaar: Timestamp Expired` | Replace `TIMESTAMP_VALIDATION_FAILED` | `qr_age_days` |
-| `AadhaarEvents.DATA_STORED` | `Aadhaar: Data Stored` | After successful storage | `duration_seconds` |
-| `AadhaarEvents.CONTINUE_PRESSED` | `Aadhaar: Continue Pressed` | `AadhaarUploadedSuccessScreen.tsx` continue button | — |
+| Constant                                | Event name                         | Fire site                                                                            | Additional properties                                              |
+| --------------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------ |
+| `AadhaarEvents.UPLOAD_STARTED`          | `Aadhaar: Upload Started`          | `app/src/screens/documents/aadhaar/AadhaarUploadScreen.tsx` on photo library tap     | —                                                                  |
+| `AadhaarEvents.PHOTO_PERMISSION_DENIED` | `Aadhaar: Photo Permission Denied` | Same screen when permission denied                                                   | —                                                                  |
+| `AadhaarEvents.QR_SELECTED`             | `Aadhaar: QR Selected`             | After photo picker returns image                                                     | —                                                                  |
+| `AadhaarEvents.QR_PARSE_FAILED`         | `Aadhaar: QR Parse Failed`         | Replace `QR_CODE_PARSE_FAILED` + `QR_CODE_INVALID_FORMAT` + `QR_CODE_MISSING_FIELDS` | `reason` (`'parse_error' \| 'invalid_format' \| 'missing_fields'`) |
+| `AadhaarEvents.TIMESTAMP_EXPIRED`       | `Aadhaar: Timestamp Expired`       | Replace `TIMESTAMP_VALIDATION_FAILED`                                                | `qr_age_days`                                                      |
+| `AadhaarEvents.DATA_STORED`             | `Aadhaar: Data Stored`             | After successful storage                                                             | `duration_seconds`                                                 |
+| `AadhaarEvents.CONTINUE_PRESSED`        | `Aadhaar: Continue Pressed`        | `AadhaarUploadedSuccessScreen.tsx` continue button                                   | —                                                                  |
 
 Events to **delete from Mixpanel emission** in this PR: `UPLOAD_SCREEN_OPENED`, `UPLOAD_BUTTON_ENABLED`, `UPLOAD_BUTTON_DISABLED`, `PHOTO_LIBRARY_UNAVAILABLE`, `PROCESSING_STARTED`, `QR_DATA_EXTRACTION_STARTED`, `QR_DATA_EXTRACTION_SUCCESS`, `TIMESTAMP_VALIDATION_STARTED`, `TIMESTAMP_VALIDATION_SUCCESS`, `DATA_STORAGE_STARTED`, `DATA_STORAGE_SUCCESS`, `QR_UPLOAD_REQUESTED`, `QR_UPLOAD_SUCCESS`, `QR_UPLOAD_FAILED`, `ERROR_SCREEN_NAVIGATED`, `RETRY_BUTTON_PRESSED`, `PERMISSION_MODAL_OPENED`, `PERMISSION_MODAL_DISMISSED`, `PERMISSION_SETTINGS_OPENED`, `HELP_BUTTON_PRESSED`, `USER_CANCELLED_SELECTION`, `QR_CODE_PARSE_FAILED`, `QR_CODE_INVALID_FORMAT`, `QR_CODE_MISSING_FIELDS`, `TIMESTAMP_VALIDATION_FAILED`. Their constants stay in `analytics.ts` only if ANA-13 needs them as breadcrumb categories; otherwise delete the constants too.
 
@@ -260,11 +260,11 @@ flowchart TD
     class Start,Pick,Logo,Bio entry
 ```
 
-| Path | Trigger | File | Emits |
-| --- | --- | --- | --- |
-| A | Biometric fallback (NFC/MRZ failure, unsupported device) | `app/src/hooks/useKycLauncher.ts` | `SCAN_STARTED` + 5 KYC events |
-| B | User says "no chip" on `LogoConfirmation` | `app/src/screens/documents/selection/LogoConfirmationScreen.tsx` | `SCAN_STARTED` + 5 KYC events |
-| C | User picks `kyc` directly from IDPicker | `app/src/providers/selfClientProvider.tsx` (`DOCUMENT_TYPE_SELECTED` listener, `case 'kyc'`) | `SCAN_STARTED` + 5 KYC events |
+| Path | Trigger                                                  | File                                                                                         | Emits                         |
+| ---- | -------------------------------------------------------- | -------------------------------------------------------------------------------------------- | ----------------------------- |
+| A    | Biometric fallback (NFC/MRZ failure, unsupported device) | `app/src/hooks/useKycLauncher.ts`                                                            | `SCAN_STARTED` + 5 KYC events |
+| B    | User says "no chip" on `LogoConfirmation`                | `app/src/screens/documents/selection/LogoConfirmationScreen.tsx`                             | `SCAN_STARTED` + 5 KYC events |
+| C    | User picks `kyc` directly from IDPicker                  | `app/src/providers/selfClientProvider.tsx` (`DOCUMENT_TYPE_SELECTED` listener, `case 'kyc'`) | `SCAN_STARTED` + 5 KYC events |
 
 Wire the emissions in each:
 
@@ -326,13 +326,13 @@ After events are live in production for 24 hours and verified in the dev Mixpane
 - **Biometric Funnel**: canonical funnel filtered to `initial_branch in (biometric_passport, biometric_id)`, plus a sequential funnel of `Biometric: MRZ Started → Biometric: MRZ Captured → Biometric: NFC Started → Biometric: NFC Succeeded → Biometric: Document Parsed`. Side panel: top 10 `(country_code, signature_algorithm)` combinations from `Biometric: Document Unsupported`.
 - **KYC Funnel**: canonical funnel filtered to `initial_branch = 'kyc'`, plus a sequential funnel of `KYC: Session Requested → KYC: Session Created → KYC: Provider Opened → KYC: Provider Closed (outcome=completed)`. Side panel: outcome breakdown of `KYC: Provider Closed`. Note: query both `initial_branch = 'kyc'` AND `current_branch = 'kyc'` to capture all three KYC entry paths (pure-KYC + biometric→KYC fallback via either `LogoConfirmationScreen` or `useKycLauncher`).
 - **Aadhaar Funnel**: canonical funnel filtered to `initial_branch = 'aadhaar'`, plus the 7-step Aadhaar drilldown.
-- **Document Type Mismatch** (new signal): count of attempts where `MRZ_STARTED.document_type ≠ MRZ_CAPTURED.document_type` for the same `attempt_id`. Reflects users who tapped the wrong document type in the IDPicker — UX-confusion signal. Break down by `(intended, scanned)` pair (e.g. *"intended: passport, scanned: id_card: 142 attempts"*) to see which direction the confusion runs. If one direction dominates, the IDPicker copy or iconography likely needs work.
+- **Document Type Mismatch** (new signal): count of attempts where `MRZ_STARTED.document_type ≠ MRZ_CAPTURED.document_type` for the same `attempt_id`. Reflects users who tapped the wrong document type in the IDPicker — UX-confusion signal. Break down by `(intended, scanned)` pair (e.g. _"intended: passport, scanned: id_card: 142 attempts"_) to see which direction the confusion runs. If one direction dominates, the IDPicker copy or iconography likely needs work.
 - **Account Recovery** (new signal): users who re-scan a document already registered on-chain emit `Onboarding: Recovered` instead of `Onboarding: Completed`. Show three metrics:
-    - **Recovery rate**: `count(Recovered) / (count(Recovered) + count(Completed))` over time. Rising = either healthy returning-user re-engagement or a UX bug where users repeatedly try to "re-register." Segment by `initial_branch` to see if one path produces more recoveries than another.
-    - **Recovery latency**: `Onboarding: Recovered.duration_seconds`, P50/P95. If the median is the same as new-registration latency, the app is making recovering users do unnecessary work — the existing-identity check should run on launch, not after a full scan.
-    - **Conversion adjustment**: the top-line "Started → Completed" funnel currently undercounts success by treating recoveries as silent drop-off. The correct conversion metric is `(Completed + Recovered) / Started`. Surface both numbers side-by-side; the gap is the recovery cohort the old funnel was hiding.
+  - **Recovery rate**: `count(Recovered) / (count(Recovered) + count(Completed))` over time. Rising = either healthy returning-user re-engagement or a UX bug where users repeatedly try to "re-register." Segment by `initial_branch` to see if one path produces more recoveries than another.
+  - **Recovery latency**: `Onboarding: Recovered.duration_seconds`, P50/P95. If the median is the same as new-registration latency, the app is making recovering users do unnecessary work — the existing-identity check should run on launch, not after a full scan.
+  - **Conversion adjustment**: the top-line "Started → Completed" funnel currently undercounts success by treating recoveries as silent drop-off. The correct conversion metric is `(Completed + Recovered) / Started`. Surface both numbers side-by-side; the gap is the recovery cohort the old funnel was hiding.
 
-Dashboard build is *part* of this PR (docs + screenshots). The dashboards themselves are constructed in the dev Mixpanel project and migrated to prod with the merge.
+Dashboard build is _part_ of this PR (docs + screenshots). The dashboards themselves are constructed in the dev Mixpanel project and migrated to prod with the merge.
 
 ## Validation
 

--- a/specs/projects/sdk/workstreams/analytics/plans/ANA-13-observability-migration.md
+++ b/specs/projects/sdk/workstreams/analytics/plans/ANA-13-observability-migration.md
@@ -77,17 +77,17 @@ Events that are neither funnel inputs nor useful debugging context. Per-mock-par
 
 Add the following Sentry tags via the existing whitelist (`app/src/config/sentry.ts:28-40`). They power "filter all sessions by German passport with RSA-PSS algo" queries:
 
-| Tag                   | Set when                                       | Cleared when            | Source                                     |
-| --------------------- | ---------------------------------------------- | ----------------------- | ------------------------------------------ |
-| `attempt_id`          | Onboarding attempt starts (in `ensureAttempt`) | Attempt completes / fails / recovers | `currentAttempt.id`                        |
-| `initial_branch`      | Locked at `DOCUMENT_TYPE_SELECTED`             | Attempt ends (completes / fails / recovers)            | `currentAttempt.initialBranch`             |
-| `current_branch`      | Updated on every branch change                 | Attempt ends (completes / fails / recovers)            | `currentAttempt.currentBranch`             |
-| `document_country`    | After country-picker confirm                   | Attempt ends (completes / fails / recovers)            | `country_code`                             |
-| `document_type`       | After ID-selection confirm                     | Attempt ends (completes / fails / recovers)            | Already whitelisted                        |
-| `signature_algorithm` | After `passport_parsed` (biometric only)       | Attempt ends (completes / fails / recovers)            | From `passportData.dg1_hash_function` etc. |
-| `csca_hash_algorithm` | Same                                           | Attempt ends (completes / fails / recovers)            | From `passportData.csca_hash_function`     |
-| `kyc_provider`        | At KYC session start                           | Attempt ends (completes / fails / recovers)            | configured provider id                     |
-| `app_build_channel`   | App startup                                    | Never (super-tag)       | Out of scope here — flagged for ANA-02     |
+| Tag                   | Set when                                       | Cleared when                                | Source                                     |
+| --------------------- | ---------------------------------------------- | ------------------------------------------- | ------------------------------------------ |
+| `attempt_id`          | Onboarding attempt starts (in `ensureAttempt`) | Attempt completes / fails / recovers        | `currentAttempt.id`                        |
+| `initial_branch`      | Locked at `DOCUMENT_TYPE_SELECTED`             | Attempt ends (completes / fails / recovers) | `currentAttempt.initialBranch`             |
+| `current_branch`      | Updated on every branch change                 | Attempt ends (completes / fails / recovers) | `currentAttempt.currentBranch`             |
+| `document_country`    | After country-picker confirm                   | Attempt ends (completes / fails / recovers) | `country_code`                             |
+| `document_type`       | After ID-selection confirm                     | Attempt ends (completes / fails / recovers) | Already whitelisted                        |
+| `signature_algorithm` | After `passport_parsed` (biometric only)       | Attempt ends (completes / fails / recovers) | From `passportData.dg1_hash_function` etc. |
+| `csca_hash_algorithm` | Same                                           | Attempt ends (completes / fails / recovers) | From `passportData.csca_hash_function`     |
+| `kyc_provider`        | At KYC session start                           | Attempt ends (completes / fails / recovers) | configured provider id                     |
+| `app_build_channel`   | App startup                                    | Never (super-tag)                           | Out of scope here — flagged for ANA-02     |
 
 All tags are session-scoped via `Sentry.setTag` inside a scope. Tag setting is centralized in a new `app/src/observability/onboardingContext.ts` module (or extension to `app/src/config/sentry.ts`); call sites do not call `Sentry.setTag` directly.
 

--- a/specs/projects/sdk/workstreams/analytics/plans/ANA-15-attempt-id-on-error-screens.md
+++ b/specs/projects/sdk/workstreams/analytics/plans/ANA-15-attempt-id-on-error-screens.md
@@ -11,9 +11,9 @@
 
 ANA-13 stamps `attempt_id` on every Sentry event captured during an active onboarding attempt. Support can already find a user's events in Sentry by `attempt_id:<uuid>` — but only if the user can tell support which `attempt_id` to search for.
 
-Today the `attempt_id` is invisible to the user. When someone files a support ticket with *"I got stuck during scanning"*, support has to guess which Sentry event corresponds to that user, often by timestamp + country, which is noisy and fragile.
+Today the `attempt_id` is invisible to the user. When someone files a support ticket with _"I got stuck during scanning"_, support has to guess which Sentry event corresponds to that user, often by timestamp + country, which is noisy and fragile.
 
-A persistent `support_uuid` (set as Sentry `user.id`) is the right cross-session identity and should be exposed in Settings — that's a separate, larger workstream. This spec is the **in-flow** counterpart: surface the `attempt_id` of the *currently active* onboarding attempt on the screens where a user is most likely to stop and ask for help.
+A persistent `support_uuid` (set as Sentry `user.id`) is the right cross-session identity and should be exposed in Settings — that's a separate, larger workstream. This spec is the **in-flow** counterpart: surface the `attempt_id` of the _currently active_ onboarding attempt on the screens where a user is most likely to stop and ask for help.
 
 ## Decision
 


### PR DESCRIPTION
## Summary

- Adds a white perks footer to the homescreen ID card showing the dense `PerkRail` from `@selfxyz/mobile-sdk-alpha` for selected, hidden, non-mock, non-KYC, non-inactive cards.
- Wires three Mixpanel events (`Homescreen: ID Card Viewed`, `Homescreen: ID Card Perk Tapped`, `Homescreen: ID Card Perk Outlink Open Failed`) — viewed re-fires on document swap, tap opens the perk outlink via `Linking.openURL`.
- Adds `showPerks` opt-out so `IdDetailsScreen` (which renders its own `EligiblePerksCard`) doesn't duplicate the surface.
- Extracts `idTypeForDocumentCategory` into a shared util reused by both `IdCard` and `IdDetailsScreen`.

## Changes

### React Native app

- `IdCard.tsx`: restructured the outer wrapper into a shadow/rounded shell + dark header/body + optional white perks footer. Added perk data lookup, document-aware `viewedDocumentKeyRef` so passport-to-passport swaps re-emit the view event, and Mixpanel-firing tap handler (with outlink failure path).
- `IdDetailsScreen.tsx`: passes `showPerks={false}` to `IdCardLayout` and dropped its local `idTypeForDocumentCategory` in favor of the shared util.
- New `app/src/utils/idType.ts` for the shared ID-type helper.

### SDK core

- `packages/mobile-sdk-alpha/src/constants/analytics.ts`: added `HomescreenEvents` (`ID_CARD_VIEWED`, `ID_CARD_PERK_TAPPED`, `ID_CARD_PERK_OUTLINK_OPEN_FAILED`) and included it in the `KnownEventName` union so `trackEvent` accepts them under the ANA-13 cap.

### Tests

- New `app/tests/src/components/homescreen/IdCard.test.tsx` covers footer render conditions (selected/hidden/non-mock/non-KYC/non-inactive), one-time view firing, document-swap re-firing, tap outlink success + failure, and `showPerks={false}` suppression.
- `IdDetailsScreen.test.tsx`: asserts `IdCardLayout` receives `showPerks={false}` while `EligiblePerksCard` still renders exactly once.

## Linear Issues

- Closes [SELF-2858](https://linear.app/selfprotocol/issue/SELF-2858/homescreen-id-card-eng-perks-indicator) — Homescreen ID Card (eng): perks indicator

## Figma

- [Homescreen ID card with perks rail (Self Mobile App, node 26166:25820)](https://www.figma.com/design/vDzdyqR61HBGd16uYHq8Y1/Self-Mobile-App?node-id=26166-25820&m=dev)

## Test Plan

- [ ] `yarn lint && yarn types` passes (app + mobile-sdk-alpha)
- [ ] `yarn workspace @selfxyz/mobile-app jest:run tests/src/components/homescreen/IdCard.test.tsx tests/src/screens/documents/management/IdDetailsScreen.test.tsx` passes (21/21)
- [ ] Manual: verify the perks footer renders on a real verified passport/ID/Aadhaar on the homescreen, taps open the Google Cloud Faucet outlink, and the same surface is suppressed on the ID details screen and on mock/KYC/inactive/expired cards.

### Native Consolidation Checklist

- [ ] CONTRACTS.md reviewed - no unintended contract changes
- [ ] Layer 1 bridge contract tests pass (`cd app && yarn jest:run` / `yarn workspace @selfxyz/rn-sdk-test-app test`)
- [ ] Layer 3 builds pass (app iOS, RN test app iOS, RN test app Android)
- [ ] Layer 4 manual smoke test signed off (if consolidation PR)
- [ ] No new native business logic added (logic belongs in TypeScript)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ID cards and ID-selection screens now display a perks rail with available offers; perks can be suppressed where needed.

* **Analytics**
  * ID card views are tracked once per document and perk interactions (including failed external opens) are recorded.

* **Tests**
  * Expanded test coverage for perks rendering, tap behavior, external opens, and analytics events.

* **Documentation**
  * Analytics and observability spec markdown updated for clarity and formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/selfxyz/self/pull/2095?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->