### PR TITLE
fix Play Store upload: pin httplib2 to escape 0.20.4 redirect bug

### DIFF
--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -1154,7 +1154,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade -r ${{ env.APP_PATH }}/scripts/requirements-play-store.txt
-          python -c "import httplib2; print('httplib2', httplib2.__version__, httplib2.__file__)"
+
+      - name: Verify httplib2 version
+        if: inputs.platform != 'ios'
+        run: python -c "import httplib2; print('httplib2', httplib2.__version__, httplib2.__file__)"
 
       - name: Setup Android private modules
         if: inputs.platform != 'ios'

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -1153,7 +1153,8 @@ jobs:
         if: inputs.platform != 'ios'
         run: |
           python -m pip install --upgrade pip
-          pip install google-auth google-auth-oauthlib google-auth-httplib2 google-api-python-client
+          python -m pip install --upgrade -r ${{ env.APP_PATH }}/scripts/requirements-play-store.txt
+          python -c "import httplib2; print('httplib2', httplib2.__version__, httplib2.__file__)"
 
       - name: Setup Android private modules
         if: inputs.platform != 'ios'

--- a/app/scripts/requirements-play-store.txt
+++ b/app/scripts/requirements-play-store.txt
@@ -1,0 +1,12 @@
+# Pinned deps for scripts/upload_to_play_store.py.
+#
+# httplib2 must be >= 0.22.0: the GitHub runner ships 0.20.4 as a system
+# package, which has a resumable-upload redirect regression that fails the
+# Play Store AAB upload with "Redirected but the response is missing a
+# Location: header". Pinning here (and installing with --upgrade) forces the
+# fixed version over the pre-installed one. Pin the rest for reproducible CI.
+httplib2==0.31.2
+google-auth==2.53.0
+google-auth-oauthlib==1.4.0
+google-auth-httplib2==0.4.0
+google-api-python-client==2.197.0


### PR DESCRIPTION
## Summary

- Fixes Android Play Store deploys failing at upload with `Redirected but the response is missing a Location: header`.
- Root cause: the GitHub runner ships **httplib2 0.20.4** as a system package, which satisfied the unpinned `>=0.19.0` floor so pip never replaced it. httplib2 0.20.x has a resumable-upload redirect regression that breaks the resumable session init for the AAB upload.
- Pins the Play Store upload's Python deps (critically `httplib2==0.31.2`) and installs them with `--upgrade` so the fixed version overrides the pre-installed one. Exact pins also make the deploy reproducible, so a future upstream release can't silently break it again.

## Changes

### Config/infra

- Add `app/scripts/requirements-play-store.txt` pinning the `upload_to_play_store.py` deps: `httplib2==0.31.2`, `google-auth==2.53.0`, `google-auth-oauthlib==1.4.0`, `google-auth-httplib2==0.4.0`, `google-api-python-client==2.197.0`.
- `.github/workflows/mobile-deploy.yml`: install step now runs `python -m pip install --upgrade -r .../requirements-play-store.txt` (same interpreter that runs the upload, forces replacement of system httplib2), plus a verification line that prints the resolved `httplib2.__version__` / `__file__` so the CI log proves it escaped `/usr/lib/python3/dist-packages`.

## Test Plan

- [ ] CI deploy install step logs `httplib2 0.31.2 …` (not `…/dist-packages/… 0.20.4`)
- [ ] Android deploy upload step proceeds past session init to `📶 … % uploaded` and completes
- [ ] `pip install -r app/scripts/requirements-play-store.txt` resolves cleanly (verified locally in a clean venv: exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Play Store deployment pipeline reliability by consolidating Python dependency management and addressing httplib2 compatibility issues to ensure more consistent app updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->