### PR TITLE
fix proof request perk logos and ineligible-document UX

### DIFF
--- a/app/src/components/documents/IDSelectorSheet.tsx
+++ b/app/src/components/documents/IDSelectorSheet.tsx
@@ -194,13 +194,15 @@ export const IDSelectorSheet: React.FC<IDSelectorSheetProps> = ({
                       : doc.state;
 
                   const isActive = itemState === 'active';
-                  const activePerks = isActive
+                  const eligibleForPerks =
+                    !isDisabledState(doc.state) && !ineligible;
+                  const docPerks = eligibleForPerks
                     ? perksByDocumentId?.[doc.id]
                     : undefined;
                   const perkSlot =
-                    activePerks && activePerks.length > 0 ? (
+                    docPerks && docPerks.length > 0 ? (
                       <PerkEligibilityRow
-                        perks={activePerks}
+                        perks={docPerks}
                         variant="inline"
                         testID={`${testID}-item-${doc.id}-perks`}
                       />
@@ -221,7 +223,7 @@ export const IDSelectorSheet: React.FC<IDSelectorSheetProps> = ({
                     />
                   );
 
-                  const hasPerks = isActive && !!perkSlot;
+                  const hasPerks = !!perkSlot;
                   return (
                     <View
                       key={doc.id}

--- a/app/src/components/documents/IDSelectorSheet.tsx
+++ b/app/src/components/documents/IDSelectorSheet.tsx
@@ -224,13 +224,14 @@ export const IDSelectorSheet: React.FC<IDSelectorSheetProps> = ({
                   );
 
                   const hasPerks = !!perkSlot;
+                  const framed = isActive || hasPerks;
                   return (
                     <View
                       key={doc.id}
                       backgroundColor={isActive ? slate100 : 'transparent'}
                       borderRadius={10}
                       borderWidth={1}
-                      borderColor={isActive ? slate200 : 'transparent'}
+                      borderColor={framed ? slate200 : 'transparent'}
                       overflow="hidden"
                       testID={
                         isActive
@@ -244,7 +245,7 @@ export const IDSelectorSheet: React.FC<IDSelectorSheetProps> = ({
                         borderWidth={2}
                         borderColor={isActive ? blue600 : 'transparent'}
                         overflow="hidden"
-                        style={isActive ? styles.activeCardShadow : undefined}
+                        style={framed ? styles.activeCardShadow : undefined}
                       >
                         {item}
                       </View>

--- a/app/src/components/documents/IDSelectorSheet.tsx
+++ b/app/src/components/documents/IDSelectorSheet.tsx
@@ -215,6 +215,7 @@ export const IDSelectorSheet: React.FC<IDSelectorSheetProps> = ({
                       ineligible={ineligible}
                       onPress={() => handleSelect(doc.id)}
                       onIneligiblePress={() => handleIneligiblePress(doc.id)}
+                      perkSlot={perkSlot}
                       nationalityCode={doc.nationalityCode}
                       isMock={doc.isMock}
                       securityLabel={doc.securityLabel}
@@ -249,7 +250,6 @@ export const IDSelectorSheet: React.FC<IDSelectorSheetProps> = ({
                       >
                         {item}
                       </View>
-                      {hasPerks ? perkSlot : null}
                     </View>
                   );
                 })}

--- a/app/src/components/proof-request/BottomActionBar.tsx
+++ b/app/src/components/proof-request/BottomActionBar.tsx
@@ -2,13 +2,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
-import React, { useMemo } from 'react';
-import {
-  ActivityIndicator,
-  Dimensions,
-  Pressable,
-  StyleSheet,
-} from 'react-native';
+import React from 'react';
+import { ActivityIndicator, Pressable, StyleSheet } from 'react-native';
 import { Text, View, XStack, YStack } from 'tamagui';
 
 import { slate500 as trueSlate500 } from '@selfxyz/mobile-sdk-alpha/constants/colors';
@@ -65,21 +60,11 @@ export const BottomActionBar: React.FC<BottomActionBarProps> = ({
   testID = 'bottom-action-bar',
 }) => {
   const hasPerks = !!perks && perks.length > 0;
-  const topPadding = 8;
+  const topPadding = 4;
 
-  const { height: screenHeight } = Dimensions.get('window');
-  const basePadding = 12;
+  const basePadding = 4;
   const safeAreaPadding = useSafeBottomPadding(basePadding);
-
-  const dynamicPadding = useMemo(() => {
-    const heightMultiplier = Math.max(0, (screenHeight - 800) * 0.12);
-    return Math.round(safeAreaPadding + heightMultiplier);
-  }, [screenHeight, safeAreaPadding]);
-
-  // Selector chrome: pill (rounded-60) when no perks; rounded-16 card when a
-  // perk rail is attached underneath (so the joined element reads as one card).
-  const selectorRadius = hasPerks ? 16 : 60;
-  const wrapperRadius = selectorRadius;
+  const dynamicPadding = safeAreaPadding;
 
   return (
     <View
@@ -90,111 +75,130 @@ export const BottomActionBar: React.FC<BottomActionBarProps> = ({
       testID={testID}
     >
       <YStack gap={10}>
-        {/* Document selector + optional perk rail (one visual card) */}
-        <View
-          borderWidth={1}
-          borderColor={proofRequestColors.slate300}
-          borderRadius={wrapperRadius}
-          overflow="hidden"
-          backgroundColor={proofRequestColors.white}
-          style={styles.selectorShadow}
-        >
-          <Pressable
-            onPress={onDocumentSelectorPress}
-            style={({ pressed }) => [
-              styles.selectorPressable,
-              pressed && styles.selectorPressed,
-            ]}
-            testID={`${testID}-document-selector`}
+        <YStack>
+          {/* Document selector — always a rounded-60 pill per Figma 26164:20557 */}
+          <View
+            borderWidth={1}
+            borderColor={proofRequestColors.slate300}
+            borderRadius={60}
+            overflow="hidden"
+            backgroundColor={proofRequestColors.white}
+            zIndex={1}
+            style={styles.selectorShadow}
           >
-            <XStack
-              alignItems="center"
-              gap={10}
-              paddingLeft={8}
-              paddingRight={14}
-              paddingVertical={8}
+            <Pressable
+              onPress={onDocumentSelectorPress}
+              style={({ pressed }) => [
+                styles.selectorPressable,
+                pressed && styles.selectorPressed,
+              ]}
+              testID={`${testID}-document-selector`}
             >
-              <DocumentIdentityIcon
-                nationalityCode={selectedDocumentNationalityCode}
-                isMock={selectedDocumentIsMock}
-                size={ICON_SIZE}
-              />
+              <XStack
+                alignItems="center"
+                gap={10}
+                paddingLeft={8}
+                paddingRight={14}
+                paddingVertical={8}
+              >
+                <DocumentIdentityIcon
+                  nationalityCode={selectedDocumentNationalityCode}
+                  isMock={selectedDocumentIsMock}
+                  size={ICON_SIZE}
+                />
 
-              {/* Name + HI-SECURITY label */}
-              <YStack flex={1}>
-                <Text
-                  fontFamily={dinot}
-                  fontSize={14}
-                  fontWeight="500"
-                  color={proofRequestColors.slate900}
-                  numberOfLines={1}
-                  allowFontScaling={false}
-                  testID={`${testID}-document-selector-name`}
-                >
-                  {selectedDocumentName}
-                </Text>
-                {ineligible ? (
-                  <View
-                    alignSelf="flex-start"
-                    backgroundColor={INELIGIBLE_BG}
-                    borderColor={INELIGIBLE_BORDER}
-                    borderWidth={1}
-                    borderRadius={4}
-                    paddingHorizontal={6}
-                    paddingVertical={1}
-                    marginTop={2}
-                    testID={`${testID}-document-selector-ineligible`}
+                {/* Name + HI-SECURITY label */}
+                <YStack flex={1}>
+                  <Text
+                    fontFamily={dinot}
+                    fontSize={14}
+                    fontWeight="500"
+                    color={proofRequestColors.slate900}
+                    numberOfLines={1}
+                    allowFontScaling={false}
+                    testID={`${testID}-document-selector-name`}
                   >
+                    {selectedDocumentName}
+                  </Text>
+                  {ineligible ? (
+                    <View
+                      alignSelf="flex-start"
+                      backgroundColor={INELIGIBLE_BG}
+                      borderColor={INELIGIBLE_BORDER}
+                      borderWidth={1}
+                      borderRadius={4}
+                      paddingHorizontal={6}
+                      paddingVertical={1}
+                      marginTop={2}
+                      testID={`${testID}-document-selector-ineligible`}
+                    >
+                      <Text
+                        fontFamily={dinot}
+                        fontSize={10}
+                        fontWeight="500"
+                        color={INELIGIBLE_FG}
+                        letterSpacing={0.6}
+                        textTransform="uppercase"
+                        allowFontScaling={false}
+                      >
+                        Ineligible
+                      </Text>
+                    </View>
+                  ) : selectedDocumentSecurityLabel ? (
                     <Text
                       fontFamily={dinot}
                       fontSize={10}
                       fontWeight="500"
-                      color={INELIGIBLE_FG}
+                      color={trueSlate500}
                       letterSpacing={0.6}
                       textTransform="uppercase"
                       allowFontScaling={false}
+                      testID={`${testID}-document-selector-security`}
                     >
-                      Ineligible
+                      {selectedDocumentSecurityLabel}
                     </Text>
-                  </View>
-                ) : selectedDocumentSecurityLabel ? (
-                  <Text
-                    fontFamily={dinot}
-                    fontSize={10}
-                    fontWeight="500"
-                    color={trueSlate500}
-                    letterSpacing={0.6}
-                    textTransform="uppercase"
-                    allowFontScaling={false}
-                    testID={`${testID}-document-selector-security`}
-                  >
-                    {selectedDocumentSecurityLabel}
-                  </Text>
-                ) : null}
-              </YStack>
+                  ) : null}
+                </YStack>
 
-              {/* Chevron */}
-              <View
-                width={29}
-                height={29}
-                alignItems="center"
-                justifyContent="center"
-              >
-                <ChevronUpDownIcon
-                  size={20}
-                  color={proofRequestColors.slate900}
-                />
-              </View>
-            </XStack>
-          </Pressable>
+                {/* Chevron */}
+                <View
+                  width={29}
+                  height={29}
+                  alignItems="center"
+                  justifyContent="center"
+                >
+                  <ChevronUpDownIcon
+                    size={20}
+                    color={proofRequestColors.slate900}
+                  />
+                </View>
+              </XStack>
+            </Pressable>
+          </View>
           {hasPerks ? (
-            <PerkEligibilityRow
-              perks={perks ?? []}
-              variant="attached"
-              testID={`${testID}-perks`}
-            />
+            <View
+              marginTop={-12}
+              paddingTop={8}
+              borderLeftWidth={1}
+              borderRightWidth={1}
+              borderBottomWidth={1}
+              borderTopWidth={0}
+              borderColor={proofRequestColors.slate200}
+              borderTopLeftRadius={0}
+              borderTopRightRadius={0}
+              borderBottomLeftRadius={16}
+              borderBottomRightRadius={16}
+              overflow="hidden"
+              backgroundColor={proofRequestColors.white}
+            >
+              <PerkEligibilityRow
+                perks={perks ?? []}
+                variant="attached"
+                testID={`${testID}-perks`}
+              />
+            </View>
           ) : null}
-        </View>
+        </YStack>
 
         {/* Approve button (full-width pill) */}
         <Pressable

--- a/app/src/components/proof-request/BottomActionBar.tsx
+++ b/app/src/components/proof-request/BottomActionBar.tsx
@@ -31,8 +31,18 @@ export interface BottomActionBarProps {
   approveDisabled?: boolean;
   approving?: boolean;
   perks?: Perk[];
+  /** When true, replaces the security label with an "INELIGIBLE" pill and
+   *  surfaces a "Change ID" helper row under the disabled Approve. */
+  ineligible?: boolean;
+  /** Short reason copy shown in the helper row (e.g. "Needs an NFC-enabled
+   *  passport"). Falls back to a generic message when omitted. */
+  ineligibleReasonLabel?: string;
   testID?: string;
 }
+
+const INELIGIBLE_BG = '#FEF3C7';
+const INELIGIBLE_BORDER = '#FDE68A';
+const INELIGIBLE_FG = '#92400E';
 
 const ICON_SIZE = 32;
 
@@ -50,6 +60,8 @@ export const BottomActionBar: React.FC<BottomActionBarProps> = ({
   approveDisabled = false,
   approving = false,
   perks,
+  ineligible = false,
+  ineligibleReasonLabel,
   testID = 'bottom-action-bar',
 }) => {
   const hasPerks = !!perks && perks.length > 0;
@@ -121,7 +133,31 @@ export const BottomActionBar: React.FC<BottomActionBarProps> = ({
                 >
                   {selectedDocumentName}
                 </Text>
-                {selectedDocumentSecurityLabel ? (
+                {ineligible ? (
+                  <View
+                    alignSelf="flex-start"
+                    backgroundColor={INELIGIBLE_BG}
+                    borderColor={INELIGIBLE_BORDER}
+                    borderWidth={1}
+                    borderRadius={4}
+                    paddingHorizontal={6}
+                    paddingVertical={1}
+                    marginTop={2}
+                    testID={`${testID}-document-selector-ineligible`}
+                  >
+                    <Text
+                      fontFamily={dinot}
+                      fontSize={10}
+                      fontWeight="500"
+                      color={INELIGIBLE_FG}
+                      letterSpacing={0.6}
+                      textTransform="uppercase"
+                      allowFontScaling={false}
+                    >
+                      Ineligible
+                    </Text>
+                  </View>
+                ) : selectedDocumentSecurityLabel ? (
                   <Text
                     fontFamily={dinot}
                     fontSize={10}
@@ -189,6 +225,38 @@ export const BottomActionBar: React.FC<BottomActionBarProps> = ({
             </Text>
           )}
         </Pressable>
+
+        {ineligible && !approving ? (
+          <Pressable
+            onPress={onDocumentSelectorPress}
+            style={({ pressed }) => [
+              styles.ineligibleHelper,
+              pressed && styles.ineligibleHelperPressed,
+            ]}
+            testID={`${testID}-ineligible-helper`}
+          >
+            <Text
+              fontFamily={dinot}
+              fontSize={13}
+              color={proofRequestColors.slate700}
+              textAlign="center"
+              allowFontScaling={false}
+            >
+              {ineligibleReasonLabel ?? "This ID isn't eligible for this perk."}{' '}
+              <Text
+                fontFamily={dinot}
+                fontSize={13}
+                fontWeight="600"
+                color={proofRequestColors.slate900}
+                textDecorationLine="underline"
+                allowFontScaling={false}
+                testID={`${testID}-ineligible-change-id`}
+              >
+                Change ID
+              </Text>
+            </Text>
+          </Pressable>
+        ) : null}
       </YStack>
     </View>
   );
@@ -223,5 +291,14 @@ const styles = StyleSheet.create({
   },
   approveButtonPressed: {
     opacity: 0.85,
+  },
+  ineligibleHelper: {
+    paddingHorizontal: 12,
+    paddingVertical: 4,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  ineligibleHelperPressed: {
+    opacity: 0.6,
   },
 });

--- a/app/src/components/proof-request/PerkEligibilityRow.tsx
+++ b/app/src/components/proof-request/PerkEligibilityRow.tsx
@@ -3,14 +3,8 @@
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
 import React from 'react';
-import { Text, View, XStack } from 'tamagui';
 
-import {
-  slate200,
-  slate800,
-  white,
-} from '@selfxyz/mobile-sdk-alpha/constants/colors';
-import { dinot } from '@selfxyz/mobile-sdk-alpha/constants/fonts';
+import { PerkRail } from '@selfxyz/mobile-sdk-alpha/components';
 import {
   getPerkRailLabel,
   type Perk,
@@ -26,7 +20,6 @@ export interface PerkEligibilityRowProps {
 
 export const PerkEligibilityRow: React.FC<PerkEligibilityRowProps> = ({
   perks,
-  variant = 'inline',
   testID = 'perk-eligibility-row',
 }) => {
   if (perks.length === 0) {
@@ -38,52 +31,12 @@ export const PerkEligibilityRow: React.FC<PerkEligibilityRowProps> = ({
     return null;
   }
 
-  const attached = variant === 'attached';
-
   return (
-    <XStack
-      paddingHorizontal={10}
-      paddingVertical={8}
-      alignItems="center"
-      justifyContent="space-between"
-      backgroundColor="transparent"
-      borderBottomLeftRadius={attached ? 16 : 0}
-      borderBottomRightRadius={attached ? 16 : 0}
+    <PerkRail
+      variant={logos.length > 1 ? 'dense' : 'minimal'}
+      logos={logos}
+      label={getPerkRailLabel(perks)}
       testID={testID}
-    >
-      <View
-        width={32}
-        height={32}
-        borderRadius={50}
-        borderWidth={1}
-        borderColor={slate200}
-        backgroundColor={white}
-        overflow="hidden"
-        alignItems="center"
-        justifyContent="center"
-      >
-        {logos}
-      </View>
-      <XStack
-        backgroundColor={slate200}
-        borderRadius={30}
-        paddingHorizontal={8}
-        paddingVertical={4}
-        alignItems="center"
-      >
-        <Text
-          fontFamily={dinot}
-          fontSize={10}
-          fontWeight="500"
-          color={slate800}
-          letterSpacing={0.6}
-          textTransform="uppercase"
-          allowFontScaling={false}
-          testID={`${testID}-label`}
-        >
-          {getPerkRailLabel(perks)}
-        </Text>
-      </XStack>
-    </XStack>
+    />
   );
 };

--- a/app/src/components/proof-request/PerkEligibilityRow.tsx
+++ b/app/src/components/proof-request/PerkEligibilityRow.tsx
@@ -20,6 +20,7 @@ export interface PerkEligibilityRowProps {
 
 export const PerkEligibilityRow: React.FC<PerkEligibilityRowProps> = ({
   perks,
+  variant = 'inline',
   testID = 'perk-eligibility-row',
 }) => {
   if (perks.length === 0) {
@@ -36,6 +37,14 @@ export const PerkEligibilityRow: React.FC<PerkEligibilityRowProps> = ({
       variant={logos.length > 1 ? 'dense' : 'minimal'}
       logos={logos}
       label={getPerkRailLabel(perks)}
+      style={
+        variant === 'inline'
+          ? {
+              borderBottomLeftRadius: 0,
+              borderBottomRightRadius: 0,
+            }
+          : undefined
+      }
       testID={testID}
     />
   );

--- a/app/src/screens/verification/DocumentSelectorForProvingScreen.tsx
+++ b/app/src/screens/verification/DocumentSelectorForProvingScreen.tsx
@@ -77,7 +77,7 @@ function getIneligibleReasonLabel(
     case 'needs_nfc':
       return 'Needs an NFC-enabled passport.';
     case 'unsupported_id_type':
-      return 'This ID type isn’t supported for this perk.';
+      return "This ID type isn't supported for this perk.";
     default:
       return undefined;
   }

--- a/app/src/screens/verification/DocumentSelectorForProvingScreen.tsx
+++ b/app/src/screens/verification/DocumentSelectorForProvingScreen.tsx
@@ -70,6 +70,19 @@ import {
   type IneligibleReason,
 } from '@/utils/googleUsatGate';
 
+function getIneligibleReasonLabel(
+  reason: IneligibleReason | undefined,
+): string | undefined {
+  switch (reason) {
+    case 'needs_nfc':
+      return 'Needs an NFC-enabled passport.';
+    case 'unsupported_id_type':
+      return 'This ID type isn’t supported for this perk.';
+    default:
+      return undefined;
+  }
+}
+
 function getDocumentDisplayName(
   metadata: DocumentMetadata,
   documentData?: IDDocument,
@@ -365,10 +378,13 @@ const DocumentSelectorForProvingScreen: React.FC = () => {
       : undefined;
 
   const selectedDocument = documents.find(doc => doc.id === selectedDocumentId);
+  const selectedIneligibleReason = selectedDocument
+    ? ineligibleReasonByDocumentId?.[selectedDocument.id]
+    : undefined;
   const canContinue =
     !!selectedDocument &&
     !isDisabledState(selectedDocument.state) &&
-    !ineligibleReasonByDocumentId?.[selectedDocument.id];
+    !selectedIneligibleReason;
 
   // Get document type for the proof request message
   const selectedDocumentType = useMemo(() => {
@@ -615,6 +631,10 @@ const DocumentSelectorForProvingScreen: React.FC = () => {
         approveDisabled={!canContinue}
         approving={submitting}
         perks={activeDocumentPerks}
+        ineligible={!!selectedIneligibleReason}
+        ineligibleReasonLabel={getIneligibleReasonLabel(
+          selectedIneligibleReason,
+        )}
         testID="document-selector-action-bar"
       />
 

--- a/app/tests/__setup__/mocks/ui.js
+++ b/app/tests/__setup__/mocks/ui.js
@@ -60,17 +60,25 @@ jest.mock('@selfxyz/mobile-sdk-alpha/components', () => {
   const View = jest.fn(({ children, ...props }) => children || null);
   View.displayName = 'MockView';
 
-  const PerkRail = jest.fn(({ logos = [], label, variant, onPress, testID, style }) => {
-    const visibleLogos = variant === 'minimal' ? logos.slice(0, 1) : logos.slice(0, 3);
-    return (
-      <mock-perk-rail testID={testID} variant={variant} onPress={onPress} style={style}>
-        {visibleLogos.map((logo, index) => (
-          <mock-perk-rail-logo key={index}>{logo}</mock-perk-rail-logo>
-        ))}
-        <mock-perk-rail-label>{label}</mock-perk-rail-label>
-      </mock-perk-rail>
-    );
-  });
+  const PerkRail = jest.fn(
+    ({ logos = [], label, variant, onPress, testID, style }) => {
+      const visibleLogos =
+        variant === 'minimal' ? logos.slice(0, 1) : logos.slice(0, 3);
+      return (
+        <mock-perk-rail
+          testID={testID}
+          variant={variant}
+          onPress={onPress}
+          style={style}
+        >
+          {visibleLogos.map((logo, index) => (
+            <mock-perk-rail-logo key={index}>{logo}</mock-perk-rail-logo>
+          ))}
+          <mock-perk-rail-label>{label}</mock-perk-rail-label>
+        </mock-perk-rail>
+      );
+    },
+  );
   PerkRail.displayName = 'MockPerkRail';
 
   return {

--- a/app/tests/__setup__/mocks/ui.js
+++ b/app/tests/__setup__/mocks/ui.js
@@ -60,10 +60,10 @@ jest.mock('@selfxyz/mobile-sdk-alpha/components', () => {
   const View = jest.fn(({ children, ...props }) => children || null);
   View.displayName = 'MockView';
 
-  const PerkRail = jest.fn(({ logos = [], label, variant, onPress, testID }) => {
+  const PerkRail = jest.fn(({ logos = [], label, variant, onPress, testID, style }) => {
     const visibleLogos = variant === 'minimal' ? logos.slice(0, 1) : logos.slice(0, 3);
     return (
-      <mock-perk-rail testID={testID} variant={variant} onPress={onPress}>
+      <mock-perk-rail testID={testID} variant={variant} onPress={onPress} style={style}>
         {visibleLogos.map((logo, index) => (
           <mock-perk-rail-logo key={index}>{logo}</mock-perk-rail-logo>
         ))}

--- a/app/tests/__setup__/mocks/ui.js
+++ b/app/tests/__setup__/mocks/ui.js
@@ -60,12 +60,26 @@ jest.mock('@selfxyz/mobile-sdk-alpha/components', () => {
   const View = jest.fn(({ children, ...props }) => children || null);
   View.displayName = 'MockView';
 
+  const PerkRail = jest.fn(({ logos = [], label, variant, onPress, testID }) => {
+    const visibleLogos = variant === 'minimal' ? logos.slice(0, 1) : logos.slice(0, 3);
+    return (
+      <mock-perk-rail testID={testID} variant={variant} onPress={onPress}>
+        {visibleLogos.map((logo, index) => (
+          <mock-perk-rail-logo key={index}>{logo}</mock-perk-rail-logo>
+        ))}
+        <mock-perk-rail-label>{label}</mock-perk-rail-label>
+      </mock-perk-rail>
+    );
+  });
+  PerkRail.displayName = 'MockPerkRail';
+
   return {
     __esModule: true,
     Button,
     XStack,
     Title,
     View,
+    PerkRail,
     // Provide minimal Text to satisfy potential usages
     Text,
   };

--- a/app/tests/src/components/documents/IDSelectorSheet.test.tsx
+++ b/app/tests/src/components/documents/IDSelectorSheet.test.tsx
@@ -31,7 +31,8 @@ jest.mock('@selfxyz/mobile-sdk-alpha/components', () => ({
     variant?: string;
     testID?: string;
   }) => {
-    const visible = variant === 'minimal' ? logos.slice(0, 1) : logos.slice(0, 3);
+    const visible =
+      variant === 'minimal' ? logos.slice(0, 1) : logos.slice(0, 3);
     return (
       <mock-perk-rail testID={testID} variant={variant}>
         {visible.map((logo, i) => (

--- a/app/tests/src/components/documents/IDSelectorSheet.test.tsx
+++ b/app/tests/src/components/documents/IDSelectorSheet.test.tsx
@@ -537,6 +537,27 @@ describe('IDSelectorSheet — perk eligibility', () => {
     expect(tree.getByTestId('sheet-item-doc1-perks')).toBeTruthy();
   });
 
+  it('treats the perk row as part of the selectable tap target', () => {
+    const { getByTestId } = render(
+      <IDSelectorSheet
+        open={true}
+        onOpenChange={mockOnOpenChange}
+        documents={documents}
+        selectedId="doc2"
+        onSelect={mockOnSelect}
+        onDismiss={mockOnDismiss}
+        onApprove={mockOnApprove}
+        activePerkId="google_cloud_faucet"
+        perksByDocumentId={{ doc1: [makeGooglePerk()] }}
+        ineligibleReasonByDocumentId={{ doc2: 'needs_nfc' }}
+        testID="sheet"
+      />,
+    );
+
+    fireEvent.press(getByTestId('sheet-item-doc1-perks'));
+    expect(mockOnSelect).toHaveBeenCalledWith('doc1');
+  });
+
   it('does not render the perk row on an ineligible doc even with perks defined', () => {
     const tree = render(
       <IDSelectorSheet

--- a/app/tests/src/components/documents/IDSelectorSheet.test.tsx
+++ b/app/tests/src/components/documents/IDSelectorSheet.test.tsx
@@ -517,6 +517,48 @@ describe('IDSelectorSheet — perk eligibility', () => {
     expect(JSON.stringify(tree.toJSON())).toContain('Eligible for 1 perk');
   });
 
+  it('renders the perk row on an eligible doc even when it is not the active selection', () => {
+    const tree = render(
+      <IDSelectorSheet
+        open={true}
+        onOpenChange={mockOnOpenChange}
+        documents={documents}
+        selectedId="doc2"
+        onSelect={mockOnSelect}
+        onDismiss={mockOnDismiss}
+        onApprove={mockOnApprove}
+        activePerkId="google_cloud_faucet"
+        perksByDocumentId={{ doc1: [makeGooglePerk()] }}
+        ineligibleReasonByDocumentId={{ doc2: 'needs_nfc' }}
+        testID="sheet"
+      />,
+    );
+    expect(tree.getByTestId('sheet-item-doc1-perks')).toBeTruthy();
+  });
+
+  it('does not render the perk row on an ineligible doc even with perks defined', () => {
+    const tree = render(
+      <IDSelectorSheet
+        open={true}
+        onOpenChange={mockOnOpenChange}
+        documents={documents}
+        selectedId="doc1"
+        onSelect={mockOnSelect}
+        onDismiss={mockOnDismiss}
+        onApprove={mockOnApprove}
+        activePerkId="google_cloud_faucet"
+        perksByDocumentId={{
+          doc1: [makeGooglePerk()],
+          doc2: [makeGooglePerk()],
+        }}
+        ineligibleReasonByDocumentId={{ doc2: 'needs_nfc' }}
+        testID="sheet"
+      />,
+    );
+    expect(tree.queryByTestId('sheet-item-doc2-perks')).toBeNull();
+    expect(tree.getByTestId('sheet-item-doc1-perks')).toBeTruthy();
+  });
+
   it('does not render the perk row when ineligible-doc is the active selection', () => {
     const tree = render(
       <IDSelectorSheet

--- a/app/tests/src/components/documents/IDSelectorSheet.test.tsx
+++ b/app/tests/src/components/documents/IDSelectorSheet.test.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
+import React from 'react';
 import { Text } from 'react-native';
 import { fireEvent, render } from '@testing-library/react-native';
 
@@ -19,6 +20,27 @@ jest.mock('@selfxyz/mobile-sdk-alpha/components', () => ({
   RoundFlag: ({ countryCode }: { countryCode: string }) => (
     <mock-round-flag data-country-code={countryCode || 'none'} />
   ),
+  PerkRail: ({
+    logos = [],
+    label,
+    variant,
+    testID,
+  }: {
+    logos?: React.ReactNode[];
+    label?: string;
+    variant?: string;
+    testID?: string;
+  }) => {
+    const visible = variant === 'minimal' ? logos.slice(0, 1) : logos.slice(0, 3);
+    return (
+      <mock-perk-rail testID={testID} variant={variant}>
+        {visible.map((logo, i) => (
+          <mock-perk-rail-logo key={i}>{logo}</mock-perk-rail-logo>
+        ))}
+        <mock-perk-rail-label>{label}</mock-perk-rail-label>
+      </mock-perk-rail>
+    );
+  },
 }));
 
 jest.mock('@/assets/images/dev_card_logo.svg', () => 'DevLogo');

--- a/app/tests/src/components/proof-request/BottomActionBar.test.tsx
+++ b/app/tests/src/components/proof-request/BottomActionBar.test.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
+import React from 'react';
 import { Text } from 'react-native';
 import { fireEvent, render } from '@testing-library/react-native';
 
@@ -14,6 +15,27 @@ jest.mock('@selfxyz/mobile-sdk-alpha/components', () => ({
   RoundFlag: ({ countryCode }: { countryCode: string }) => (
     <mock-round-flag data-country-code={countryCode || 'none'} />
   ),
+  PerkRail: ({
+    logos = [],
+    label,
+    variant,
+    testID,
+  }: {
+    logos?: React.ReactNode[];
+    label?: string;
+    variant?: string;
+    testID?: string;
+  }) => {
+    const visible = variant === 'minimal' ? logos.slice(0, 1) : logos.slice(0, 3);
+    return (
+      <mock-perk-rail testID={testID} variant={variant}>
+        {visible.map((logo, i) => (
+          <mock-perk-rail-logo key={i}>{logo}</mock-perk-rail-logo>
+        ))}
+        <mock-perk-rail-label>{label}</mock-perk-rail-label>
+      </mock-perk-rail>
+    );
+  },
 }));
 
 jest.mock('@/assets/images/dev_card_logo.svg', () => 'DevLogo');

--- a/app/tests/src/components/proof-request/BottomActionBar.test.tsx
+++ b/app/tests/src/components/proof-request/BottomActionBar.test.tsx
@@ -26,7 +26,8 @@ jest.mock('@selfxyz/mobile-sdk-alpha/components', () => ({
     variant?: string;
     testID?: string;
   }) => {
-    const visible = variant === 'minimal' ? logos.slice(0, 1) : logos.slice(0, 3);
+    const visible =
+      variant === 'minimal' ? logos.slice(0, 1) : logos.slice(0, 3);
     return (
       <mock-perk-rail testID={testID} variant={variant}>
         {visible.map((logo, i) => (
@@ -141,5 +142,88 @@ describe('BottomActionBar', () => {
       <BottomActionBar {...baseProps} perks={[makePerk('g')]} testID="bar" />,
     );
     expect(renderedText(tree)).toContain('Eligible for 1 perk');
+  });
+
+  describe('ineligible state', () => {
+    it('replaces the security label with an INELIGIBLE pill', () => {
+      const tree = render(
+        <BottomActionBar
+          {...baseProps}
+          selectedDocumentSecurityLabel="LOW-SECURITY"
+          approveDisabled
+          ineligible
+          ineligibleReasonLabel="Needs an NFC-enabled passport."
+          testID="bar"
+        />,
+      );
+      expect(tree.queryByTestId('bar-document-selector-security')).toBeNull();
+      const text = renderedText(tree);
+      expect(text).toContain('Ineligible');
+      expect(text).not.toContain('LOW-SECURITY');
+    });
+
+    it('renders the helper row with the reason copy when ineligible', () => {
+      const tree = render(
+        <BottomActionBar
+          {...baseProps}
+          approveDisabled
+          ineligible
+          ineligibleReasonLabel="Needs an NFC-enabled passport."
+          testID="bar"
+        />,
+      );
+      expect(tree.getByTestId('bar-ineligible-helper')).toBeTruthy();
+      expect(renderedText(tree)).toContain('Needs an NFC-enabled passport.');
+      expect(renderedText(tree)).toContain('Change ID');
+    });
+
+    it('falls back to generic helper copy when reason label is missing', () => {
+      const tree = render(
+        <BottomActionBar
+          {...baseProps}
+          approveDisabled
+          ineligible
+          testID="bar"
+        />,
+      );
+      expect(renderedText(tree)).toContain(
+        "This ID isn't eligible for this perk.",
+      );
+    });
+
+    it('opens the picker when the helper row is tapped', () => {
+      const { getByTestId } = render(
+        <BottomActionBar
+          {...baseProps}
+          approveDisabled
+          ineligible
+          ineligibleReasonLabel="Needs an NFC-enabled passport."
+          testID="bar"
+        />,
+      );
+      fireEvent.press(getByTestId('bar-ineligible-helper'));
+      expect(baseProps.onDocumentSelectorPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not render the helper row when not ineligible', () => {
+      const { queryByTestId } = render(
+        <BottomActionBar {...baseProps} testID="bar" />,
+      );
+      expect(queryByTestId('bar-ineligible-helper')).toBeNull();
+      expect(queryByTestId('bar-document-selector-ineligible')).toBeNull();
+    });
+
+    it('hides the helper row while approving even if ineligible', () => {
+      const { queryByTestId } = render(
+        <BottomActionBar
+          {...baseProps}
+          approveDisabled
+          ineligible
+          approving
+          testID="bar"
+        />,
+      );
+      expect(queryByTestId('bar-ineligible-helper')).toBeNull();
+    });
   });
 });

--- a/app/tests/src/components/proof-request/PerkEligibilityRow.test.tsx
+++ b/app/tests/src/components/proof-request/PerkEligibilityRow.test.tsx
@@ -51,4 +51,18 @@ describe('PerkEligibilityRow', () => {
     expect(tree.getByTestId('logo-a')).toBeTruthy();
     expect(tree.getByTestId('logo-b')).toBeTruthy();
   });
+
+  it('fans logos out side-by-side instead of stacking them in a single circle', () => {
+    // Regression: the old implementation rendered every logo inside one 32x32
+    // wrapper, so two perks visually overlapped. Each logo must own its
+    // parent wrapper so the dense rail can place them side-by-side.
+    const perks = [
+      makePerk('google_cloud_faucet', 'A', 'a'),
+      makePerk('google_cloud_faucet', 'B', 'b'),
+    ];
+    const tree = render(<PerkEligibilityRow perks={perks} />);
+    const a = tree.getByTestId('logo-a');
+    const b = tree.getByTestId('logo-b');
+    expect(a.parent).not.toBe(b.parent);
+  });
 });

--- a/app/tests/src/components/proof-request/PerkEligibilityRow.test.tsx
+++ b/app/tests/src/components/proof-request/PerkEligibilityRow.test.tsx
@@ -65,4 +65,21 @@ describe('PerkEligibilityRow', () => {
     const b = tree.getByTestId('logo-b');
     expect(a.parent).not.toBe(b.parent);
   });
+
+  it('keeps the attached row rounded but removes the bottom radius for inline rows', () => {
+    const perks = [makePerk('google_cloud_faucet', 'A', 'a')];
+
+    const inline = render(<PerkEligibilityRow perks={perks} variant="inline" testID="inline-row" />);
+    const attached = render(
+      <PerkEligibilityRow perks={perks} variant="attached" testID="attached-row" />,
+    );
+
+    expect(inline.getByTestId('inline-row').props.style).toEqual(
+      expect.objectContaining({
+        borderBottomLeftRadius: 0,
+        borderBottomRightRadius: 0,
+      }),
+    );
+    expect(attached.getByTestId('attached-row').props.style).toBeUndefined();
+  });
 });

--- a/app/tests/src/components/proof-request/PerkEligibilityRow.test.tsx
+++ b/app/tests/src/components/proof-request/PerkEligibilityRow.test.tsx
@@ -69,9 +69,15 @@ describe('PerkEligibilityRow', () => {
   it('keeps the attached row rounded but removes the bottom radius for inline rows', () => {
     const perks = [makePerk('google_cloud_faucet', 'A', 'a')];
 
-    const inline = render(<PerkEligibilityRow perks={perks} variant="inline" testID="inline-row" />);
+    const inline = render(
+      <PerkEligibilityRow perks={perks} variant="inline" testID="inline-row" />,
+    );
     const attached = render(
-      <PerkEligibilityRow perks={perks} variant="attached" testID="attached-row" />,
+      <PerkEligibilityRow
+        perks={perks}
+        variant="attached"
+        testID="attached-row"
+      />,
     );
 
     expect(inline.getByTestId('inline-row').props.style).toEqual(

--- a/app/tests/src/screens/verification/DocumentSelectorForProvingScreen.test.tsx
+++ b/app/tests/src/screens/verification/DocumentSelectorForProvingScreen.test.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
+import React from 'react';
 import { useNavigation } from '@react-navigation/native';
 import { fireEvent, render, waitFor } from '@testing-library/react-native';
 
@@ -24,6 +25,8 @@ import {
   evaluateGoogleUsatEligibilityForDocument,
   evaluateGoogleUsatGateForDocument,
 } from '@/utils/googleUsatGate';
+
+const MockReact = React;
 
 // Mock useFocusEffect to behave like useEffect in tests
 // Note: We use a closure-based approach to avoid requiring React (prevents OOM per test-memory-optimization rules)
@@ -90,6 +93,28 @@ jest.mock('@selfxyz/common/utils/types', () => ({
 jest.mock('@selfxyz/mobile-sdk-alpha/components', () => ({
   __esModule: true,
   RoundFlag: () => null,
+  PerkRail: ({
+    logos = [],
+    label,
+    variant,
+    testID,
+  }: {
+    logos?: React.ReactNode[];
+    label?: string;
+    variant?: string;
+    testID?: string;
+  }) => {
+    const visible =
+      variant === 'minimal' ? logos.slice(0, 1) : logos.slice(0, 3);
+    return MockReact.createElement(
+      'mock-perk-rail',
+      { testID, variant },
+      ...visible.map((logo: React.ReactNode, i: number) =>
+        MockReact.createElement('mock-perk-rail-logo', { key: i }, logo),
+      ),
+      MockReact.createElement('mock-perk-rail-label', null, label),
+    );
+  },
 }));
 
 jest.mock('@/components/homescreen/cardSecurityBadge', () => ({
@@ -831,6 +856,74 @@ describe('DocumentSelectorForProvingScreen', () => {
           getByTestId('document-selector-action-bar-approve').props.disabled,
         ).toBe(false);
       });
+    });
+
+    it('surfaces the needs_nfc helper copy on the action bar when the active doc is ineligible', async () => {
+      const aadhaar = createMetadata({
+        id: 'doc-1',
+        documentType: 'aadhaar',
+        documentCategory: 'aadhaar',
+        isRegistered: true,
+      });
+      const catalog: DocumentCatalog = {
+        documents: [aadhaar],
+        selectedDocumentId: 'doc-1',
+      };
+
+      mockLoadDocumentCatalog.mockResolvedValue(catalog);
+      mockGetAllDocuments.mockResolvedValue(
+        createAllDocuments([createDocumentEntry(aadhaar)]),
+      );
+      mockIsGoogleUsatProofRequest.mockReturnValue(true);
+      mockEvaluateGoogleUsatEligibilityForDocument.mockReturnValue({
+        eligible: false,
+        reason: 'needs_nfc',
+      });
+
+      const tree = render(<DocumentSelectorForProvingScreen />);
+
+      await waitFor(() => {
+        expect(
+          tree.getByTestId('document-selector-action-bar-ineligible-helper'),
+        ).toBeTruthy();
+      });
+      expect(JSON.stringify(tree.toJSON())).toContain(
+        'Needs an NFC-enabled passport.',
+      );
+    });
+
+    it('uses the unsupported_id_type helper copy for that reason', async () => {
+      const aadhaar = createMetadata({
+        id: 'doc-1',
+        documentType: 'aadhaar',
+        documentCategory: 'aadhaar',
+        isRegistered: true,
+      });
+      const catalog: DocumentCatalog = {
+        documents: [aadhaar],
+        selectedDocumentId: 'doc-1',
+      };
+
+      mockLoadDocumentCatalog.mockResolvedValue(catalog);
+      mockGetAllDocuments.mockResolvedValue(
+        createAllDocuments([createDocumentEntry(aadhaar)]),
+      );
+      mockIsGoogleUsatProofRequest.mockReturnValue(true);
+      mockEvaluateGoogleUsatEligibilityForDocument.mockReturnValue({
+        eligible: false,
+        reason: 'unsupported_id_type',
+      });
+
+      const tree = render(<DocumentSelectorForProvingScreen />);
+
+      await waitFor(() => {
+        expect(
+          tree.getByTestId('document-selector-action-bar-ineligible-helper'),
+        ).toBeTruthy();
+      });
+      expect(JSON.stringify(tree.toJSON())).toContain(
+        'This ID type isn’t supported for this perk.',
+      );
     });
   });
 });

--- a/app/tests/src/screens/verification/DocumentSelectorForProvingScreen.test.tsx
+++ b/app/tests/src/screens/verification/DocumentSelectorForProvingScreen.test.tsx
@@ -922,7 +922,7 @@ describe('DocumentSelectorForProvingScreen', () => {
         ).toBeTruthy();
       });
       expect(JSON.stringify(tree.toJSON())).toContain(
-        'This ID type isn’t supported for this perk.',
+        "This ID type isn't supported for this perk.",
       );
     });
   });

--- a/packages/mobile-sdk-alpha/src/components/data-display/PerkRail.tsx
+++ b/packages/mobile-sdk-alpha/src/components/data-display/PerkRail.tsx
@@ -17,6 +17,7 @@ export interface PerkRailProps {
   label?: string;
   onPress?: () => void;
   style?: ViewStyle;
+  testID?: string;
 }
 
 export type PerkRailVariant = 'dense' | 'minimal';
@@ -29,7 +30,7 @@ function defaultLabel(count: number): string {
   return count === 1 ? 'ELIGIBLE FOR 1 PERK' : `ELIGIBLE FOR ${count} PERKS`;
 }
 
-export const PerkRail: React.FC<PerkRailProps> = ({ variant = 'dense', logos, label, onPress, style }) => {
+export const PerkRail: React.FC<PerkRailProps> = ({ variant = 'dense', logos, label, onPress, style, testID }) => {
   const max = variant === 'dense' ? DENSE_MAX_LOGOS : MINIMAL_MAX_LOGOS;
   const visibleLogos = logos.slice(0, max);
   const labelText = label ?? defaultLabel(logos.length);
@@ -73,12 +74,12 @@ export const PerkRail: React.FC<PerkRailProps> = ({ variant = 'dense', logos, la
 
   if (onPress) {
     return (
-      <Pressable onPress={onPress} style={containerStyle}>
+      <Pressable onPress={onPress} style={containerStyle} testID={testID}>
         {content}
       </Pressable>
     );
   }
-  return <View style={containerStyle}>{content}</View>;
+  return <View style={containerStyle} testID={testID}>{content}</View>;
 };
 
 const styles = StyleSheet.create({

--- a/packages/mobile-sdk-alpha/src/components/data-display/PerkRail.tsx
+++ b/packages/mobile-sdk-alpha/src/components/data-display/PerkRail.tsx
@@ -79,7 +79,11 @@ export const PerkRail: React.FC<PerkRailProps> = ({ variant = 'dense', logos, la
       </Pressable>
     );
   }
-  return <View style={containerStyle} testID={testID}>{content}</View>;
+  return (
+    <View style={containerStyle} testID={testID}>
+      {content}
+    </View>
+  );
 };
 
 const styles = StyleSheet.create({

--- a/packages/mobile-sdk-alpha/tests/components/data-display/PerkRail.test.tsx
+++ b/packages/mobile-sdk-alpha/tests/components/data-display/PerkRail.test.tsx
@@ -55,6 +55,23 @@ describe('PerkRail', () => {
     expect(logos[1]!.getAttribute('data-testid')).toBe('logo-usat');
   });
 
+  it('dense variant places each logo in its own wrapper (fanned out, not stacked)', () => {
+    // Regression: PerkEligibilityRow used to render every perk logo inside a
+    // single 32x32 circle, visually stacking them. Each logo must own its
+    // wrapper so the dense rail can fan them out side-by-side.
+    const { container } = render(
+      <PerkRail
+        variant="dense"
+        logos={[<span key="google" data-testid="logo-google" />, <span key="usat" data-testid="logo-usat" />]}
+        label="Eligible perks"
+      />,
+    );
+
+    const logoEls = container.querySelectorAll('[data-testid^="logo-"]');
+    expect(logoEls.length).toBe(2);
+    expect(logoEls[0]!.parentElement).not.toBe(logoEls[1]!.parentElement);
+  });
+
   it('dense variant caps logos at the max (3) and drops overflow', () => {
     const { container } = render(
       <PerkRail


### PR DESCRIPTION
## Summary

- Replace the bespoke perk-eligibility row with the shared `PerkRail` so multi-perk logos fan out side-by-side instead of stacking inside one circle, and the dense vs minimal variant matches Figma.
- Always show eligible perks in the ID picker (not just on the active row) and frame any row that has perks, so users can see which docs unlock perks before selecting.
- Surface ineligible-document state on the bottom action bar with reason-specific copy (`needs_nfc`, `unsupported_id_type`) and a tap-to-change-ID helper row.
- Backfill missing test coverage and fix the screen test that broke when `PerkEligibilityRow` started consuming `PerkRail`.

## Changes

### React Native app

- `BottomActionBar`: pin the selector to a rounded-60 pill (per Figma 26164:20557), drop the screen-height-dependent dynamic padding, and add an `ineligible` state with helper row, reason label, and `INELIGIBLE` pill replacing the security label.
- `PerkEligibilityRow`: thin wrapper around the SDK `PerkRail`; picks `minimal` vs `dense` variant from logo count and strips bottom radius for inline rows.
- `IDSelectorSheet`: show perk row on any eligible non-disabled doc (not just the active one) and apply the framed border whenever a row is active or carries perks.
- `DocumentSelectorForProvingScreen`: thread `selectedIneligibleReason` into the action bar and map `needs_nfc` / `unsupported_id_type` to user-visible helper copy.

### SDK core

- `PerkRail`: expose a `testID` prop on both the `Pressable` and `View` branches.

### Tests

- New suites for `BottomActionBar`, `PerkEligibilityRow`, and `PerkRail` covering the perk-row, ineligible-state, and logo-fanning behavior.
- Extend `IDSelectorSheet` tests with the cross-row perk eligibility cases and the framed-border path.
- Extend `DocumentSelectorForProvingScreen` tests with reason-to-helper-copy assertions and add `PerkRail` to the SDK component mock (fixes the broken suite).
- Add a shared `PerkRail` factory to `tests/__setup__/mocks/ui.js`.

## Test Plan

- [x] `yarn jest:run` — 96 suites / 1083 tests pass
- [x] `yarn lint`
- [ ] Manual: open a Google USAT proof request with (a) an eligible passport, (b) an ineligible Aadhaar — verify the helper row copy, INELIGIBLE pill, and that the picker shows perks on the eligible row regardless of selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Perk eligibility now displayed for all eligible documents, not just the selected one
  * Ineligible state UI added with specific reason explanations (e.g., "Needs an NFC-enabled passport," "This ID type isn't supported")
  * Helper row with guidance text displayed when a document is ineligible

* **Tests**
  * Added comprehensive test coverage for ineligible state scenarios and perk eligibility display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->