### PR TITLE
capture iOS gym build logs and upload them on failure

### DIFF
--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -765,6 +765,15 @@ jobs:
               --verbose
           fi
 
+      - name: Upload iOS build logs on failure
+        if: failure() && inputs.platform != 'android'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-gym-buildlogs
+          path: ${{ env.APP_PATH }}/ios/build/gymlogs
+          if-no-files-found: warn
+          retention-days: 7
+
       - name: Verify iOS build output
         if: inputs.platform != 'android'
         run: |

--- a/app/fastlane/Fastfile
+++ b/app/fastlane/Fastfile
@@ -229,6 +229,7 @@ platform :ios do
       scheme: PROJECT_SCHEME,
       export_method: "app-store",
       output_directory: "ios/build",
+      buildlog_path: "ios/build/gymlogs",
       clean: true,
       export_options: {
         method: "app-store",


### PR DESCRIPTION
## Summary

- iOS deploy builds that fail at the "Bundle React Native code and images" Xcode script phase currently surface only `** ARCHIVE FAILED **` — gym streams xcpretty-filtered output and discards the underlying Metro/Hermes error, so the real cause is unrecoverable from CI logs.
- This adds full `xcodebuild` log capture via gym's `buildlog_path` and uploads those logs as an artifact when the iOS build fails, so the next failure is diagnosable in one read.
- Diagnostics only — no build behavior changes.

## Changes

### Config/infra

- **`app/fastlane/Fastfile`** — `build_app` now writes the raw `xcodebuild` log to `ios/build/gymlogs` (`buildlog_path`).
- **`.github/workflows/mobile-deploy.yml`** — new `if: failure()` step uploads `ios/build/gymlogs` as the `ios-gym-buildlogs` artifact (7-day retention, `upload-artifact@v4`).

## Test Plan

- [ ] Trigger a Mobile Deploy iOS run; on a build failure, confirm the `ios-gym-buildlogs` artifact is attached and contains the full `xcodebuild` output (including the bundle/`hermesc` error).
- [ ] On a successful build, confirm the step is skipped (`if: failure()`) and the build is otherwise unchanged.
- [ ] `mobile-deploy.yml` parses as valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)