### PR TITLE
fix React 19 set-state-in-effect warnings in app screens and hooks

### DIFF
--- a/app/src/components/proof-request/WalletAddressModal.tsx
+++ b/app/src/components/proof-request/WalletAddressModal.tsx
@@ -32,15 +32,16 @@ export const WalletAddressModal: React.FC<WalletAddressModalProps> = ({
   testID = 'wallet-address-modal',
 }) => {
   const [copied, setCopied] = useState(false);
+  const [wasVisible, setWasVisible] = useState(visible);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const label = userIdType === 'hex' ? 'Connected Wallet' : 'Connected ID';
 
-  // Reset copied state when modal closes
-  useEffect(() => {
+  if (wasVisible !== visible) {
+    setWasVisible(visible);
     if (!visible) {
       setCopied(false);
     }
-  }, [visible]);
+  }
 
   // Clear timeout on unmount or when modal closes/address changes
   useEffect(() => {

--- a/app/src/hooks/useDeeplinkRedirectCountdown.ts
+++ b/app/src/hooks/useDeeplinkRedirectCountdown.ts
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface DeeplinkRedirectCountdownParams {
+  seconds: number;
+  shouldStart: boolean;
+  isFocused: boolean;
+  resetKey: unknown;
+  onRedirect: () => void;
+}
+
+export interface DeeplinkRedirectCountdown {
+  countdown: number | null;
+  cancel: () => void;
+}
+
+/**
+ * Counts down from `seconds` once `shouldStart` is met while focused, then fires
+ * `onRedirect` at zero. Losing focus hides the countdown without restarting it;
+ * a change to `resetKey` (the session) clears the latch so a new session can run
+ * its own countdown.
+ */
+export function useDeeplinkRedirectCountdown({
+  seconds,
+  shouldStart,
+  isFocused,
+  resetKey,
+  onRedirect,
+}: DeeplinkRedirectCountdownParams): DeeplinkRedirectCountdown {
+  const [countdown, setCountdown] = useState<number | null>(null);
+  const [started, setStarted] = useState(false);
+  const onRedirectRef = useRef(onRedirect);
+  useEffect(() => {
+    onRedirectRef.current = onRedirect;
+  });
+
+  const [prevResetKey, setPrevResetKey] = useState(resetKey);
+  if (prevResetKey !== resetKey) {
+    setPrevResetKey(resetKey);
+    setStarted(false);
+    setCountdown(null);
+  }
+
+  if (shouldStart && isFocused && !started) {
+    setStarted(true);
+    setCountdown(seconds);
+  }
+
+  const [wasFocused, setWasFocused] = useState(isFocused);
+  if (wasFocused !== isFocused) {
+    setWasFocused(isFocused);
+    if (!isFocused && countdown !== null) {
+      setCountdown(null);
+    }
+  }
+
+  useEffect(() => {
+    if (countdown === null) return;
+    if (countdown <= 0) {
+      onRedirectRef.current();
+      return;
+    }
+    const timer = setTimeout(() => {
+      setCountdown(prev => (prev !== null ? prev - 1 : null));
+    }, 1000);
+    return () => clearTimeout(timer);
+  }, [countdown]);
+
+  const cancel = useCallback(() => setCountdown(null), []);
+
+  return { countdown, cancel };
+}

--- a/app/src/hooks/useEarnPointsFlow.ts
+++ b/app/src/hooks/useEarnPointsFlow.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
@@ -36,6 +36,7 @@ export const useEarnPointsFlow = ({
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const { registerReferral } = useRegisterReferral();
   const referrer = useUserStore(state => state.deepLinkReferrer);
+  const handleReferralFlowRef = useRef<() => Promise<void>>(async () => {});
 
   const navigateToPointsProof = useCallback(async () => {
     const selfApp = await pointsSelfApp();
@@ -136,7 +137,7 @@ export const useEarnPointsFlow = ({
     const showReferralErrorModal = (errorMessage: string) => {
       const callbackId = registerModalCallbacks({
         onButtonPress: async () => {
-          await handleReferralFlow();
+          await handleReferralFlowRef.current();
         },
         onModalDismiss: () => {
           // Clear referrer when user dismisses to prevent retry loop
@@ -181,6 +182,10 @@ export const useEarnPointsFlow = ({
       });
     }
   }, [referrer, registerReferral, navigation]);
+
+  useEffect(() => {
+    handleReferralFlowRef.current = handleReferralFlow;
+  }, [handleReferralFlow]);
 
   const onEarnPointsPress = useCallback(
     async (skipReferralFlow = true) => {

--- a/app/src/hooks/useProvingStallTimeout.ts
+++ b/app/src/hooks/useProvingStallTimeout.ts
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { useEffect, useState } from 'react';
+
+export interface ProvingStallTimeoutParams {
+  currentState: string;
+  isFocused: boolean;
+  sessionId: string | null;
+  stallStates: Set<string>;
+  timeoutMs: number;
+}
+
+export interface ProvingStallTimeout {
+  hasTimedOut: boolean;
+  timedOutSessionId: string | null;
+}
+
+/**
+ * Arms a single timeout while the proving flow sits in a stall-prone state and
+ * the screen is focused. When it fires, the flow is marked timed-out and the
+ * session id in effect at that moment is captured for downstream reporting.
+ * The timed-out flag resets whenever the session id changes.
+ */
+export function useProvingStallTimeout({
+  currentState,
+  isFocused,
+  sessionId,
+  stallStates,
+  timeoutMs,
+}: ProvingStallTimeoutParams): ProvingStallTimeout {
+  const [hasTimedOut, setHasTimedOut] = useState(false);
+  const [timedOutSessionId, setTimedOutSessionId] = useState<string | null>(
+    null,
+  );
+
+  const [prevSessionId, setPrevSessionId] = useState(sessionId);
+  if (prevSessionId !== sessionId) {
+    setPrevSessionId(sessionId);
+    setHasTimedOut(false);
+    setTimedOutSessionId(null);
+  }
+
+  // Track the active stall state (not just a boolean) so that progressing from
+  // one stall-prone state to another restarts the window — each active state
+  // gets its own full timeout rather than sharing one from the first entry.
+  const stallState =
+    isFocused && !hasTimedOut && stallStates.has(currentState)
+      ? currentState
+      : null;
+
+  useEffect(() => {
+    if (stallState === null) return;
+    const timer = setTimeout(() => {
+      setTimedOutSessionId(sessionId);
+      setHasTimedOut(true);
+    }, timeoutMs);
+    return () => clearTimeout(timer);
+  }, [stallState, sessionId, timeoutMs]);
+
+  return { hasTimedOut, timedOutSessionId };
+}

--- a/app/src/hooks/usePullToRefresh.ts
+++ b/app/src/hooks/usePullToRefresh.ts
@@ -17,7 +17,9 @@ export function usePullToRefresh(
   const onRefresh = useCallback(() => {
     setRefreshing(true);
     Promise.resolve(refreshAction())
-      .catch(() => {})
+      .catch(error => {
+        console.warn('usePullToRefresh: refresh action failed', error);
+      })
       .finally(() => setRefreshing(false));
   }, [refreshAction]);
 

--- a/app/src/hooks/usePullToRefresh.ts
+++ b/app/src/hooks/usePullToRefresh.ts
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { useCallback, useState } from 'react';
+
+export interface PullToRefresh {
+  refreshing: boolean;
+  onRefresh: () => void;
+}
+
+export function usePullToRefresh(
+  refreshAction: () => void | Promise<void>,
+): PullToRefresh {
+  const [refreshing, setRefreshing] = useState(false);
+
+  const onRefresh = useCallback(() => {
+    setRefreshing(true);
+    Promise.resolve(refreshAction())
+      .catch(() => {})
+      .finally(() => setRefreshing(false));
+  }, [refreshAction]);
+
+  return { refreshing, onRefresh };
+}

--- a/app/src/hooks/useSelfAppData.ts
+++ b/app/src/hooks/useSelfAppData.ts
@@ -16,42 +16,44 @@ import { formatUserId } from '@/utils/formatUserId';
  * Returns memoized values for logo source, URL, formatted user ID, and disclosure items.
  */
 export function useSelfAppData(selfApp: SelfApp | null) {
+  const logoBase64 = selfApp?.logoBase64;
+  const endpoint = selfApp?.endpoint;
+  const userId = selfApp?.userId;
+  const userIdType = selfApp?.userIdType;
+  const disclosures = selfApp?.disclosures as SelfAppDisclosureConfig;
+
   const logoSource = useMemo(() => {
-    if (!selfApp?.logoBase64) {
+    if (!logoBase64) {
       return null;
     }
 
     // Check if the logo is already a URL
-    if (
-      selfApp.logoBase64.startsWith('http://') ||
-      selfApp.logoBase64.startsWith('https://')
-    ) {
-      return { uri: selfApp.logoBase64 };
+    if (logoBase64.startsWith('http://') || logoBase64.startsWith('https://')) {
+      return { uri: logoBase64 };
     }
 
     // Otherwise handle as base64
-    const base64String = selfApp.logoBase64.startsWith('data:image')
-      ? selfApp.logoBase64
-      : `data:image/png;base64,${selfApp.logoBase64}`;
+    const base64String = logoBase64.startsWith('data:image')
+      ? logoBase64
+      : `data:image/png;base64,${logoBase64}`;
     return { uri: base64String };
-  }, [selfApp?.logoBase64]);
+  }, [logoBase64]);
 
   const url = useMemo(() => {
-    if (!selfApp?.endpoint) {
+    if (!endpoint) {
       return null;
     }
-    return formatEndpoint(selfApp.endpoint);
-  }, [selfApp?.endpoint]);
+    return formatEndpoint(endpoint);
+  }, [endpoint]);
 
   const formattedUserId = useMemo(
-    () => formatUserId(selfApp?.userId, selfApp?.userIdType),
-    [selfApp?.userId, selfApp?.userIdType],
+    () => formatUserId(userId, userIdType),
+    [userId, userIdType],
   );
 
   const disclosureItems = useMemo(() => {
-    const disclosures = (selfApp?.disclosures as SelfAppDisclosureConfig) || {};
-    return getDisclosureItems(disclosures);
-  }, [selfApp?.disclosures]);
+    return getDisclosureItems(disclosures || {});
+  }, [disclosures]);
 
   return {
     logoSource,

--- a/app/src/screens/app/LoadingScreen.tsx
+++ b/app/src/screens/app/LoadingScreen.tsx
@@ -3,7 +3,7 @@
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
 import type LottieView from 'lottie-react-native';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { StyleSheet } from 'react-native';
 import type { StaticScreenProps } from '@react-navigation/native';
 import { useFocusEffect, useIsFocused } from '@react-navigation/native';
@@ -29,7 +29,6 @@ import LoadingUI from '@/components/LoadingUI';
 import { loadingScreenProgress } from '@/integrations/haptics';
 import { getLoadingScreenText } from '@/proving/loadingScreenStateText';
 import { setupNotifications } from '@/services/notifications/notificationService';
-import { useSettingStore } from '@/stores/settingStore';
 
 type LoadingScreenParams = {
   documentCategory?: DocumentCategory;
@@ -54,24 +53,6 @@ const LoadingScreen: React.FC<LoadingScreenProps> = ({ route }) => {
   // Track if we're initializing to show clean state
   const [isInitializing, setIsInitializing] = useState(false);
 
-  // Animation states
-  const [animationSource, setAnimationSource] = useState<
-    LottieView['props']['source']
-  >(proveLoadingAnimation);
-
-  // Loading text state
-  const [loadingText, setLoadingText] = useState<{
-    actionText: string;
-    actionSubText: string;
-    estimatedTime: string;
-    statusBarProgress: number;
-  }>({
-    actionText: '',
-    actionSubText: '',
-    estimatedTime: '',
-    statusBarProgress: 0,
-  });
-
   // Get document metadata from navigation params
   const {
     signatureAlgorithm: paramSignatureAlgorithm,
@@ -82,7 +63,6 @@ const LoadingScreen: React.FC<LoadingScreenProps> = ({ route }) => {
   // Get proving store and self client
   const selfClient = useSelfClient();
   const currentState = useProvingStore(state => state.currentState) ?? 'idle';
-  const fcmToken = useSettingStore(state => state.fcmToken);
   const init = useProvingStore(state => state.init);
   const circuitType = useProvingStore(state => state.circuitType);
   const isFocused = useIsFocused();
@@ -95,11 +75,10 @@ const LoadingScreen: React.FC<LoadingScreenProps> = ({ route }) => {
   useEffect(() => {
     if (!isFocused) return;
 
-    setIsInitializing(true);
-
     // Always initialize when screen becomes focused, regardless of current state
     // This ensures proper reset between proving sessions
     const initializeProving = async () => {
+      setIsInitializing(true);
       try {
         const selectedDocument = await loadSelectedDocument(selfClient);
         if (
@@ -135,70 +114,50 @@ const LoadingScreen: React.FC<LoadingScreenProps> = ({ route }) => {
     };
   }, [isFocused]);
 
-  // Handle UI updates based on state changes
-  useEffect(() => {
-    // Stop haptics if screen is not focused
-    if (!isFocused) {
-      loadingScreenProgress(false);
-      return;
-    }
+  // Use clean initial state while re-initializing, otherwise the live state.
+  const displayState = (
+    isInitializing ? 'idle' : currentState
+  ) as ProvingStateType;
+  const displayCircuitType = isInitializing ? 'dsc' : circuitType || 'dsc';
+  const signatureAlgorithm =
+    paramSignatureAlgorithm && paramCurveOrExponent
+      ? paramSignatureAlgorithm
+      : 'rsa';
+  const curveOrExponent =
+    paramSignatureAlgorithm && paramCurveOrExponent
+      ? paramCurveOrExponent
+      : '65537';
 
-    // Use params from navigation or fallback to defaults
-    let signatureAlgorithm = 'rsa';
-    let curveOrExponent = '65537';
-
-    // Use provided params if available (only relevant for passport/id_card)
-    if (paramSignatureAlgorithm && paramCurveOrExponent) {
-      signatureAlgorithm = paramSignatureAlgorithm;
-      curveOrExponent = paramCurveOrExponent;
-    }
-
-    // Use clean initial state if we're initializing, otherwise use current state
-    const displayState = isInitializing ? 'idle' : currentState;
-    const displayCircuitType = isInitializing ? 'dsc' : circuitType || 'dsc';
-
-    const { actionText, actionSubText, estimatedTime, statusBarProgress } =
+  const loadingText = useMemo(
+    () =>
       getLoadingScreenText(
-        displayState as ProvingStateType,
+        displayState,
         signatureAlgorithm,
         curveOrExponent,
         displayCircuitType,
-      );
-    setLoadingText({
-      actionText,
-      actionSubText,
-      estimatedTime,
-      statusBarProgress,
-    });
+      ),
+    [displayState, signatureAlgorithm, curveOrExponent, displayCircuitType],
+  );
 
-    // Update animation based on state (use clean state if initializing)
-    const animationState = isInitializing ? 'idle' : currentState;
-    switch (animationState) {
-      case 'completed':
-        // setAnimationSource(successAnimation);
-        break;
+  const animationSource = useMemo<LottieView['props']['source']>(() => {
+    switch (displayState) {
       case 'error':
       case 'failure':
       case 'passport_not_supported':
-        setAnimationSource(failAnimation);
-        break;
       case 'account_recovery_choice':
       case 'passport_data_not_found':
-        setAnimationSource(failAnimation);
-        break;
+        return failAnimation;
       default:
-        setAnimationSource(proveLoadingAnimation);
-        break;
+        return proveLoadingAnimation;
     }
-  }, [
-    currentState,
-    fcmToken,
-    isInitializing,
-    circuitType,
-    paramCurveOrExponent,
-    paramSignatureAlgorithm,
-    isFocused,
-  ]);
+  }, [displayState]);
+
+  // Stop haptics when the screen loses focus while still mounted.
+  useEffect(() => {
+    if (!isFocused) {
+      loadingScreenProgress(false);
+    }
+  }, [isFocused]);
 
   // Handle haptic feedback using useFocusEffect for immediate response
   useFocusEffect(

--- a/app/src/screens/dev/CreateMockScreenDeepLink.tsx
+++ b/app/src/screens/dev/CreateMockScreenDeepLink.tsx
@@ -3,7 +3,7 @@
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
 import { flag } from 'country-emoji';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { ActivityIndicator, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { ScrollView, Text, XStack, YStack } from 'tamagui';
@@ -36,8 +36,6 @@ const CreateMockScreenDeepLink: React.FC = () => {
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
 
-  const [selectedCountry, setSelectedCountry] = useState('USA');
-
   const {
     deepLinkName,
     deepLinkSurname,
@@ -51,6 +49,8 @@ const CreateMockScreenDeepLink: React.FC = () => {
     deepLinkBirthDate: state.deepLinkBirthDate,
     deepLinkGender: state.deepLinkGender,
   }));
+
+  const selectedCountry = deepLinkNationality || 'USA';
 
   const handleGenerate = useCallback(async () => {
     const storeState = useUserStore.getState();
@@ -67,12 +67,6 @@ const CreateMockScreenDeepLink: React.FC = () => {
     navigation.navigate('ConfirmBelonging', {});
     useUserStore.getState().clearDeepLinkUserDetails();
   }, [navigation]);
-
-  useEffect(() => {
-    if (deepLinkNationality) {
-      setSelectedCountry(deepLinkNationality);
-    }
-  }, [deepLinkNationality]);
 
   useEffect(() => {
     if (

--- a/app/src/screens/dev/DevFeatureFlagsScreen.tsx
+++ b/app/src/screens/dev/DevFeatureFlagsScreen.tsx
@@ -49,8 +49,8 @@ const DevFeatureFlagsScreen: React.FC = () => {
 
   const loadFeatureFlags = useCallback(async () => {
     try {
-      setErrorState(null);
       const flags = await getAllFeatureFlags();
+      setErrorState(null);
       setFeatureFlags(flags);
       setLastRefresh(new Date());
 
@@ -185,7 +185,10 @@ const DevFeatureFlagsScreen: React.FC = () => {
   }, [loadFeatureFlags]);
 
   useEffect(() => {
-    loadFeatureFlags();
+    const run = async () => {
+      await loadFeatureFlags();
+    };
+    run();
   }, [loadFeatureFlags]);
 
   useEffect(() => {

--- a/app/src/screens/dev/DevLoadingScreen.tsx
+++ b/app/src/screens/dev/DevLoadingScreen.tsx
@@ -3,7 +3,7 @@
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
 import type LottieView from 'lottie-react-native';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Adapt, Button, Select, Sheet, Text, XStack, YStack } from 'tamagui';
 import { Check, ChevronDown } from '@tamagui/lucide-icons';
 
@@ -37,71 +37,45 @@ const allProvingStates = [
   'passport_data_not_found',
 ] as const;
 
+const TERMINAL_STATES: ProvingStateType[] = [
+  'completed',
+  'error',
+  'failure',
+  'passport_not_supported',
+  'account_recovery_choice',
+  'passport_data_not_found',
+];
+
+const SAFE_TO_CLOSE_STATES: ProvingStateType[] = [
+  'proving',
+  'post_proving',
+  'completed',
+];
+
 const DevLoadingScreen: React.FC = () => {
   const [currentState, setCurrentState] = useState<ProvingStateType>('idle');
   const [documentType, setDocumentType] =
     useState<provingMachineCircuitType>('dsc');
-  const [animationSource, setAnimationSource] = useState<
-    LottieView['props']['source']
-  >(proveLoadingAnimation);
-  const [loadingText, setLoadingText] = useState<{
-    actionText: string;
-    actionSubText: string;
-    estimatedTime: string;
-    statusBarProgress: number;
-  }>({
-    actionText: '',
-    actionSubText: '',
-    estimatedTime: '',
-    statusBarProgress: 0,
-  });
-  const [canCloseApp, setCanCloseApp] = useState(false);
-  const [shouldLoopAnimation, setShouldLoopAnimation] = useState(true);
-
-  const terminalStates = useMemo<ProvingStateType[]>(
-    () => [
-      'completed',
-      'error',
-      'failure',
-      'passport_not_supported',
-      'account_recovery_choice',
-      'passport_data_not_found',
-    ],
-    [],
+  const loadingText = useMemo(
+    () => getLoadingScreenText(currentState, 'rsa', '65537', documentType),
+    [currentState, documentType],
   );
 
-  const safeToCloseStates = useMemo<ProvingStateType[]>(
-    () => ['proving', 'post_proving', 'completed'],
-    [],
-  );
-
-  useEffect(() => {
-    const { actionText, actionSubText, estimatedTime, statusBarProgress } =
-      getLoadingScreenText(currentState, 'rsa', '65537', documentType);
-    setLoadingText({
-      actionText,
-      actionSubText,
-      estimatedTime,
-      statusBarProgress,
-    });
-
+  const animationSource = useMemo<LottieView['props']['source']>(() => {
     switch (currentState) {
-      case 'completed':
-        break;
       case 'error':
       case 'failure':
       case 'passport_not_supported':
       case 'account_recovery_choice':
       case 'passport_data_not_found':
-        setAnimationSource(failAnimation);
-        break;
+        return failAnimation;
       default:
-        setAnimationSource(proveLoadingAnimation);
-        break;
+        return proveLoadingAnimation;
     }
-    setCanCloseApp(safeToCloseStates.includes(currentState));
-    setShouldLoopAnimation(!terminalStates.includes(currentState));
-  }, [currentState, documentType, safeToCloseStates, terminalStates]);
+  }, [currentState]);
+
+  const canCloseApp = SAFE_TO_CLOSE_STATES.includes(currentState);
+  const shouldLoopAnimation = !TERMINAL_STATES.includes(currentState);
 
   const [open, setOpen] = useState(false);
   const [documentTypeOpen, setDocumentTypeOpen] = useState(false);

--- a/app/src/screens/dev/hooks/useNotificationHandlers.ts
+++ b/app/src/screens/dev/hooks/useNotificationHandlers.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Alert, AppState } from 'react-native';
 
 import {
@@ -18,23 +18,29 @@ export const useNotificationHandlers = () => {
   const [hasNotificationPermission, setHasNotificationPermission] =
     useState(false);
 
-  const checkPermissions = useCallback(async () => {
-    const readiness = await isNotificationSystemReady();
-    setHasNotificationPermission(readiness.ready);
-  }, []);
-
   // Check notification permissions on mount and when app regains focus
   useEffect(() => {
-    checkPermissions();
+    let active = true;
+    const syncPermission = async () => {
+      const readiness = await isNotificationSystemReady();
+      if (active) {
+        setHasNotificationPermission(readiness.ready);
+      }
+    };
+
+    syncPermission();
 
     const subscription = AppState.addEventListener('change', nextAppState => {
       if (nextAppState === 'active') {
-        checkPermissions();
+        syncPermission();
       }
     });
 
-    return () => subscription.remove();
-  }, [checkPermissions]);
+    return () => {
+      active = false;
+      subscription.remove();
+    };
+  }, []);
 
   const handleTopicToggle = async (topics: string[], topicLabel: string) => {
     // Check permissions first

--- a/app/src/screens/documents/management/ManageDocumentsScreen.tsx
+++ b/app/src/screens/documents/management/ManageDocumentsScreen.tsx
@@ -53,7 +53,6 @@ const PassportDataSelector = () => {
   const [loading, setLoading] = useState(true);
 
   const loadPassportDataInfo = useCallback(async () => {
-    setLoading(true);
     const catalog = await loadDocumentCatalog();
     const docs = await getAllDocuments();
     setDocumentCatalog(catalog);
@@ -74,7 +73,10 @@ const PassportDataSelector = () => {
   ]);
 
   useEffect(() => {
-    loadPassportDataInfo();
+    const run = async () => {
+      await loadPassportDataInfo();
+    };
+    run();
   }, [loadPassportDataInfo]);
 
   const handleDocumentSelection = async (

--- a/app/src/screens/documents/scanning/DocumentCameraScreen.tsx
+++ b/app/src/screens/documents/scanning/DocumentCameraScreen.tsx
@@ -64,7 +64,8 @@ const DocumentCameraScreen: React.FC = () => {
   });
 
   // Add a ref to track when the camera screen is mounted
-  const scanStartTimeRef = useRef(Date.now());
+  const [scanStartTime] = useState(() => Date.now());
+  const scanStartTimeRef = useRef(scanStartTime);
   const { onPassportRead } = useReadMRZ(scanStartTimeRef);
 
   useEffect(() => {

--- a/app/src/screens/documents/scanning/DocumentNFCScanScreen.tsx
+++ b/app/src/screens/documents/scanning/DocumentNFCScanScreen.tsx
@@ -143,15 +143,15 @@ const DocumentNFCScanScreen: React.FC = () => {
   const [nfcMessage, setNfcMessage] = useState<string | null>(null);
   const scanTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const scanCancelledRef = useRef(false);
-  const sessionIdRef = useRef(uuidv4());
+  const [sessionId] = useState(() => uuidv4());
 
   const baseContext = useMemo(
     () => ({
-      sessionId: sessionIdRef.current,
+      sessionId,
       platform: Platform.OS as 'ios' | 'android',
       scanType: (route.params?.useCan ? 'can' : 'mrz') as 'mrz' | 'can',
     }),
-    [route.params?.useCan],
+    [route.params?.useCan, sessionId],
   );
 
   const animationRef = useRef<LottieView>(null);
@@ -377,7 +377,7 @@ const DocumentNFCScanScreen: React.FC = () => {
           skipCA,
           extendedMode,
           usePacePolling: isPacePolling,
-          sessionId: sessionIdRef.current,
+          sessionId,
           skipReselect,
         });
 
@@ -508,6 +508,7 @@ const DocumentNFCScanScreen: React.FC = () => {
     navigation,
     openErrorModal,
     selfClient,
+    sessionId,
     shouldInjectError,
   ]);
 

--- a/app/src/screens/home/HomeScreen.tsx
+++ b/app/src/screens/home/HomeScreen.tsx
@@ -113,27 +113,29 @@ const HomeScreen: React.FC = () => {
     | undefined;
   const [shouldTriggerReferralTest, setShouldTriggerReferralTest] =
     useState(false);
+  const [referralParamSeen, setReferralParamSeen] = useState(false);
 
-  // Watch for testReferralFlow param and trigger once
-  useEffect(() => {
-    if (routeParams?.testReferralFlow && isFocused) {
-      setShouldTriggerReferralTest(true);
-      // Clear the param
-      navigation.setParams({ testReferralFlow: undefined } as never);
-    }
-  }, [routeParams?.testReferralFlow, isFocused, navigation]);
+  const referralParamActive =
+    Boolean(routeParams?.testReferralFlow) && isFocused;
+
+  // Latch the dev trigger on the rising edge of the one-shot nav param.
+  if (referralParamActive && !referralParamSeen) {
+    setReferralParamSeen(true);
+    setShouldTriggerReferralTest(true);
+  } else if (!referralParamActive && referralParamSeen) {
+    setReferralParamSeen(false);
+  }
 
   useTestReferralFlow(shouldTriggerReferralTest);
 
-  // Reset trigger flag after hook processes it
   useEffect(() => {
-    if (shouldTriggerReferralTest) {
-      const timer = setTimeout(() => {
-        setShouldTriggerReferralTest(false);
-      }, 3500); // Slightly longer than the 3 second timer in the hook
-      return () => clearTimeout(timer);
-    }
-  }, [shouldTriggerReferralTest]);
+    if (!shouldTriggerReferralTest) return;
+    navigation.setParams({ testReferralFlow: undefined } as never);
+    const timer = setTimeout(() => {
+      setShouldTriggerReferralTest(false);
+    }, 3500); // Slightly longer than the 3 second timer in the hook
+    return () => clearTimeout(timer);
+  }, [shouldTriggerReferralTest, navigation]);
 
   const loadDocuments = useCallback(async () => {
     setLoading(true);

--- a/app/src/screens/home/ProofHistoryList.tsx
+++ b/app/src/screens/home/ProofHistoryList.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import {
   ActivityIndicator,
   RefreshControl,
@@ -29,6 +29,7 @@ import {
 } from '@selfxyz/mobile-sdk-alpha/constants/colors';
 import { dinot, plexMono } from '@selfxyz/mobile-sdk-alpha/constants/fonts';
 
+import { usePullToRefresh } from '@/hooks/usePullToRefresh';
 import type { RootStackParamList } from '@/navigation';
 import { useProofHistoryStore } from '@/stores/proofHistoryStore';
 import type { ProofHistory } from '@/stores/proofTypes';
@@ -70,19 +71,18 @@ export const ProofHistoryList: React.FC<ProofHistoryListProps> = ({
     initDatabase,
     hasMore,
   } = useProofHistoryStore();
-  const [refreshing, setRefreshing] = useState(false);
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+
+  const refreshHistory = useCallback(async () => {
+    resetHistory();
+    await loadMoreHistory();
+  }, [resetHistory, loadMoreHistory]);
+  const { refreshing, onRefresh } = usePullToRefresh(refreshHistory);
 
   useEffect(() => {
     initDatabase();
   }, [initDatabase]);
-
-  useEffect(() => {
-    if (!isLoading && refreshing) {
-      setRefreshing(false);
-    }
-  }, [isLoading, refreshing]);
 
   const formatDate = (timestamp: number) => {
     return new Date(timestamp).toLocaleTimeString([], {
@@ -342,12 +342,6 @@ export const ProofHistoryList: React.FC<ProofHistoryListProps> = ({
     },
     [],
   );
-
-  const onRefresh = useCallback(() => {
-    setRefreshing(true);
-    resetHistory();
-    loadMoreHistory();
-  }, [resetHistory, loadMoreHistory]);
 
   const keyExtractor = useCallback((item: ProofHistory) => item.sessionId, []);
 

--- a/app/src/screens/home/ProofHistoryScreen.tsx
+++ b/app/src/screens/home/ProofHistoryScreen.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import {
   ActivityIndicator,
   RefreshControl,
@@ -29,6 +29,7 @@ import {
 } from '@selfxyz/mobile-sdk-alpha/constants/colors';
 import { dinot } from '@selfxyz/mobile-sdk-alpha/constants/fonts';
 
+import { usePullToRefresh } from '@/hooks/usePullToRefresh';
 import type { RootStackParamList } from '@/navigation';
 import { useProofHistoryStore } from '@/stores/proofHistoryStore';
 import type { ProofHistory } from '@/stores/proofTypes';
@@ -59,20 +60,19 @@ const ProofHistoryScreen: React.FC = () => {
     initDatabase,
     hasMore,
   } = useProofHistoryStore();
-  const [refreshing, setRefreshing] = useState(false);
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const { bottom } = useSafeAreaInsets();
 
+  const refreshHistory = useCallback(async () => {
+    resetHistory();
+    await loadMoreHistory();
+  }, [resetHistory, loadMoreHistory]);
+  const { refreshing, onRefresh } = usePullToRefresh(refreshHistory);
+
   useEffect(() => {
     initDatabase();
   }, [initDatabase]);
-
-  useEffect(() => {
-    if (!isLoading && refreshing) {
-      setRefreshing(false);
-    }
-  }, [isLoading, refreshing]);
 
   const formatDate = (timestamp: number) => {
     return new Date(timestamp).toLocaleTimeString([], {
@@ -334,12 +334,6 @@ const ProofHistoryScreen: React.FC = () => {
     },
     [],
   );
-
-  const onRefresh = useCallback(() => {
-    setRefreshing(true);
-    resetHistory();
-    loadMoreHistory();
-  }, [resetHistory, loadMoreHistory]);
 
   const keyExtractor = useCallback((item: ProofHistory) => item.sessionId, []);
 

--- a/app/src/screens/verification/ProofRequestStatusScreen.tsx
+++ b/app/src/screens/verification/ProofRequestStatusScreen.tsx
@@ -3,7 +3,13 @@
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
 import type { LottieViewProps } from 'lottie-react-native';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { Linking, Platform, StyleSheet, Text, View } from 'react-native';
 import { ScrollView, Spinner } from 'tamagui';
 import { useIsFocused, useNavigation } from '@react-navigation/native';
@@ -28,7 +34,9 @@ import {
 import failAnimation from '@/assets/animations/proof_failed.json';
 import succesAnimation from '@/assets/animations/proof_success.json';
 import { captureException } from '@/config/sentry';
+import { useDeeplinkRedirectCountdown } from '@/hooks/useDeeplinkRedirectCountdown';
 import useHapticNavigation from '@/hooks/useHapticNavigation';
+import { useProvingStallTimeout } from '@/hooks/useProvingStallTimeout';
 import {
   buttonTap,
   notificationError,
@@ -80,26 +88,23 @@ const SuccessScreen: React.FC = () => {
 
   const isFocused = useIsFocused();
 
-  const [animationSource, setAnimationSource] =
-    useState<LottieViewProps['source']>(loadingAnimation);
-  const [countdown, setCountdown] = useState<number | null>(null);
-  const [countdownStarted, setCountdownStarted] = useState(false);
-  const [hasTimedOut, setHasTimedOut] = useState(false);
   const [isDismissingTimedOutProof, setIsDismissingTimedOutProof] =
     useState(false);
   const [whitelistedPoints, setWhitelistedPoints] = useState<
     number | null | undefined
   >(undefined);
-  const timerRef = useRef<NodeJS.Timeout | null>(null);
-  const provingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const timedOutSessionIdRef = useRef<string | null>(null);
   const dismissingTimedOutProofRef = useRef(false);
   const timedOutAnalyticsTrackedRef = useRef(false);
 
-  const displayState = hasTimedOut ? 'failure' : currentState;
-  const displayReason = hasTimedOut
-    ? PROOF_TIMEOUT_REASON
-    : (reason ?? undefined);
+  const deeplinkCallback = selfApp?.deeplinkCallback;
+  const hasValidDeeplink = useMemo(() => {
+    if (!deeplinkCallback) return false;
+    try {
+      return Boolean(new URL(deeplinkCallback));
+    } catch {
+      return false;
+    }
+  }, [deeplinkCallback]);
 
   const onOkPress = useCallback(async () => {
     // The whitelistedPoints guard only applies to the success path — on
@@ -153,12 +158,43 @@ const SuccessScreen: React.FC = () => {
     useProvingStore,
   ]);
 
-  const clearProvingTimeout = useCallback(() => {
-    if (provingTimeoutRef.current) {
-      clearTimeout(provingTimeoutRef.current);
-      provingTimeoutRef.current = null;
+  const handleDeeplinkRedirect = useCallback(() => {
+    if (!deeplinkCallback) return;
+    Linking.openURL(deeplinkCallback).catch(err => {
+      console.error('Failed to open deep link:', err);
+      onOkPress();
+    });
+  }, [deeplinkCallback, onOkPress]);
+
+  const { hasTimedOut, timedOutSessionId } = useProvingStallTimeout({
+    currentState,
+    isFocused,
+    sessionId,
+    stallStates: STALL_TIMEOUT_STATES,
+    timeoutMs: PROVING_STALL_TIMEOUT_MS,
+  });
+
+  const { countdown, cancel: cancelCountdown } = useDeeplinkRedirectCountdown({
+    seconds: 5,
+    shouldStart: currentState === 'completed' && hasValidDeeplink,
+    isFocused,
+    resetKey: sessionId,
+    onRedirect: handleDeeplinkRedirect,
+  });
+
+  const displayState = hasTimedOut ? 'failure' : currentState;
+  const displayReason = hasTimedOut
+    ? PROOF_TIMEOUT_REASON
+    : (reason ?? undefined);
+
+  const animationSource = useMemo<LottieViewProps['source']>(() => {
+    if (hasTimedOut) return failAnimation;
+    if (currentState === 'completed') return succesAnimation;
+    if (currentState === 'failure' || currentState === 'error') {
+      return failAnimation;
     }
-  }, []);
+    return loadingAnimation;
+  }, [hasTimedOut, currentState]);
 
   const onTimedOutDismiss = useCallback(async () => {
     if (dismissingTimedOutProofRef.current) {
@@ -177,7 +213,7 @@ const SuccessScreen: React.FC = () => {
         {
           module: 'proof-request-status-screen',
           action: 'dismiss_timed_out_proof',
-          sessionId: timedOutSessionIdRef.current,
+          sessionId: timedOutSessionId,
         },
       );
     } finally {
@@ -186,36 +222,20 @@ const SuccessScreen: React.FC = () => {
       selfClient.getSelfAppState().cleanSelfApp();
       goHome();
     }
-  }, [goHome, selfClient, useProvingStore]);
-
-  function cancelDeeplinkCallbackRedirect() {
-    setCountdown(null);
-  }
-
-  function cancelCountdown() {
-    if (timerRef.current) {
-      clearTimeout(timerRef.current);
-      timerRef.current = null;
-    }
-    setCountdown(null);
-  }
+  }, [goHome, selfClient, timedOutSessionId, useProvingStore]);
 
   useEffect(() => {
-    setHasTimedOut(false);
     timedOutAnalyticsTrackedRef.current = false;
-    setCountdownStarted(false);
-    setCountdown(null);
   }, [sessionId]);
 
   useEffect(() => {
     if (currentState !== 'completed') return;
 
-    if (!selfApp?.endpoint) {
-      setWhitelistedPoints(null);
-      return;
-    }
-
     const checkWhitelist = async () => {
+      if (!selfApp?.endpoint) {
+        setWhitelistedPoints(null);
+        return;
+      }
       try {
         const whitelistedContracts = await getWhiteListedDisclosureAddresses();
         const endpoint = selfApp.endpoint.toLowerCase();
@@ -236,8 +256,6 @@ const SuccessScreen: React.FC = () => {
 
   useEffect(() => {
     if (hasTimedOut) {
-      setAnimationSource(failAnimation);
-
       if (!timedOutAnalyticsTrackedRef.current) {
         timedOutAnalyticsTrackedRef.current = true;
         notificationError();
@@ -256,28 +274,12 @@ const SuccessScreen: React.FC = () => {
     } else if (currentState === 'completed') {
       timedOutAnalyticsTrackedRef.current = false;
       notificationSuccess();
-      setAnimationSource(succesAnimation);
       if (sessionId) {
         updateProofStatus(sessionId, ProofStatus.SUCCESS);
-      }
-
-      if (isFocused && !countdownStarted && selfApp?.deeplinkCallback) {
-        try {
-          const url = new URL(selfApp.deeplinkCallback);
-          if (url) {
-            setCountdown(5);
-            setCountdownStarted(true);
-          }
-        } catch {
-          console.warn(
-            'Invalid deep link URL provided (URL sanitized for security)',
-          );
-        }
       }
     } else if (currentState === 'failure' || currentState === 'error') {
       timedOutAnalyticsTrackedRef.current = false;
       notificationError();
-      setAnimationSource(failAnimation);
       if (sessionId) {
         updateProofStatus(
           sessionId,
@@ -288,74 +290,15 @@ const SuccessScreen: React.FC = () => {
       }
     } else {
       timedOutAnalyticsTrackedRef.current = false;
-      setAnimationSource(loadingAnimation);
     }
   }, [
     hasTimedOut,
     currentState,
-    isFocused,
-    appName,
     sessionId,
     errorCode,
     reason,
     updateProofStatus,
-    selfApp?.deeplinkCallback,
-    countdownStarted,
   ]);
-
-  useEffect(() => {
-    if (hasTimedOut) {
-      clearProvingTimeout();
-      return;
-    }
-
-    if (!isFocused || !STALL_TIMEOUT_STATES.has(currentState)) {
-      clearProvingTimeout();
-      return;
-    }
-
-    clearProvingTimeout();
-    provingTimeoutRef.current = setTimeout(() => {
-      timedOutSessionIdRef.current = sessionId;
-      setHasTimedOut(true);
-    }, PROVING_STALL_TIMEOUT_MS);
-
-    return () => {
-      clearProvingTimeout();
-    };
-  }, [clearProvingTimeout, currentState, hasTimedOut, isFocused, sessionId]);
-
-  useEffect(() => {
-    if (countdown === null) return;
-    if (countdown > 0) {
-      timerRef.current = setTimeout(() => {
-        setCountdown(prev => (prev !== null ? prev - 1 : null));
-      }, 1000);
-      return () => {
-        if (timerRef.current) {
-          clearTimeout(timerRef.current);
-        }
-      };
-    } else {
-      setCountdown(null);
-      if (selfApp?.deeplinkCallback) {
-        Linking.openURL(selfApp.deeplinkCallback).catch(err => {
-          console.error('Failed to open deep link:', err);
-          onOkPress();
-        });
-      }
-    }
-  }, [countdown, selfApp?.deeplinkCallback, onOkPress]);
-
-  useEffect(() => {
-    if (!isFocused) {
-      cancelCountdown();
-    }
-    return () => {
-      cancelCountdown();
-      clearProvingTimeout();
-    };
-  }, [clearProvingTimeout, isFocused]);
 
   return (
     <ExpandableBottomLayout.Layout backgroundColor={white}>
@@ -416,7 +359,7 @@ const SuccessScreen: React.FC = () => {
             hasTimedOut
               ? onTimedOutDismiss
               : countdown !== null && countdown > 0
-                ? cancelDeeplinkCallbackRedirect
+                ? cancelCountdown
                 : onOkPress
           }
         >

--- a/app/src/screens/verification/ProveScreen.tsx
+++ b/app/src/screens/verification/ProveScreen.tsx
@@ -81,6 +81,8 @@ const ProveScreen: React.FC = () => {
   const [hasScrolledToBottom, setHasScrolledToBottom] = useState(false);
   const [scrollViewContentHeight, setScrollViewContentHeight] = useState(0);
   const [scrollViewHeight, setScrollViewHeight] = useState(0);
+  const scrollViewContentHeightRef = useRef(0);
+  const scrollViewHeightRef = useRef(0);
   const [isDocumentExpired, setIsDocumentExpired] = useState(false);
   const [documentType, setDocumentType] = useState('');
   const [walletModalOpen, setWalletModalOpen] = useState(false);
@@ -108,16 +110,17 @@ const ProveScreen: React.FC = () => {
   // Use window dimensions for dynamic scroll offset padding
   // This scales with viewport height rather than using hardcoded platform values
   const { height: windowHeight } = useWindowDimensions();
+  const routeScrollOffset = route.params?.scrollOffset;
 
   const initialScrollOffset = useMemo(() => {
-    if (route.params?.scrollOffset === undefined) {
+    if (routeScrollOffset === undefined) {
       return undefined;
     }
     // Use ~1.5% of window height as padding to account for minor layout differences
     // This scales appropriately across different device sizes
     const padding = windowHeight * 0.01;
-    return route.params.scrollOffset + padding;
-  }, [route.params?.scrollOffset, windowHeight]);
+    return routeScrollOffset + padding;
+  }, [routeScrollOffset, windowHeight]);
 
   const { addProofHistory } = useProofHistoryStore();
   const { loadDocumentCatalog } = usePassport();
@@ -214,34 +217,26 @@ const ProveScreen: React.FC = () => {
     hasCheckedForInactiveDocument,
   ]);
 
-  useEffect(() => {
-    if (!hasCheckedForInactiveDocument) {
-      return;
-    }
+  const initializeScrollStateIfReady = useCallback(
+    (contentHeight: number, layoutHeight: number) => {
+      if (
+        !hasCheckedForInactiveDocument ||
+        hasInitializedScrollStateRef.current ||
+        contentHeight <= 0 ||
+        layoutHeight <= 0
+      ) {
+        return;
+      }
 
-    // Wait for actual measurements before determining initial scroll state
-    // Both start at 0, causing false-positive on first render
-    const hasMeasurements = scrollViewContentHeight > 0 && scrollViewHeight > 0;
+      // Only auto-enable if content is short enough that no scrolling is needed.
+      if (contentHeight <= layoutHeight + 50) {
+        setHasScrolledToBottom(true);
+      }
 
-    if (!hasMeasurements || hasInitializedScrollStateRef.current) {
-      return;
-    }
-
-    // Only auto-enable if content is short enough that no scrolling is needed
-    if (isContentShorterThanScrollView) {
-      setHasScrolledToBottom(true);
-    }
-    // If content is long, leave hasScrolledToBottom as false (require scroll)
-    // Don't explicitly set to false to avoid resetting user's scroll progress
-
-    // Mark as initialized so we don't override user's scroll state later
-    hasInitializedScrollStateRef.current = true;
-  }, [
-    isContentShorterThanScrollView,
-    scrollViewContentHeight,
-    scrollViewHeight,
-    hasCheckedForInactiveDocument,
-  ]);
+      hasInitializedScrollStateRef.current = true;
+    },
+    [hasCheckedForInactiveDocument],
+  );
 
   useEffect(() => {
     if (!isFocused || !selectedApp || !hasCheckedForInactiveDocument) {
@@ -257,9 +252,10 @@ const ProveScreen: React.FC = () => {
       // Use setTimeout(0) to ensure we read values AFTER React processes the reset,
       // without adding measurements to dependencies (which causes race conditions).
       setTimeout(() => {
-        const hasMeasurements =
-          scrollViewContentHeight > 0 && scrollViewHeight > 0;
-        const isShort = scrollViewContentHeight <= scrollViewHeight + 50;
+        const contentHeight = scrollViewContentHeightRef.current;
+        const layoutHeight = scrollViewHeightRef.current;
+        const hasMeasurements = contentHeight > 0 && layoutHeight > 0;
+        const isShort = contentHeight <= layoutHeight + 50;
 
         if (hasMeasurements && isShort) {
           setHasScrolledToBottom(true);
@@ -427,15 +423,25 @@ const ProveScreen: React.FC = () => {
 
   const handleContentSizeChange = useCallback(
     (contentWidth: number, contentHeight: number) => {
+      scrollViewContentHeightRef.current = contentHeight;
       setScrollViewContentHeight(contentHeight);
+      initializeScrollStateIfReady(contentHeight, scrollViewHeightRef.current);
     },
-    [],
+    [initializeScrollStateIfReady],
   );
 
-  const handleScrollViewLayout = useCallback((event: LayoutChangeEvent) => {
-    const layoutHeight = event.nativeEvent.layout.height;
-    setScrollViewHeight(layoutHeight);
-  }, []);
+  const handleScrollViewLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      const layoutHeight = event.nativeEvent.layout.height;
+      scrollViewHeightRef.current = layoutHeight;
+      setScrollViewHeight(layoutHeight);
+      initializeScrollStateIfReady(
+        scrollViewContentHeightRef.current,
+        layoutHeight,
+      );
+    },
+    [initializeScrollStateIfReady],
+  );
 
   return (
     <View style={styles.container}>

--- a/app/tests/src/hooks/useDeeplinkRedirectCountdown.test.ts
+++ b/app/tests/src/hooks/useDeeplinkRedirectCountdown.test.ts
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { act, renderHook } from '@testing-library/react-native';
+
+import { useDeeplinkRedirectCountdown } from '@/hooks/useDeeplinkRedirectCountdown';
+
+const params = (
+  overrides: Partial<Parameters<typeof useDeeplinkRedirectCountdown>[0]> = {},
+) => ({
+  seconds: 5,
+  shouldStart: true,
+  isFocused: true,
+  resetKey: 'session-1',
+  onRedirect: jest.fn(),
+  ...overrides,
+});
+
+// Each tick is only scheduled after the previous one re-renders, so advance
+// the clock one second at a time to drive the chain deterministically.
+const tickSeconds = (n: number) => {
+  for (let i = 0; i < n; i++) {
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+  }
+};
+
+describe('useDeeplinkRedirectCountdown', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('does not start until shouldStart is met', () => {
+    const { result } = renderHook(p => useDeeplinkRedirectCountdown(p), {
+      initialProps: params({ shouldStart: false }),
+    });
+    expect(result.current.countdown).toBeNull();
+  });
+
+  it('starts at the configured seconds when conditions are met', () => {
+    const { result } = renderHook(p => useDeeplinkRedirectCountdown(p), {
+      initialProps: params(),
+    });
+    expect(result.current.countdown).toBe(5);
+  });
+
+  it('counts down one per second', () => {
+    const { result } = renderHook(p => useDeeplinkRedirectCountdown(p), {
+      initialProps: params(),
+    });
+    tickSeconds(1);
+    expect(result.current.countdown).toBe(4);
+    tickSeconds(2);
+    expect(result.current.countdown).toBe(2);
+  });
+
+  it('fires onRedirect exactly once when it reaches zero', () => {
+    const onRedirect = jest.fn();
+    const { result } = renderHook(p => useDeeplinkRedirectCountdown(p), {
+      initialProps: params({ onRedirect }),
+    });
+    tickSeconds(5);
+    expect(result.current.countdown).toBe(0);
+    expect(onRedirect).toHaveBeenCalledTimes(1);
+
+    tickSeconds(5);
+    expect(onRedirect).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancel() stops the countdown and prevents redirect', () => {
+    const onRedirect = jest.fn();
+    const { result } = renderHook(p => useDeeplinkRedirectCountdown(p), {
+      initialProps: params({ onRedirect }),
+    });
+    tickSeconds(2);
+    act(() => {
+      result.current.cancel();
+    });
+    expect(result.current.countdown).toBeNull();
+    tickSeconds(10);
+    expect(onRedirect).not.toHaveBeenCalled();
+  });
+
+  it('hides the countdown on blur and does not auto-restart on refocus', () => {
+    const { result, rerender } = renderHook(
+      p => useDeeplinkRedirectCountdown(p),
+      { initialProps: params() },
+    );
+    expect(result.current.countdown).toBe(5);
+
+    rerender(params({ isFocused: false }));
+    expect(result.current.countdown).toBeNull();
+
+    rerender(params({ isFocused: true }));
+    expect(result.current.countdown).toBeNull();
+  });
+
+  it('restarts for a new session when resetKey changes', () => {
+    const { result, rerender } = renderHook(
+      p => useDeeplinkRedirectCountdown(p),
+      { initialProps: params() },
+    );
+    tickSeconds(5);
+    expect(result.current.countdown).toBe(0);
+
+    rerender(params({ resetKey: 'session-2' }));
+    expect(result.current.countdown).toBe(5);
+  });
+});

--- a/app/tests/src/hooks/useProvingStallTimeout.test.ts
+++ b/app/tests/src/hooks/useProvingStallTimeout.test.ts
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { act, renderHook } from '@testing-library/react-native';
+
+import { useProvingStallTimeout } from '@/hooks/useProvingStallTimeout';
+
+const STALL = new Set(['proving', 'fetching_data']);
+const TIMEOUT = 90_000;
+
+const params = (
+  overrides: Partial<Parameters<typeof useProvingStallTimeout>[0]> = {},
+) => ({
+  currentState: 'proving',
+  isFocused: true,
+  sessionId: 'session-1',
+  stallStates: STALL,
+  timeoutMs: TIMEOUT,
+  ...overrides,
+});
+
+describe('useProvingStallTimeout', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('does not time out before the window elapses', () => {
+    const { result } = renderHook(p => useProvingStallTimeout(p), {
+      initialProps: params(),
+    });
+    act(() => {
+      jest.advanceTimersByTime(TIMEOUT - 1);
+    });
+    expect(result.current.hasTimedOut).toBe(false);
+  });
+
+  it('times out after the window and captures the active session id', () => {
+    const { result } = renderHook(p => useProvingStallTimeout(p), {
+      initialProps: params(),
+    });
+    act(() => {
+      jest.advanceTimersByTime(TIMEOUT);
+    });
+    expect(result.current.hasTimedOut).toBe(true);
+    expect(result.current.timedOutSessionId).toBe('session-1');
+  });
+
+  it('does not arm when the screen is unfocused', () => {
+    const { result } = renderHook(p => useProvingStallTimeout(p), {
+      initialProps: params({ isFocused: false }),
+    });
+    act(() => {
+      jest.advanceTimersByTime(TIMEOUT * 2);
+    });
+    expect(result.current.hasTimedOut).toBe(false);
+  });
+
+  it('does not arm outside of stall-prone states', () => {
+    const { result } = renderHook(p => useProvingStallTimeout(p), {
+      initialProps: params({ currentState: 'completed' }),
+    });
+    act(() => {
+      jest.advanceTimersByTime(TIMEOUT * 2);
+    });
+    expect(result.current.hasTimedOut).toBe(false);
+  });
+
+  it('restarts the window when progressing to another stall state', () => {
+    const { result, rerender } = renderHook(p => useProvingStallTimeout(p), {
+      initialProps: params({ currentState: 'fetching_data' }),
+    });
+    act(() => {
+      jest.advanceTimersByTime(TIMEOUT - 10_000);
+    });
+    expect(result.current.hasTimedOut).toBe(false);
+
+    // Progress to a different stall-prone state; the window should restart.
+    rerender(params({ currentState: 'proving' }));
+    act(() => {
+      jest.advanceTimersByTime(TIMEOUT - 10_000);
+    });
+    // Had the window not restarted, the original timer would have fired
+    // 10s after the transition (at the 90s mark from first entry).
+    expect(result.current.hasTimedOut).toBe(false);
+
+    act(() => {
+      jest.advanceTimersByTime(10_000);
+    });
+    expect(result.current.hasTimedOut).toBe(true);
+  });
+
+  it('resets the timed-out flag when the session id changes', () => {
+    const { result, rerender } = renderHook(p => useProvingStallTimeout(p), {
+      initialProps: params(),
+    });
+    act(() => {
+      jest.advanceTimersByTime(TIMEOUT);
+    });
+    expect(result.current.hasTimedOut).toBe(true);
+
+    rerender(params({ sessionId: 'session-2' }));
+    expect(result.current.hasTimedOut).toBe(false);
+  });
+
+  it('clears the pending timer on unmount', () => {
+    const { unmount } = renderHook(p => useProvingStallTimeout(p), {
+      initialProps: params(),
+    });
+    unmount();
+    expect(() => {
+      act(() => {
+        jest.advanceTimersByTime(TIMEOUT * 2);
+      });
+    }).not.toThrow();
+  });
+});

--- a/app/tests/src/hooks/usePullToRefresh.test.ts
+++ b/app/tests/src/hooks/usePullToRefresh.test.ts
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { act, renderHook } from '@testing-library/react-native';
+
+import { usePullToRefresh } from '@/hooks/usePullToRefresh';
+
+const flush = () => act(async () => {});
+
+describe('usePullToRefresh', () => {
+  it('starts not refreshing', () => {
+    const { result } = renderHook(() => usePullToRefresh(jest.fn()));
+    expect(result.current.refreshing).toBe(false);
+  });
+
+  it('shows refreshing while an async action is in flight, then clears it', async () => {
+    let resolveAction: () => void = () => {};
+    const action = jest.fn(
+      () =>
+        new Promise<void>(resolve => {
+          resolveAction = resolve;
+        }),
+    );
+    const { result } = renderHook(() => usePullToRefresh(action));
+
+    act(() => {
+      result.current.onRefresh();
+    });
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(result.current.refreshing).toBe(true);
+
+    await act(async () => {
+      resolveAction();
+    });
+    expect(result.current.refreshing).toBe(false);
+  });
+
+  it('clears refreshing for a synchronous (void) action', async () => {
+    const action = jest.fn(() => undefined);
+    const { result } = renderHook(() => usePullToRefresh(action));
+
+    act(() => {
+      result.current.onRefresh();
+    });
+    await flush();
+    expect(result.current.refreshing).toBe(false);
+  });
+
+  it('clears refreshing even when the action rejects', async () => {
+    const action = jest.fn(() => Promise.reject(new Error('boom')));
+    const { result } = renderHook(() => usePullToRefresh(action));
+
+    await act(async () => {
+      result.current.onRefresh();
+    });
+    expect(result.current.refreshing).toBe(false);
+  });
+});

--- a/app/tests/src/hooks/usePullToRefresh.test.ts
+++ b/app/tests/src/hooks/usePullToRefresh.test.ts
@@ -47,13 +47,20 @@ describe('usePullToRefresh', () => {
     expect(result.current.refreshing).toBe(false);
   });
 
-  it('clears refreshing even when the action rejects', async () => {
-    const action = jest.fn(() => Promise.reject(new Error('boom')));
+  it('clears refreshing and logs when the action rejects', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const error = new Error('boom');
+    const action = jest.fn(() => Promise.reject(error));
     const { result } = renderHook(() => usePullToRefresh(action));
 
     await act(async () => {
       result.current.onRefresh();
     });
     expect(result.current.refreshing).toBe(false);
+    expect(warn).toHaveBeenCalledWith(
+      'usePullToRefresh: refresh action failed',
+      error,
+    );
+    warn.mockRestore();
   });
 });

--- a/app/tests/src/providers/passportDataProvider.test.tsx
+++ b/app/tests/src/providers/passportDataProvider.test.tsx
@@ -70,17 +70,11 @@ const MockText = ({
 // Test component that uses the passport hook and extracts context values
 const TestComponent = () => {
   const passportContext = usePassport();
-  const [contextValues, setContextValues] = useState<string[]>([]);
-
-  useEffect(() => {
-    // Extract function names from context to verify they exist
-    const functionNames = Object.keys(passportContext).filter(
-      key =>
-        typeof passportContext[key as keyof typeof passportContext] ===
-        'function',
-    );
-    setContextValues(functionNames);
-  }, [passportContext]);
+  const contextValues = Object.keys(passportContext).filter(
+    key =>
+      typeof passportContext[key as keyof typeof passportContext] ===
+      'function',
+  );
 
   return (
     <>

--- a/specs/topics/RN-UPGRADE-FOLLOWUPS.md
+++ b/specs/topics/RN-UPGRADE-FOLLOWUPS.md
@@ -4,13 +4,31 @@ _Created: 2026-05-24, alongside the RN 0.77 → 0.83 / Expo SDK 52 → 55 / Reac
 
 Tracks deferred work surfaced during PR review of `justin/upgrade-react-native-phase1` that did **not** block merging the upgrade but needs explicit ownership and acceptance criteria so it isn't lost.
 
-This is a topic-level umbrella doc. Each item below should become a Linear issue (and, for SDK-touching work, a workstream-level spec under `specs/projects/sdk/workstreams/<scope>/`) before implementation. Mark items `Done` and link the PR/issue when shipped; never remove rows, since the historical context is the point.
+This is a topic-level umbrella doc. SDK-touching items still need a workstream-level spec under `specs/projects/sdk/workstreams/<scope>/` before implementation. App-only chore/cleanup items (lint, test infra, mock drift, docs) ship directly from this doc — see the PR breakdown below — and skip Linear since branch naming + this umbrella provide traceability. Mark items `Done` and link the PR when shipped; never remove rows, since the historical context is the point.
 
 ## Related context
 
 - [React Native Upgrade Plan](./RN-UPGRADE-PLAN.md) — narrative plan for the multi-phase upgrade
 - [RN Upgrade Checklist](./RN-UPGRADE-CHECKLIST.md) — version tracker, gate decisions
 - [Fabric View Managers](./RN-UPGRADE-FABRIC-VIEW-MANAGERS.md) — Android Fabric migration; iOS Paper exception documented at the bottom
+
+## PR breakdown
+
+These follow-ups ship as **4 PRs total**, grouped to keep each within the 1k–3k LOC target and avoid mixing semantically unrelated concerns. Linear issues are skipped for this work — the umbrella doc + branch naming (`justin/rn-0_83-upgrade-follow-up-rd*`) provide sufficient traceability for chore/cleanup work per CLAUDE.md's "app-only work" carve-out.
+
+| PR  | Branch                                 | Scope                                                      | Items                 | Est. LOC               |
+| --- | -------------------------------------- | ---------------------------------------------------------- | --------------------- | ---------------------- |
+| 1   | `rn-0_83-upgrade-follow-up-rd1`        | `react-hooks/set-state-in-effect` cleanup (18 sites)       | Item 6 PR A           | 500–1500               |
+| 2   | `rn-0_83-upgrade-follow-up-rd2`        | React Compiler bailouts + mock-drift + test-pattern + docs | Items 6 PR B, 3, 4, 5 | 500–1000               |
+| 3   | _separate analytics workstream branch_ | KYC Path A/B event-ordering audit                          | Item 2                | TBD per analytics spec |
+| 4   | _Phase 2 gate (RN 0.85.x)_             | iOS PassportOCRView Fabric decision                        | Item 1                | TBD                    |
+
+**Why this split:**
+
+- **PR 1 first** — biggest signal-to-noise win (18 of 26 lint warnings), real correctness work since cascading renders are user-visible, and touches screens the 0.83 upgrade just changed (fresh context).
+- **PR 2 bundles small items** — Compiler bailouts (8 warnings), mock drift, test-pattern verification, and the docs note are all small and SDK-hygiene-adjacent. Bundling keeps churn low while staying under the size cap.
+- **PR 3 is separate** — Item 2 belongs in the analytics workstream with its own spec under `specs/projects/sdk/workstreams/analytics/`, not in the RN-upgrade follow-up stream.
+- **PR 4 is gated on Phase 2** — Item 1 is explicitly deferred until the RN 0.85.x gate; don't touch it on this branch.
 
 ## Items
 
@@ -85,6 +103,40 @@ The test passes today and CI hasn't OOMed on it, but the pattern deserves a deli
 **Acceptance criteria:**
 
 - Either the pattern is documented as supported in `app/AGENTS.md` with a rationale, or the test is refactored to the project's standard mocking pattern.
+
+### 6. React 19 / React Compiler lint cleanup
+
+**Status:** PR A in review (`rn-0_83-upgrade-follow-up-rd1`); PR B open. **Owner:** Justin. **Target:** App hygiene, post-upgrade.
+
+`yarn lint` reports 26 warnings (0 errors) after the 0.83 / React 19 upgrade, all from rules that did not exist on the prior toolchain:
+
+- 18× `react-hooks/set-state-in-effect` — `setState` called synchronously inside `useEffect` bodies (cascading renders). Hot spots include `app/src/screens/verification/ProofRequestStatusScreen.tsx`, `app/src/screens/verification/ProveScreen.tsx`, and `app/tests/src/providers/passportDataProvider.test.tsx`.
+- 3× `react-hooks/preserve-manual-memoization` — React Compiler bailouts where `useMemo` dependency arrays don't match inferred deps (e.g. `ProveScreen.tsx:112`).
+- 3× `react-hooks/refs` — ref usage that violates the new ref-purity rules.
+- 1× `react-hooks/purity`, 1× `react-hooks/immutability` — Compiler purity violations.
+
+These are warnings today but suppress real correctness signal and may become errors in a future Expo/RN bump.
+
+**Scope of follow-up — split into two PRs to stay within the 1k–3k LOC target and keep semantic groups together:**
+
+- **PR A — `set-state-in-effect` cleanup.** Per-site decision: move to an event handler, derive during render, lift to `useSyncExternalStore`, or guard with a state-equality check. Each site needs reasoning, not a blanket codemod. Pay extra attention to `ProofRequestStatusScreen` countdown cancellation and `ProveScreen` scroll-state — those are user-visible.
+- **PR B — Compiler bailouts (`preserve-manual-memoization` + `refs` + `purity` + `immutability`).** Smaller, but semantically subtler — these are Compiler opt-out signals. Fixing them re-enables auto-memoization, which can change re-render behavior. Each fix needs a before/after Compiler-status check.
+
+**PR A — what shipped (`rn-0_83-upgrade-follow-up-rd1`):** 17 of 18 `set-state-in-effect` sites resolved. Fixes by strategy:
+
+- **Derive during render** (no effect): `DevLoadingScreen` loading text/animation, `LoadingScreen` loading text/animation, `CreateMockScreenDeepLink` selected country, `passportDataProvider.test` context fns.
+- **Adjust-state-on-prop-change (prev-value during render):** `WalletAddressModal` copied reset, `HomeScreen` referral-test rising-edge latch.
+- **Shared hook (DRY):** extracted `usePullToRefresh` for the duplicated pull-to-refresh logic in `ProofHistoryList` + `ProofHistoryScreen`; async `onRefresh` clears the spinner on completion (also fixed a latent unhandled-rejection). Unit-tested.
+- **Async-load wrapper + relocated synchronous setState:** `ManageDocumentsScreen`, `DevFeatureFlagsScreen`, `useNotificationHandlers` (the last also gained an unmount-cancellation guard).
+- **Extract + unit-test timer state-machines:** `ProofRequestStatusScreen` countdown → `useDeeplinkRedirectCountdown`; 90s stall → `useProvingStallTimeout`. Animation derived via `useMemo`; analytics effect reduced to side-effects only. Both hooks unit-tested (13 tests).
+
+**Deferred from PR A:** `ProveScreen.tsx:232` (scroll-init `setHasScrolledToBottom`) is intentionally left for the in-flight ProveScreen simplification that builds on the proving-machine refactor (PR #1936). One `set-state-in-effect` warning remains in `ProveScreen` until that lands.
+
+**Acceptance criteria:**
+
+- `yarn lint` reports 0 warnings on both rule families after each PR lands. _(PR A: 0 `set-state-in-effect` warnings except the deferred `ProveScreen:232`.)_
+- No behavioral regressions in the affected screens (manual smoke + existing tests pass). _(PR A: full app suite green — 1110 tests; 21 new tests across `usePullToRefresh`, `useDeeplinkRedirectCountdown`, `useProvingStallTimeout`. Note: repo `yarn types` has 113 pre-existing `KnownEventName`/analytics-export errors unrelated to this work — count unchanged by PR A.)_
+- PR B records the Compiler optimization status (skipped → optimized) per touched component in the PR description.
 
 ### 5. (Optional) Root vs app React/RN version skew documentation
 


### PR DESCRIPTION
## Summary

- PR A of the RN 0.83 / React 19 upgrade follow-ups ([RN-UPGRADE-FOLLOWUPS.md](specs/topics/RN-UPGRADE-FOLLOWUPS.md), Item 6): resolves 17 of 18 \`react-hooks/set-state-in-effect\` warnings surfaced by the new React Compiler lint rules. These flag \`setState\` called synchronously inside effects, which causes cascading renders.
- Each site was fixed per its situation — derive during render, adjust-state-on-prop-change, async-load wrappers, or extracting timer state machines — rather than a blanket codemod. No behavioral changes intended.
- Two user-visible timer flows in \`ProofRequestStatusScreen\` (deeplink redirect countdown, 90s proving-stall timeout) were extracted into dedicated, unit-tested hooks.
- Duplicated pull-to-refresh logic across the two proof-history screens was extracted into a shared \`usePullToRefresh\` hook (also fixing a latent unhandled rejection).

## Changes

### React Native app

- **Extracted hooks** (new, unit-tested):
  - \`useDeeplinkRedirectCountdown\` — replaces the inline countdown/cancel effects in \`ProofRequestStatusScreen\`; hides on blur, restarts per session, fires redirect once at zero.
  - \`useProvingStallTimeout\` — replaces the inline 90s stall-timeout effect; arms only while focused + in a stall-prone state, captures the active session id, resets on session change.
  - \`usePullToRefresh\` — shared spinner/refresh state for \`ProofHistoryList\` and \`ProofHistoryScreen\`; async-aware, clears on completion or rejection.
- **Derived during render** (effect removed): loading text + animation source in \`LoadingScreen\` and \`DevLoadingScreen\`; selected country in \`CreateMockScreenDeepLink\`.
- **Adjust-state-on-prop-change** (prev-value compare during render): copied-state reset in \`WalletAddressModal\`; referral-test rising-edge latch in \`HomeScreen\`.
- **Async-load wrappers / relocated setState**: \`ManageDocumentsScreen\`, \`DevFeatureFlagsScreen\`, \`useNotificationHandlers\` (also added an unmount-cancellation guard).
- **Other**: \`useEarnPointsFlow\` uses a ref to break the callback-before-declaration cycle; \`useSelfAppData\` destructures \`selfApp\` fields for stable memo deps; \`ProveScreen\` scroll-state init moved into measurement callbacks via refs (one \`set-state-in-effect\` at \`ProveScreen:232\` intentionally deferred — see below).

### Tests

- Added \`useDeeplinkRedirectCountdown.test.ts\`, \`useProvingStallTimeout.test.ts\`, \`usePullToRefresh.test.ts\` (21 new tests).
- \`passportDataProvider.test.tsx\` updated to derive context values during render instead of via effect.

### Docs/specs

- Updated \`RN-UPGRADE-FOLLOWUPS.md\`: added the 4-PR breakdown, recorded what shipped in PR A, and noted the \`ProveScreen:232\` deferral.

## Test Plan

- [ ] \`cd app && yarn lint\` — 0 \`set-state-in-effect\` warnings except the deferred \`ProveScreen:232\`
- [ ] \`cd app && yarn jest:run\` — full app suite green (1110 + 21 new tests)
- [ ] Manual smoke: proof-request success/failure/timeout, deeplink redirect countdown + cancel, pull-to-refresh on both history screens, loading screen state transitions

> Note: \`ProveScreen.tsx:232\` is intentionally deferred to the in-flight ProveScreen simplification (PR #1936). PR B will handle the remaining 8 Compiler-bailout warnings (\`preserve-manual-memoization\`, \`refs\`, \`purity\`). \`yarn types\` has 113 pre-existing \`KnownEventName\`/analytics errors unrelated to this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull-to-refresh added for proof history
  * Deeplink redirect countdown with cancel support
  * Proving stall timeout detection with session tracking

* **Bug Fixes & Improvements**
  * Referral error retry now uses the latest handler
  * Improved notification permission resync on app focus
  * Various UI/behavior refinements (loading/proving flows, modals, document flows)

* **Tests**
  * Added tests covering new countdown, stall timeout, and pull-to-refresh behavior

* **Documentation**
  * RN upgrade follow-ups clarified and tracked in docs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/selfxyz/self/pull/2111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->