### PR TITLE
feat(analytics): emit KYC async verdict event (ANA-16)

### DIFF
--- a/app/src/hooks/useKycWebSocket.ts
+++ b/app/src/hooks/useKycWebSocket.ts
@@ -8,7 +8,13 @@ import { KYC_TEE_URL } from '@env';
 
 import { deserializeApplicantInfo } from '@selfxyz/common';
 import type { DocumentType, KycData } from '@selfxyz/common/utils/types';
+import {
+  sanitizeErrorMessage,
+  trackKycVerdict,
+  useSelfClient,
+} from '@selfxyz/mobile-sdk-alpha';
 
+import { KYC_PROVIDER } from '@/integrations/kyc';
 import type { ApplicantInfoSerialized } from '@/integrations/kyc/types';
 import { navigationRef } from '@/navigation';
 import { storeDocumentWithDeduplication } from '@/providers/passportDataProvider';
@@ -45,6 +51,16 @@ export function useKycWebSocket(options: UseKycWebSocketOptions = {}) {
   );
   const getPendingVerification = usePendingKycStore(
     state => state.getPendingVerification,
+  );
+  const selfClient = useSelfClient();
+
+  const verdictDurationSeconds = useCallback(
+    (sessionId: string): number | undefined => {
+      const createdAt = getPendingVerification(sessionId)?.createdAt;
+      if (!createdAt) return undefined;
+      return parseFloat(((Date.now() - createdAt) / 1000).toFixed(2));
+    },
+    [getPendingVerification],
   );
 
   const socketsRef = useRef<Map<string, Socket>>(new Map());
@@ -127,6 +143,14 @@ export function useKycWebSocket(options: UseKycWebSocketOptions = {}) {
             documentId,
           );
 
+          if (!kycData.mock) {
+            trackKycVerdict(selfClient, {
+              provider: KYC_PROVIDER,
+              outcome: 'approved',
+              duration_seconds: verdictDurationSeconds(sessionId),
+            });
+          }
+
           if (navigationRef.isReady()) {
             navigationRef.navigate('KYCVerified', { documentId });
           }
@@ -140,6 +164,12 @@ export function useKycWebSocket(options: UseKycWebSocketOptions = {}) {
             'failed',
             'Failed to store KYC data',
           );
+          trackKycVerdict(selfClient, {
+            provider: KYC_PROVIDER,
+            outcome: 'error',
+            error_code: 'store_failed',
+            duration_seconds: verdictDurationSeconds(sessionId),
+          });
           onError?.('Failed to store KYC data');
         }
 
@@ -151,6 +181,12 @@ export function useKycWebSocket(options: UseKycWebSocketOptions = {}) {
       socket.on('verification_failed', (reason: string) => {
         console.log('[KycWebSocket] Verification failed:', reason);
         updateVerificationStatus(sessionId, 'failed', reason);
+        trackKycVerdict(selfClient, {
+          provider: KYC_PROVIDER,
+          outcome: 'rejected',
+          reason: sanitizeErrorMessage(reason),
+          duration_seconds: verdictDurationSeconds(sessionId),
+        });
         onVerificationFailed?.(reason);
 
         socket.disconnect();
@@ -161,6 +197,13 @@ export function useKycWebSocket(options: UseKycWebSocketOptions = {}) {
       socket.on('error', (errorMessage: string) => {
         console.error('[KycWebSocket] Socket error:', errorMessage);
         updateVerificationStatus(sessionId, 'failed', errorMessage);
+        trackKycVerdict(selfClient, {
+          provider: KYC_PROVIDER,
+          outcome: 'error',
+          error_code: 'tee_error',
+          reason: sanitizeErrorMessage(errorMessage),
+          duration_seconds: verdictDurationSeconds(sessionId),
+        });
         onError?.(errorMessage);
 
         socket.disconnect();
@@ -179,6 +222,8 @@ export function useKycWebSocket(options: UseKycWebSocketOptions = {}) {
       addPendingVerification,
       updateVerificationStatus,
       getPendingVerification,
+      selfClient,
+      verdictDurationSeconds,
       onSuccess,
       onError,
       onVerificationFailed,

--- a/app/src/hooks/useKycWebSocket.ts
+++ b/app/src/hooks/useKycWebSocket.ts
@@ -118,14 +118,16 @@ export function useKycWebSocket(options: UseKycWebSocketOptions = {}) {
           redactSessionId(sessionId),
         );
 
+        let isMockData = false;
         try {
           const applicantInfoDeserialized = deserializeApplicantInfo(
             data.applicantInfo,
           );
+          isMockData = applicantInfoDeserialized.idNumber.startsWith('Mock');
           const kycData: KycData = {
             documentType: applicantInfoDeserialized.idType as DocumentType,
             documentCategory: 'kyc',
-            mock: applicantInfoDeserialized.idNumber.startsWith('Mock'),
+            mock: isMockData,
             signature: data.signature,
             pubkey: data.pubkey,
             serializedApplicantInfo: data.applicantInfo,
@@ -143,7 +145,7 @@ export function useKycWebSocket(options: UseKycWebSocketOptions = {}) {
             documentId,
           );
 
-          if (!kycData.mock) {
+          if (!isMockData) {
             trackKycVerdict(selfClient, {
               provider: KYC_PROVIDER,
               outcome: 'approved',
@@ -164,12 +166,14 @@ export function useKycWebSocket(options: UseKycWebSocketOptions = {}) {
             'failed',
             'Failed to store KYC data',
           );
-          trackKycVerdict(selfClient, {
-            provider: KYC_PROVIDER,
-            outcome: 'error',
-            error_code: 'store_failed',
-            duration_seconds: verdictDurationSeconds(sessionId),
-          });
+          if (!isMockData) {
+            trackKycVerdict(selfClient, {
+              provider: KYC_PROVIDER,
+              outcome: 'error',
+              error_code: 'store_failed',
+              duration_seconds: verdictDurationSeconds(sessionId),
+            });
+          }
           onError?.('Failed to store KYC data');
         }
 

--- a/packages/mobile-sdk-alpha/src/analytics/onboardingFunnel.ts
+++ b/packages/mobile-sdk-alpha/src/analytics/onboardingFunnel.ts
@@ -3,7 +3,7 @@
 // NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
 
 import type { KnownEventName } from '../constants/analytics';
-import { OnboardingEvents } from '../constants/analytics';
+import { KycEvents, OnboardingEvents } from '../constants/analytics';
 import type { SelfClient } from '../types/public';
 
 export type OnboardingBranch = 'biometric_passport' | 'biometric_id' | 'kyc' | 'aadhaar' | 'pending';
@@ -201,6 +201,14 @@ export function trackBranchEvent(
   selfClient.trackEvent(event, {
     ...properties,
     ...baseProperties(currentAttempt),
+  });
+}
+
+export function trackKycVerdict(selfClient: Pick<SelfClient, 'trackEvent'>, properties: Record<string, unknown>): void {
+  if (currentAttempt?.isMock) return;
+  selfClient.trackEvent(KycEvents.VERIFICATION_RESOLVED, {
+    ...properties,
+    ...(currentAttempt ? baseProperties(currentAttempt) : {}),
   });
 }
 

--- a/packages/mobile-sdk-alpha/src/constants/analytics.ts
+++ b/packages/mobile-sdk-alpha/src/constants/analytics.ts
@@ -84,6 +84,7 @@ export const KycEvents = {
   RETRY_TRIGGERED: 'KYC: Retry Triggered',
   SESSION_CREATED: 'KYC: Session Created',
   SESSION_REQUESTED: 'KYC: Session Requested',
+  VERIFICATION_RESOLVED: 'KYC: Verification Resolved',
 } as const;
 
 export const IDDataEvents = {

--- a/packages/mobile-sdk-alpha/src/index.ts
+++ b/packages/mobile-sdk-alpha/src/index.ts
@@ -147,6 +147,7 @@ export {
   resolveOnboardingBranch,
   setOnboardingBranch,
   trackBranchEvent,
+  trackKycVerdict,
   trackOnboardingRetry,
   trackOnboardingStep,
 } from './analytics/onboardingFunnel';

--- a/packages/mobile-sdk-alpha/tests/analytics/onboardingFunnel.test.ts
+++ b/packages/mobile-sdk-alpha/tests/analytics/onboardingFunnel.test.ts
@@ -10,14 +10,16 @@ import {
   completeOnboardingAttempt,
   failOnboardingAttempt,
   incrementAttemptRetryCount,
+  markCurrentAttemptAsMock,
   recoverOnboardingAttempt,
   resolveOnboardingBranch,
   setOnboardingBranch,
   trackBranchEvent,
+  trackKycVerdict,
   trackOnboardingRetry,
   trackOnboardingStep,
 } from '../../src/analytics/onboardingFunnel';
-import { BiometricEvents, OnboardingEvents } from '../../src/constants/analytics';
+import { BiometricEvents, KycEvents, OnboardingEvents } from '../../src/constants/analytics';
 
 function makeClient() {
   return { trackEvent: vi.fn() };
@@ -418,6 +420,53 @@ describe('failOnboardingAttempt', () => {
   it('is a no-op when no attempt is active', () => {
     const client = makeClient();
     failOnboardingAttempt(client, 'scan_started', 'nfc_timeout');
+    expect(client.trackEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe('trackKycVerdict', () => {
+  it('emits the verdict with the funnel triple when an attempt is active', () => {
+    const client = makeClient();
+    trackOnboardingStep(client, OnboardingEvents.SCAN_STARTED, { branch: 'kyc' });
+    client.trackEvent.mockClear();
+
+    trackKycVerdict(client, { provider: 'didit', outcome: 'approved', duration_seconds: 12.5 });
+
+    expect(client.trackEvent).toHaveBeenCalledTimes(1);
+    const [event, props] = client.trackEvent.mock.calls[0];
+    expect(event).toBe(KycEvents.VERIFICATION_RESOLVED);
+    expect(props.outcome).toBe('approved');
+    expect(props.provider).toBe('didit');
+    expect(props.current_branch).toBe('kyc');
+    expect(props.attempt_id).toBeTruthy();
+  });
+
+  it('still emits when no attempt is active, without the funnel triple', () => {
+    const client = makeClient();
+
+    trackKycVerdict(client, { provider: 'didit', outcome: 'rejected', reason: 'document_expired' });
+
+    expect(client.trackEvent).toHaveBeenCalledTimes(1);
+    const [event, props] = client.trackEvent.mock.calls[0];
+    expect(event).toBe(KycEvents.VERIFICATION_RESOLVED);
+    expect(props.outcome).toBe('rejected');
+    expect(props.attempt_id).toBeUndefined();
+    expect(props.initial_branch).toBeUndefined();
+  });
+
+  it('does not bootstrap an attempt', () => {
+    const client = makeClient();
+    trackKycVerdict(client, { provider: 'didit', outcome: 'approved' });
+    expect(_getCurrentOnboardingAttempt()).toBeNull();
+  });
+
+  it('suppresses emission for mock attempts', () => {
+    const client = makeClient();
+    markCurrentAttemptAsMock(client);
+    client.trackEvent.mockClear();
+
+    trackKycVerdict(client, { provider: 'didit', outcome: 'approved' });
+
     expect(client.trackEvent).not.toHaveBeenCalled();
   });
 });

--- a/specs/projects/sdk/workstreams/analytics/SPEC.md
+++ b/specs/projects/sdk/workstreams/analytics/SPEC.md
@@ -125,6 +125,7 @@ The branch split tells you _what happened_ (initial intent vs final outcome) but
 | ANA-13 | Observability migration — Mixpanel diet, Sentry breadcrumbs, Session Replay   | Ready       | High     | ANA-01, ANA-11, ANA-12 | [plan](./plans/ANA-13-observability-migration.md)               |
 | ANA-14 | Suppress all analytics events from mock passport flow                         | In Progress | High     | ANA-01                 | [plan](./plans/ANA-14-suppress-mock-analytics.md)               |
 | ANA-15 | Per-attempt support reference (attempt_id footer) on onboarding error screens | Ready       | Medium   | ANA-01, ANA-13         | [plan](./plans/ANA-15-attempt-id-on-error-screens.md)           |
+| ANA-16 | KYC async verdict event (provider approve/reject over websocket)              | In Review   | High     | ANA-12                 | [plan](./plans/ANA-16-kyc-verdict-event.md)                     |
 | ANA-05 | Fallback decision events and fallback-offer mini-funnel                       | Ready       | Medium   | ANA-01, ANA-12         | —                                                               |
 | ANA-08 | Explicit abandonment events on app background                                 | Ready       | Low      | ANA-01                 | —                                                               |
 | ANA-02 | Investigation: internal/TestFlight traffic filtering                          | Ready       | Medium   | —                      | —                                                               |

--- a/specs/projects/sdk/workstreams/analytics/plans/ANA-16-kyc-verdict-event.md
+++ b/specs/projects/sdk/workstreams/analytics/plans/ANA-16-kyc-verdict-event.md
@@ -1,0 +1,44 @@
+# ANA-16: KYC Async Verdict Event
+
+> Status: In Review
+> Priority: High
+> Depends on: ANA-12
+
+- Workstream: analytics
+- Backlog ID: ANA-16
+- Branch: `feat/ana-16-kyc-verdict-event`
+
+## Why
+
+`KYC: Provider Closed outcome=completed` only means the user exited the third-party provider webapp. The actual identity verdict (approve/reject) arrives later, asynchronously, over websocket in `useKycWebSocket.ts`, which today emits no analytics. So true KYC conversion (provider-completed -> backend-approved) and the real rejection rate are not measurable, and the canonical `Scan Succeeded -> Proof Started` drop for KYC silently bundles rejected / pending / abandoned users.
+
+## What
+
+Add `KycEvents.VERIFICATION_RESOLVED` (`'KYC: Verification Resolved'`) emitted from the three `useKycWebSocket` socket handlers:
+
+- `success` -> `outcome: 'approved'` (skipped when `kycData.mock`)
+- `success` store failure -> `outcome: 'error'`, `error_code: 'store_failed'`
+- `verification_failed` -> `outcome: 'rejected'`, `reason` (sanitized)
+- `error` -> `outcome: 'error'`, `error_code: 'tee_error'`, `reason` (sanitized)
+
+`duration_seconds` is provider-close-to-verdict latency, derived from the pending verification's `createdAt`. All payloads are non-PII (enum outcome, sanitized reason, provider id, latency).
+
+Emission goes through a new SDK helper `trackKycVerdict` (in `onboardingFunnel.ts`). Unlike `trackBranchEvent`, it MUST emit even with no active attempt (the verdict often lands after the attempt is cleared / app restarted), stamping the funnel triple only when an attempt is still live, and no-opping for mock attempts.
+
+## Out of scope
+
+- Provider interior steps (selfie / liveness) - black box.
+- Dashboard build - separate; the KYC funnel dashboard gets a Verification Resolved step once data lands.
+
+## Validation
+
+```bash
+cd packages/mobile-sdk-alpha && yarn test onboardingFunnel && yarn types
+cd app && yarn types
+```
+
+## Done
+
+- `VERIFICATION_RESOLVED` constant + `trackKycVerdict` helper with unit tests.
+- Emissions wired in all three `useKycWebSocket` handlers.
+- Manual check: completed KYC -> `approved`; provider rejection -> `rejected`.


### PR DESCRIPTION
## Why

`KYC: Provider Closed outcome=completed` only means the user **exited the third-party provider webapp** — not that they were verified. The actual identity verdict (approve/reject) arrives later, asynchronously, over websocket in `useKycWebSocket.ts`, which today emits **no analytics**.

Consequences surfaced while building the KYC branch dashboard:
- True KYC conversion (provider-completed → backend-approved) and the real **rejection rate** are not measurable.
- The canonical `Scan Succeeded → Proof Started` drop for `current_branch=kyc` (510 → 318 over 30d) silently bundles **rejected / still-pending / abandoned** users with no way to separate them.

## What

- New event `KycEvents.VERIFICATION_RESOLVED` (`'KYC: Verification Resolved'`), emitted from all three `useKycWebSocket` socket handlers:
  - `success` → `outcome: 'approved'` (skipped when `kycData.mock`)
  - `success` store failure → `outcome: 'error'`, `error_code: 'store_failed'`
  - `verification_failed` → `outcome: 'rejected'`, `reason` (sanitized)
  - `error` → `outcome: 'error'`, `error_code: 'tee_error'`, `reason` (sanitized)
- `duration_seconds` = provider-close-to-verdict latency, from the pending verification's `createdAt`.
- New SDK helper `trackKycVerdict` (in `onboardingFunnel.ts`). Unlike `trackBranchEvent`, it **emits even with no active attempt** — the verdict often lands after the attempt is cleared or the app restarted — stamping the funnel triple only when an attempt is still live, and no-opping for mock flows.

Payload is non-PII: enum `outcome`, sanitized `reason`, `provider` id, latency.

## Spec

`specs/projects/sdk/workstreams/analytics/plans/ANA-16-kyc-verdict-event.md` (backlog row added to the analytics `SPEC.md`).

## Test

- `packages/mobile-sdk-alpha`: 4 new `trackKycVerdict` unit tests (stamps triple when active, still emits with no attempt, does not bootstrap, suppresses mock). `yarn test onboardingFunnel` → 43 passing; `yarn types` clean.
- `app`: `yarn types` clean for the change (pre-existing unrelated errors only).

## Out of scope

- Provider interior (selfie/liveness) — black box.
- Dashboard wiring — follow-up once data lands; the KYC funnel gets a `Verification Resolved` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added analytics tracking for KYC verification outcomes (approval, rejection, storage/error), recording verdict duration and exposing a new SDK helper to emit the event.

* **Tests**
  * Added unit tests verifying event emission across success, failure, error, mock, and no-attempt scenarios.

* **Documentation**
  * Added spec and backlog entry describing the new KYC verification event and payload structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/selfxyz/self/pull/2114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->