### PR TITLE
add shared Sentry redaction + onboarding cohort tags (RN + WebView)

### DIFF
--- a/app/src/config/sentry.ts
+++ b/app/src/config/sentry.ts
@@ -24,6 +24,12 @@ import type {
   NFCScanContext,
   ProofContext,
 } from '@selfxyz/mobile-sdk-alpha';
+import {
+  redactSensitiveFields,
+  sanitizeTagValue,
+} from '@selfxyz/mobile-sdk-alpha/observability';
+
+export { redactSensitiveFields, sanitizeTagValue };
 // Security: Whitelist of allowed tag keys to prevent XSS
 const ALLOWED_TAG_KEYS = new Set([
   'session_id',
@@ -101,24 +107,6 @@ export const captureWebViewLoadDiagnostic = (
     }
     sentryCaptureException(new Error(`WebView load ${kind}`));
   });
-};
-
-const SENSITIVE_KEY_PATTERN =
-  /passport|mrz|dg\d|chip|aadhaar|(?:first|last|full|given|family|holder|sur)_?name|name_?(?:first|last|of_?holder|holder)|date_?of_?birth|dob|birth|photo/i;
-const REDACTED = '[REDACTED]';
-
-const redactObjectInPlace = <T extends Record<string, unknown>>(obj: T): T => {
-  for (const key of Object.keys(obj)) {
-    if (SENSITIVE_KEY_PATTERN.test(key)) {
-      obj[key as keyof T] = REDACTED as T[keyof T];
-      continue;
-    }
-    const value = obj[key];
-    if (value && typeof value === 'object') {
-      redactObjectInPlace(value as Record<string, unknown>);
-    }
-  }
-  return obj;
 };
 
 export const captureFeedback = (
@@ -337,60 +325,6 @@ export const logAuthEvent = (
   context: BaseContext & Record<string, unknown>,
   extra?: Record<string, unknown>,
 ) => logEvent(level, 'auth', message, context, extra);
-
-export const redactSensitiveFields = <
-  T extends {
-    breadcrumbs?: Array<{ data?: Record<string, unknown> | undefined }>;
-    contexts?: Record<string, unknown>;
-    extra?: Record<string, unknown>;
-  },
->(
-  event: T,
-): T => {
-  if (event.breadcrumbs) {
-    for (const crumb of event.breadcrumbs) {
-      if (crumb.data) redactObjectInPlace(crumb.data);
-    }
-  }
-  if (event.contexts) {
-    redactObjectInPlace(event.contexts);
-  }
-  if (event.extra) {
-    redactObjectInPlace(event.extra);
-  }
-  return event;
-};
-
-export const sanitizeTagValue = (value: unknown): string => {
-  if (value == null) return '';
-
-  const stringValue = String(value);
-
-  const MAX_TAG_LENGTH = 200;
-  const truncated =
-    stringValue.length > MAX_TAG_LENGTH
-      ? stringValue.substring(0, MAX_TAG_LENGTH) + '...'
-      : stringValue;
-
-  return truncated
-    .replace(/[<>&"']/g, char => {
-      switch (char) {
-        case '<':
-          return '&lt;';
-        case '>':
-          return '&gt;';
-        case '&':
-          return '&amp;';
-        case '"':
-          return '&quot;';
-        case "'":
-          return '&#x27;';
-        default:
-          return char;
-      }
-    })
-    .replace(/[^\x20-\x7E]/g, '');
-};
 
 export const setSupportUuidInSentry = (
   supportUuid: string | null,

--- a/app/src/observability/onboardingContext.ts
+++ b/app/src/observability/onboardingContext.ts
@@ -16,7 +16,7 @@ export { tagsFromAnalyticsEvent };
 
 export function clearOnboardingTags(): void {
   for (const key of COHORT_TAG_KEYS) {
-    Sentry.setTag(key, null);
+    Sentry.setTag(key, undefined);
   }
 }
 

--- a/app/src/observability/onboardingContext.ts
+++ b/app/src/observability/onboardingContext.ts
@@ -4,29 +4,15 @@
 
 import * as Sentry from '@sentry/react-native';
 
-import { sanitizeTagValue } from '@/config/sentry';
+import type { OnboardingTagSnapshot } from '@selfxyz/mobile-sdk-alpha/observability';
+import {
+  COHORT_TAG_KEYS,
+  sanitizeTagValue,
+  tagsFromAnalyticsEvent,
+} from '@selfxyz/mobile-sdk-alpha/observability';
 
-export interface OnboardingTagSnapshot {
-  attempt_id?: string;
-  initial_branch?: string;
-  current_branch?: string;
-  document_country?: string;
-  document_type?: string;
-  signature_algorithm?: string;
-  csca_hash_algorithm?: string;
-  kyc_provider?: string;
-}
-
-const COHORT_TAG_KEYS: readonly (keyof OnboardingTagSnapshot)[] = [
-  'attempt_id',
-  'initial_branch',
-  'current_branch',
-  'document_country',
-  'document_type',
-  'signature_algorithm',
-  'csca_hash_algorithm',
-  'kyc_provider',
-];
+export type { OnboardingTagSnapshot };
+export { tagsFromAnalyticsEvent };
 
 export function clearOnboardingTags(): void {
   for (const key of COHORT_TAG_KEYS) {
@@ -42,43 +28,4 @@ export function setOnboardingTags(snapshot: OnboardingTagSnapshot): void {
     if (!sanitized) continue;
     Sentry.setTag(key, sanitized);
   }
-}
-
-export function tagsFromAnalyticsEvent(
-  eventName: string,
-  properties: Record<string, unknown> | undefined,
-): OnboardingTagSnapshot {
-  if (!properties) return {};
-  if (!isOnboardingEvent(eventName)) return {};
-
-  const snapshot: OnboardingTagSnapshot = {};
-  const setString = <K extends keyof OnboardingTagSnapshot>(
-    key: K,
-    value: unknown,
-  ): void => {
-    if (typeof value === 'string') snapshot[key] = value;
-  };
-
-  setString('attempt_id', properties.attempt_id);
-  setString('initial_branch', properties.initial_branch);
-  setString('current_branch', properties.current_branch);
-  setString('document_country', properties.country_code);
-  setString('document_type', properties.document_type);
-  setString('signature_algorithm', properties.signature_algorithm);
-  setString('csca_hash_algorithm', properties.csca_hash_function);
-  if (eventName.startsWith('KYC:')) {
-    setString('kyc_provider', properties.provider);
-  }
-
-  return snapshot;
-}
-
-function isOnboardingEvent(eventName: string): boolean {
-  return (
-    eventName.startsWith('Onboarding:') ||
-    eventName.startsWith('Biometric:') ||
-    eventName.startsWith('KYC:') ||
-    eventName.startsWith('Aadhaar:') ||
-    eventName.startsWith('Passport:')
-  );
 }

--- a/app/tests/src/observability/onboardingContext.test.ts
+++ b/app/tests/src/observability/onboardingContext.test.ts
@@ -74,7 +74,7 @@ describe('clearOnboardingTags', () => {
     setTagMock.mockClear();
   });
 
-  it('nulls out every cohort tag key', () => {
+  it('clears every cohort tag key', () => {
     clearOnboardingTags();
 
     const cleared = setTagMock.mock.calls.map(([key]) => key);
@@ -91,7 +91,7 @@ describe('clearOnboardingTags', () => {
       ]),
     );
     for (const [, value] of setTagMock.mock.calls) {
-      expect(value).toBeNull();
+      expect(value).toBeUndefined();
     }
   });
 });

--- a/app/tests/src/observability/onboardingContext.test.ts
+++ b/app/tests/src/observability/onboardingContext.test.ts
@@ -127,7 +127,7 @@ describe('tagsFromAnalyticsEvent', () => {
     });
   });
 
-  it('maps signature_algorithm and csca_hash_function on biometric events', () => {
+  it('maps signature_algorithm and csca_hash_algorithm on biometric events', () => {
     expect(
       tagsFromAnalyticsEvent('Biometric: Document Parsed', {
         attempt_id: 'a',
@@ -135,7 +135,7 @@ describe('tagsFromAnalyticsEvent', () => {
         current_branch: 'biometric_passport',
         document_type: 'passport',
         signature_algorithm: 'ecdsa-sha256',
-        csca_hash_function: 'sha384',
+        csca_hash_algorithm: 'sha384',
       }),
     ).toEqual({
       attempt_id: 'a',

--- a/packages/mobile-sdk-alpha/package.json
+++ b/packages/mobile-sdk-alpha/package.json
@@ -51,6 +51,12 @@
       "import": "./dist/esm/stores.js",
       "require": "./dist/cjs/stores.cjs"
     },
+    "./observability": {
+      "types": "./dist/esm/observability.d.ts",
+      "react-native": "./dist/esm/observability.js",
+      "import": "./dist/esm/observability.js",
+      "require": "./dist/cjs/observability.cjs"
+    },
     "./constants/analytics": {
       "types": "./dist/esm/constants/analytics.d.ts",
       "react-native": "./dist/esm/constants/analytics.js",

--- a/packages/mobile-sdk-alpha/src/browser.ts
+++ b/packages/mobile-sdk-alpha/src/browser.ts
@@ -36,18 +36,28 @@ export type {
 } from './types/public';
 export type { BaseContext, NFCScanContext, ProofContext } from './proving/internal/logging';
 export type { DG1, DG2, ParsedNFCResponse } from './nfc';
+export type { OnboardingTagSnapshot } from './observability/onboardingContext';
 export type { PassportValidationCallbacks } from './validation/document';
 export type { PerkId, PerkRecord } from './data/perks';
 export type { ProvingState, ProvingStateType, provingMachineCircuitType } from './proving/provingMachine';
-export type { RecoveryValidationResult } from './proving/recoveryValidation';
 
+export type { RecoveryValidationResult } from './proving/recoveryValidation';
 export type { SDKEvent, SDKEventMap } from './types/events';
+
 export type { SdkErrorCategory } from './errors';
 // Re-export common types needed for SelfApp context construction
 export type { SelfApp, SelfAppDisclosureConfig } from '@selfxyz/common';
-export type { SelfAppState } from './stores/selfAppStore';
 
+export type { SelfAppState } from './stores/selfAppStore';
 export type { WebAnalyticsOptions } from './adapters/browser';
+export {
+  COHORT_TAG_KEYS,
+  REDACTED,
+  SENSITIVE_KEY_PATTERN,
+  redactSensitiveFields,
+  sanitizeTagValue,
+  tagsFromAnalyticsEvent,
+} from './observability/onboardingContext';
 export {
   GOOGLE_USAT_FAUCET_APP_NAME,
   GOOGLE_USAT_FAUCET_ENDPOINT,
@@ -85,13 +95,14 @@ export {
   createWebCryptoAdapter,
   createWebNetworkAdapter,
 } from './adapters/browser';
+
 export { createListenersMap, createSelfClient } from './client';
 
 export { defaultConfig } from './config/defaults';
 /** @deprecated Use createSelfClient().extractMRZInfo or import from './mrz' */
 export { extractMRZInfo, extractNameFromMRZ, formatDateToYYMMDD } from './mrz';
-export { finalizeRecoveredDocumentRegistration, validateRecoverySecretForDocument } from './proving/recoveryValidation';
 
+export { finalizeRecoveredDocumentRegistration, validateRecoverySecretForDocument } from './proving/recoveryValidation';
 export { generateMockDocument, signatureAlgorithmToStrictSignatureAlgorithm } from './mock/generator';
 export { getPostVerificationRoute, useProvingStore } from './proving/provingMachine';
 export { hasEligibleAlternativeDocumentForPolicy, isDocumentEligibleForPolicy } from './utils/restrictedApps';

--- a/packages/mobile-sdk-alpha/src/index.ts
+++ b/packages/mobile-sdk-alpha/src/index.ts
@@ -175,16 +175,17 @@ export { defaultOptions } from './haptic/shared';
 export { extractMRZInfo } from './mrz';
 
 export { extractNameFromDocument } from './documents/utils';
+
 export { extractNameFromMRZ, formatDateToYYMMDD, parseMRZBirthDate, parseMRZExpiryDate } from './mrz';
 
 export { finalizeRecoveredDocumentRegistration, validateRecoverySecretForDocument } from './proving/recoveryValidation';
-
 export { generateMockDocument, signatureAlgorithmToStrictSignatureAlgorithm } from './mock/generator';
 export { hasEligibleAlternativeDocumentForPolicy, isDocumentEligibleForPolicy } from './utils/restrictedApps';
-export { isGoogleUsatProofRequest } from './utils/googleUsat';
 
+export { isGoogleUsatProofRequest } from './utils/googleUsat';
 export { isPassportDataValid } from './validation/document';
 export { mergeConfig } from './config/merge';
+
 export { parseNFCResponse, scanNFC } from './nfc';
 
 export { reactNativeScannerAdapter } from './adapters/react-native/nfc-scanner';

--- a/packages/mobile-sdk-alpha/src/observability/onboardingContext.ts
+++ b/packages/mobile-sdk-alpha/src/observability/onboardingContext.ts
@@ -32,7 +32,7 @@ export const COHORT_TAG_KEYS: readonly (keyof OnboardingTagSnapshot)[] = [
 export const REDACTED = '[REDACTED]';
 
 export const SENSITIVE_KEY_PATTERN =
-  /passport|mrz|dg\d|chip|aadhaar|(?:first|last|full|given|family|holder|sur)_?name|name_?(?:first|last|of_?holder|holder)|date_?of_?birth|dob|birth|photo/i;
+  /passport|mrz|dg\d|chip|aadhaar|(?:first|last|full|given|family|holder|sur)_?name|name_?(?:first|last|of_?holder|holder)|date_?of_?birth|dob|birth|photo|email/i;
 
 function isOnboardingEvent(eventName: string): boolean {
   return (
@@ -73,13 +73,8 @@ export function tagsFromAnalyticsEvent(
 export function sanitizeTagValue(value: unknown): string {
   if (value == null) return '';
 
-  const stringValue = String(value);
-
   const MAX_TAG_LENGTH = 200;
-  const truncated =
-    stringValue.length > MAX_TAG_LENGTH ? stringValue.substring(0, MAX_TAG_LENGTH) + '...' : stringValue;
-
-  return truncated
+  const normalized = String(value)
     .replace(/[<>&"']/g, char => {
       switch (char) {
         case '<':
@@ -97,6 +92,8 @@ export function sanitizeTagValue(value: unknown): string {
       }
     })
     .replace(/[^\x20-\x7E]/g, '');
+
+  return normalized.length > MAX_TAG_LENGTH ? normalized.slice(0, MAX_TAG_LENGTH - 3) + '...' : normalized;
 }
 
 function redactObjectInPlace<T extends Record<string, unknown>>(obj: T): T {
@@ -115,15 +112,17 @@ function redactObjectInPlace<T extends Record<string, unknown>>(obj: T): T {
 
 /**
  * Redacts PII-keyed fields from a Sentry-shaped event's `breadcrumbs`,
- * `contexts`, and `extra` in place. SDK-agnostic: both the RN and browser
- * Sentry SDKs expose these properties on their event object, so each side wires
- * this into its own `beforeSend`.
+ * `contexts`, `extra`, and `user` in place. SDK-agnostic: both the RN and
+ * browser Sentry SDKs expose these properties on their event object, so each
+ * side wires this into its own `beforeSend`. `user` is included so feedback
+ * `contact_email` (contexts.feedback) and `user.email` cannot leak.
  */
 export function redactSensitiveFields<
   T extends {
     breadcrumbs?: Array<{ data?: Record<string, unknown> | undefined }>;
     contexts?: Record<string, unknown>;
     extra?: Record<string, unknown>;
+    user?: Record<string, unknown> | null;
   },
 >(event: T): T {
   if (event.breadcrumbs) {
@@ -136,6 +135,9 @@ export function redactSensitiveFields<
   }
   if (event.extra) {
     redactObjectInPlace(event.extra);
+  }
+  if (event.user) {
+    redactObjectInPlace(event.user);
   }
   return event;
 }

--- a/packages/mobile-sdk-alpha/src/observability/onboardingContext.ts
+++ b/packages/mobile-sdk-alpha/src/observability/onboardingContext.ts
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+// Platform-agnostic observability helpers shared by the RN host
+// (@sentry/react-native) and the WebView app (@sentry/react). This module must
+// not import react-native, any Sentry SDK, browser globals, or app aliases —
+// each runtime wires these pure helpers into its own Sentry SDK.
+
+export interface OnboardingTagSnapshot {
+  attempt_id?: string;
+  initial_branch?: string;
+  current_branch?: string;
+  document_country?: string;
+  document_type?: string;
+  signature_algorithm?: string;
+  csca_hash_algorithm?: string;
+  kyc_provider?: string;
+}
+
+export const COHORT_TAG_KEYS: readonly (keyof OnboardingTagSnapshot)[] = [
+  'attempt_id',
+  'initial_branch',
+  'current_branch',
+  'document_country',
+  'document_type',
+  'signature_algorithm',
+  'csca_hash_algorithm',
+  'kyc_provider',
+];
+
+export const REDACTED = '[REDACTED]';
+
+export const SENSITIVE_KEY_PATTERN =
+  /passport|mrz|dg\d|chip|aadhaar|(?:first|last|full|given|family|holder|sur)_?name|name_?(?:first|last|of_?holder|holder)|date_?of_?birth|dob|birth|photo/i;
+
+function isOnboardingEvent(eventName: string): boolean {
+  return (
+    eventName.startsWith('Onboarding:') ||
+    eventName.startsWith('Biometric:') ||
+    eventName.startsWith('KYC:') ||
+    eventName.startsWith('Aadhaar:') ||
+    eventName.startsWith('Passport:')
+  );
+}
+
+export function tagsFromAnalyticsEvent(
+  eventName: string,
+  properties: Record<string, unknown> | undefined,
+): OnboardingTagSnapshot {
+  if (!properties) return {};
+  if (!isOnboardingEvent(eventName)) return {};
+
+  const snapshot: OnboardingTagSnapshot = {};
+  const setString = <K extends keyof OnboardingTagSnapshot>(key: K, value: unknown): void => {
+    if (typeof value === 'string') snapshot[key] = value;
+  };
+
+  setString('attempt_id', properties.attempt_id);
+  setString('initial_branch', properties.initial_branch);
+  setString('current_branch', properties.current_branch);
+  setString('document_country', properties.country_code);
+  setString('document_type', properties.document_type);
+  setString('signature_algorithm', properties.signature_algorithm);
+  setString('csca_hash_algorithm', properties.csca_hash_algorithm);
+  if (eventName.startsWith('KYC:')) {
+    setString('kyc_provider', properties.provider);
+  }
+
+  return snapshot;
+}
+
+export function sanitizeTagValue(value: unknown): string {
+  if (value == null) return '';
+
+  const stringValue = String(value);
+
+  const MAX_TAG_LENGTH = 200;
+  const truncated =
+    stringValue.length > MAX_TAG_LENGTH ? stringValue.substring(0, MAX_TAG_LENGTH) + '...' : stringValue;
+
+  return truncated
+    .replace(/[<>&"']/g, char => {
+      switch (char) {
+        case '<':
+          return '&lt;';
+        case '>':
+          return '&gt;';
+        case '&':
+          return '&amp;';
+        case '"':
+          return '&quot;';
+        case "'":
+          return '&#x27;';
+        default:
+          return char;
+      }
+    })
+    .replace(/[^\x20-\x7E]/g, '');
+}
+
+function redactObjectInPlace<T extends Record<string, unknown>>(obj: T): T {
+  for (const key of Object.keys(obj)) {
+    if (SENSITIVE_KEY_PATTERN.test(key)) {
+      obj[key as keyof T] = REDACTED as T[keyof T];
+      continue;
+    }
+    const value = obj[key];
+    if (value && typeof value === 'object') {
+      redactObjectInPlace(value as Record<string, unknown>);
+    }
+  }
+  return obj;
+}
+
+/**
+ * Redacts PII-keyed fields from a Sentry-shaped event's `breadcrumbs`,
+ * `contexts`, and `extra` in place. SDK-agnostic: both the RN and browser
+ * Sentry SDKs expose these properties on their event object, so each side wires
+ * this into its own `beforeSend`.
+ */
+export function redactSensitiveFields<
+  T extends {
+    breadcrumbs?: Array<{ data?: Record<string, unknown> | undefined }>;
+    contexts?: Record<string, unknown>;
+    extra?: Record<string, unknown>;
+  },
+>(event: T): T {
+  if (event.breadcrumbs) {
+    for (const crumb of event.breadcrumbs) {
+      if (crumb.data) redactObjectInPlace(crumb.data);
+    }
+  }
+  if (event.contexts) {
+    redactObjectInPlace(event.contexts);
+  }
+  if (event.extra) {
+    redactObjectInPlace(event.extra);
+  }
+  return event;
+}

--- a/packages/mobile-sdk-alpha/src/observability/onboardingContext.ts
+++ b/packages/mobile-sdk-alpha/src/observability/onboardingContext.ts
@@ -96,6 +96,13 @@ export function sanitizeTagValue(value: unknown): string {
   return normalized.length > MAX_TAG_LENGTH ? normalized.slice(0, MAX_TAG_LENGTH - 3) + '...' : normalized;
 }
 
+function stripUrlQuery(url: string): string {
+  const cut = url.search(/[?#]/);
+  return cut === -1 ? url : url.slice(0, cut);
+}
+
+const URL_BREADCRUMB_KEYS = ['url', 'to', 'from'] as const;
+
 function redactObjectInPlace<T extends Record<string, unknown>>(obj: T): T {
   for (const key of Object.keys(obj)) {
     if (SENSITIVE_KEY_PATTERN.test(key)) {
@@ -112,10 +119,12 @@ function redactObjectInPlace<T extends Record<string, unknown>>(obj: T): T {
 
 /**
  * Redacts PII-keyed fields from a Sentry-shaped event's `breadcrumbs`,
- * `contexts`, `extra`, and `user` in place. SDK-agnostic: both the RN and
- * browser Sentry SDKs expose these properties on their event object, so each
- * side wires this into its own `beforeSend`. `user` is included so feedback
- * `contact_email` (contexts.feedback) and `user.email` cannot leak.
+ * `contexts`, `extra`, `user`, and `request` in place. SDK-agnostic: both the
+ * RN and browser Sentry SDKs expose these properties on their event object, so
+ * each side wires this into its own `beforeSend`. `user` is included so feedback
+ * `contact_email` (contexts.feedback) and `user.email` cannot leak; `request`
+ * and breadcrumb URL fields are query-stripped so URL params from the browser
+ * `HttpContext`/`Breadcrumbs` integrations cannot carry sensitive values.
  */
 export function redactSensitiveFields<
   T extends {
@@ -123,11 +132,19 @@ export function redactSensitiveFields<
     contexts?: Record<string, unknown>;
     extra?: Record<string, unknown>;
     user?: Record<string, unknown> | null;
+    request?: { url?: string; query_string?: unknown; cookies?: unknown; headers?: unknown; data?: unknown } | null;
   },
 >(event: T): T {
   if (event.breadcrumbs) {
     for (const crumb of event.breadcrumbs) {
-      if (crumb.data) redactObjectInPlace(crumb.data);
+      if (crumb.data) {
+        redactObjectInPlace(crumb.data);
+        for (const key of URL_BREADCRUMB_KEYS) {
+          if (typeof crumb.data[key] === 'string') {
+            crumb.data[key] = stripUrlQuery(crumb.data[key] as string);
+          }
+        }
+      }
     }
   }
   if (event.contexts) {
@@ -138,6 +155,16 @@ export function redactSensitiveFields<
   }
   if (event.user) {
     redactObjectInPlace(event.user);
+  }
+  if (event.request) {
+    const request = event.request;
+    if (typeof request.url === 'string') request.url = stripUrlQuery(request.url);
+    delete request.query_string;
+    delete request.cookies;
+    delete request.headers;
+    if (request.data && typeof request.data === 'object') {
+      redactObjectInPlace(request.data as Record<string, unknown>);
+    }
   }
   return event;
 }

--- a/packages/mobile-sdk-alpha/tests/observability/onboardingContext.test.ts
+++ b/packages/mobile-sdk-alpha/tests/observability/onboardingContext.test.ts
@@ -87,7 +87,13 @@ describe('sanitizeTagValue', () => {
   it('truncates values longer than 200 characters', () => {
     const out = sanitizeTagValue('a'.repeat(250));
     expect(out.endsWith('...')).toBe(true);
-    expect(out.length).toBe(203);
+    expect(out.length).toBe(200);
+  });
+
+  it('keeps escaped values within the 200-char Sentry tag limit', () => {
+    const out = sanitizeTagValue('<'.repeat(250));
+    expect(out.length).toBeLessThanOrEqual(200);
+    expect(out.endsWith('...')).toBe(true);
   });
 });
 
@@ -115,6 +121,9 @@ describe('SENSITIVE_KEY_PATTERN (ANA-13 live regex)', () => {
     'dob',
     'birthDate',
     'photo',
+    'email',
+    'contact_email',
+    'userEmail',
   ];
   it.each(sensitive)('matches sensitive key %s', key => {
     expect(SENSITIVE_KEY_PATTERN.test(key)).toBe(true);
@@ -148,6 +157,22 @@ describe('redactSensitiveFields', () => {
     });
     expect((event.extra!.nested as Record<string, unknown>).holderName).toBe(REDACTED);
     expect((event.extra!.nested as Record<string, unknown>).id).toBe(7);
+  });
+
+  it('redacts user.email but keeps non-PII user fields', () => {
+    const event = redactSensitiveFields({
+      user: { id: 'u1', email: 'jane@example.com' },
+    });
+    expect((event.user as Record<string, unknown>).email).toBe(REDACTED);
+    expect((event.user as Record<string, unknown>).id).toBe('u1');
+  });
+
+  it('redacts feedback contact_email in contexts', () => {
+    const event = redactSensitiveFields({
+      contexts: { feedback: { contact_email: 'jane@example.com', message: 'hi' } },
+    });
+    expect((event.contexts!.feedback as Record<string, unknown>).contact_email).toBe(REDACTED);
+    expect((event.contexts!.feedback as Record<string, unknown>).message).toBe('hi');
   });
 
   it('does not throw on an empty event', () => {

--- a/packages/mobile-sdk-alpha/tests/observability/onboardingContext.test.ts
+++ b/packages/mobile-sdk-alpha/tests/observability/onboardingContext.test.ts
@@ -175,6 +175,31 @@ describe('redactSensitiveFields', () => {
     expect((event.contexts!.feedback as Record<string, unknown>).message).toBe('hi');
   });
 
+  it('strips query strings from request.url and drops query_string/cookies/headers', () => {
+    const event = redactSensitiveFields({
+      request: {
+        url: 'https://app.self.xyz/verify?session=secret&token=abc',
+        query_string: 'session=secret',
+        cookies: { sid: 'secret' },
+        headers: { Referer: 'https://app.self.xyz/verify?session=secret' },
+      },
+    });
+    expect((event.request as Record<string, unknown>).url).toBe('https://app.self.xyz/verify');
+    expect((event.request as Record<string, unknown>).query_string).toBeUndefined();
+    expect((event.request as Record<string, unknown>).cookies).toBeUndefined();
+    expect((event.request as Record<string, unknown>).headers).toBeUndefined();
+  });
+
+  it('strips query strings from breadcrumb url/to/from fields', () => {
+    const event = redactSensitiveFields({
+      breadcrumbs: [{ data: { from: '/a?token=x', to: '/b#frag', url: 'https://x.io/p?q=1' } }],
+    });
+    const data = event.breadcrumbs![0].data!;
+    expect(data.from).toBe('/a');
+    expect(data.to).toBe('/b');
+    expect(data.url).toBe('https://x.io/p');
+  });
+
   it('does not throw on an empty event', () => {
     expect(() => redactSensitiveFields({})).not.toThrow();
   });

--- a/packages/mobile-sdk-alpha/tests/observability/onboardingContext.test.ts
+++ b/packages/mobile-sdk-alpha/tests/observability/onboardingContext.test.ts
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  COHORT_TAG_KEYS,
+  REDACTED,
+  redactSensitiveFields,
+  sanitizeTagValue,
+  SENSITIVE_KEY_PATTERN,
+  tagsFromAnalyticsEvent,
+} from '../../src/observability/onboardingContext';
+
+describe('tagsFromAnalyticsEvent', () => {
+  it('returns empty for non-onboarding events', () => {
+    expect(tagsFromAnalyticsEvent('Some Other: Event', { attempt_id: 'abc' })).toEqual({});
+  });
+
+  it('returns empty when properties are missing', () => {
+    expect(tagsFromAnalyticsEvent('Onboarding: Country Selected', undefined)).toEqual({});
+  });
+
+  it('extracts canonical funnel properties (country_code → document_country)', () => {
+    expect(
+      tagsFromAnalyticsEvent('Onboarding: Country Selected', {
+        attempt_id: 'abc',
+        initial_branch: 'pending',
+        current_branch: 'pending',
+        country_code: 'FRA',
+      }),
+    ).toEqual({
+      attempt_id: 'abc',
+      initial_branch: 'pending',
+      current_branch: 'pending',
+      document_country: 'FRA',
+    });
+  });
+
+  it('maps signature_algorithm and csca_hash_algorithm on biometric events', () => {
+    expect(
+      tagsFromAnalyticsEvent('Biometric: Document Parsed', {
+        document_type: 'passport',
+        signature_algorithm: 'ecdsa-sha256',
+        csca_hash_algorithm: 'sha384',
+      }),
+    ).toMatchObject({
+      document_type: 'passport',
+      signature_algorithm: 'ecdsa-sha256',
+      csca_hash_algorithm: 'sha384',
+    });
+  });
+
+  it('only maps provider to kyc_provider on KYC: events', () => {
+    expect(tagsFromAnalyticsEvent('KYC: Session Created', { provider: 'didit' })).toMatchObject({
+      kyc_provider: 'didit',
+    });
+    expect(
+      tagsFromAnalyticsEvent('Onboarding: Country Selected', { provider: 'didit', attempt_id: 'a' }),
+    ).not.toHaveProperty('kyc_provider');
+  });
+
+  it('ignores non-string property values', () => {
+    expect(tagsFromAnalyticsEvent('Onboarding: Country Selected', { country_code: 42 })).toEqual({});
+  });
+});
+
+describe('sanitizeTagValue', () => {
+  it('returns empty string for null/undefined', () => {
+    expect(sanitizeTagValue(null)).toBe('');
+    expect(sanitizeTagValue(undefined)).toBe('');
+  });
+
+  it('HTML-escapes angle brackets and quotes', () => {
+    const out = sanitizeTagValue('<script>alert("x")</script>');
+    expect(out).not.toContain('<script>');
+    expect(out).toContain('&lt;');
+    expect(out).toContain('&gt;');
+    expect(out).toContain('&quot;');
+  });
+
+  it('strips non-printable / non-ASCII control characters', () => {
+    expect(sanitizeTagValue('hello\u0000\u200bworld')).toBe('helloworld');
+  });
+
+  it('truncates values longer than 200 characters', () => {
+    const out = sanitizeTagValue('a'.repeat(250));
+    expect(out.endsWith('...')).toBe(true);
+    expect(out.length).toBe(203);
+  });
+});
+
+describe('SENSITIVE_KEY_PATTERN (ANA-13 live regex)', () => {
+  const sensitive = [
+    'passport',
+    'passportNumber',
+    'mrz',
+    'mrzString',
+    'dg1',
+    'dg2',
+    'chip',
+    'aadhaar',
+    'firstName',
+    'first_name',
+    'last_name',
+    'fullName',
+    'givenName',
+    'family_name',
+    'holderName',
+    'surname',
+    'name_of_holder',
+    'dateOfBirth',
+    'date_of_birth',
+    'dob',
+    'birthDate',
+    'photo',
+  ];
+  it.each(sensitive)('matches sensitive key %s', key => {
+    expect(SENSITIVE_KEY_PATTERN.test(key)).toBe(true);
+  });
+
+  const safe = ['attempt_id', 'document_country', 'signature_algorithm', 'current_branch', 'kyc_provider'];
+  it.each(safe)('does not match safe cohort key %s', key => {
+    expect(SENSITIVE_KEY_PATTERN.test(key)).toBe(false);
+  });
+});
+
+describe('redactSensitiveFields', () => {
+  it('redacts PII-keyed fields in breadcrumbs, contexts, and extra', () => {
+    const event = redactSensitiveFields({
+      breadcrumbs: [{ data: { passportNumber: 'X123', safe: 'ok' } }],
+      contexts: { doc: { date_of_birth: '1990-01-01', country: 'DEU' } },
+      extra: { mrz: 'P<DEU...', attempt_id: 'a1' },
+    });
+
+    expect(event.breadcrumbs![0].data!.passportNumber).toBe(REDACTED);
+    expect(event.breadcrumbs![0].data!.safe).toBe('ok');
+    expect((event.contexts!.doc as Record<string, unknown>).date_of_birth).toBe(REDACTED);
+    expect((event.contexts!.doc as Record<string, unknown>).country).toBe('DEU');
+    expect(event.extra!.mrz).toBe(REDACTED);
+    expect(event.extra!.attempt_id).toBe('a1');
+  });
+
+  it('recurses into nested objects', () => {
+    const event = redactSensitiveFields({
+      extra: { nested: { holderName: 'Jane Doe', id: 7 } },
+    });
+    expect((event.extra!.nested as Record<string, unknown>).holderName).toBe(REDACTED);
+    expect((event.extra!.nested as Record<string, unknown>).id).toBe(7);
+  });
+
+  it('does not throw on an empty event', () => {
+    expect(() => redactSensitiveFields({})).not.toThrow();
+  });
+});
+
+describe('COHORT_TAG_KEYS', () => {
+  it('lists the eight ANA-13 cohort tag keys', () => {
+    expect(COHORT_TAG_KEYS).toEqual([
+      'attempt_id',
+      'initial_branch',
+      'current_branch',
+      'document_country',
+      'document_type',
+      'signature_algorithm',
+      'csca_hash_algorithm',
+      'kyc_provider',
+    ]);
+  });
+});

--- a/packages/mobile-sdk-alpha/tsup.config.ts
+++ b/packages/mobile-sdk-alpha/tsup.config.ts
@@ -45,6 +45,7 @@ const entry = {
   'hooks/index': 'src/hooks/index.ts',
   'hooks/useSafeBottomPadding': 'src/hooks/useSafeBottomPadding.ts',
   stores: 'src/stores/index.ts',
+  observability: 'src/observability/onboardingContext.ts',
   'utils/utils': 'src/utils/utils.ts',
   'adapters/react-native/index': 'src/adapters/react-native/index.ts',
   ...flowEntries,

--- a/packages/webview-app/package.json
+++ b/packages/webview-app/package.json
@@ -26,6 +26,7 @@
     "@selfxyz/euclid-core": "1.4.6",
     "@selfxyz/mobile-sdk-alpha": "workspace:^",
     "@selfxyz/webview-bridge": "workspace:^",
+    "@sentry/react": "^9.32.0",
     "buffer": "^6.0.3",
     "elliptic": "^6.5.4",
     "lottie-react": "^2.4.0",

--- a/packages/webview-app/src/config/sentry.ts
+++ b/packages/webview-app/src/config/sentry.ts
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import type { OnboardingTagSnapshot } from '@selfxyz/mobile-sdk-alpha/browser';
+import { COHORT_TAG_KEYS, redactSensitiveFields, sanitizeTagValue } from '@selfxyz/mobile-sdk-alpha/browser';
+
+import { init as sentryInit, setTag } from '@sentry/react';
+
+const SENTRY_DSN = import.meta.env.VITE_SENTRY_DSN as string | undefined;
+
+export const isSentryEnabled = Boolean(SENTRY_DSN);
+
+export function initSentry(): void {
+  if (!isSentryEnabled) return;
+
+  sentryInit({
+    dsn: SENTRY_DSN,
+    environment: import.meta.env.MODE,
+    // Default integrations capture unhandled errors. Session Replay is NOT a
+    // default integration and is intentionally not added here — WIA-13 owns
+    // replay sample rates and DOM mask wrappers.
+    // No tracing/performance instrumentation (parity with ANA-13).
+    tracesSampleRate: 0,
+    // The runtime tag distinguishes WebView events from the RN host's
+    // `runtime: rn-host` in the shared Sentry project. Set once, never cleared.
+    initialScope: { tags: { runtime: 'webview' } },
+    beforeSend(event) {
+      return redactSensitiveFields(event);
+    },
+  });
+}
+
+export function setOnboardingTags(snapshot: OnboardingTagSnapshot): void {
+  if (!isSentryEnabled) return;
+  for (const key of COHORT_TAG_KEYS) {
+    const value = snapshot[key];
+    if (value === undefined || value === null || value === '') continue;
+    const sanitized = sanitizeTagValue(value);
+    if (!sanitized) continue;
+    setTag(key, sanitized);
+  }
+}
+
+export function clearOnboardingTags(): void {
+  if (!isSentryEnabled) return;
+  for (const key of COHORT_TAG_KEYS) {
+    setTag(key, null);
+  }
+}

--- a/packages/webview-app/src/config/sentry.ts
+++ b/packages/webview-app/src/config/sentry.ts
@@ -5,7 +5,7 @@
 import type { OnboardingTagSnapshot } from '@selfxyz/mobile-sdk-alpha/browser';
 import { COHORT_TAG_KEYS, redactSensitiveFields, sanitizeTagValue } from '@selfxyz/mobile-sdk-alpha/browser';
 
-import { init as sentryInit, setTag } from '@sentry/react';
+import { breadcrumbsIntegration, init as sentryInit, setTag } from '@sentry/react';
 
 const SENTRY_DSN = import.meta.env.VITE_SENTRY_DSN as string | undefined;
 
@@ -22,6 +22,14 @@ export function initSentry(): void {
     // replay sample rates and DOM mask wrappers.
     // No tracing/performance instrumentation (parity with ANA-13).
     tracesSampleRate: 0,
+    // Drop the free-text breadcrumb sources: `dom` captures user input/labels
+    // and `console` captures arbitrary logged strings, both of which can hold
+    // PII that beforeSend cannot reliably scrub. URL-bearing crumbs (navigation/
+    // fetch/xhr) stay on; their query strings are stripped in redactSensitiveFields.
+    integrations: defaults => [
+      ...defaults.filter(integration => integration.name !== 'Breadcrumbs'),
+      breadcrumbsIntegration({ console: false, dom: false }),
+    ],
     // The runtime tag distinguishes WebView events from the RN host's
     // `runtime: rn-host` in the shared Sentry project. Set once, never cleared.
     initialScope: { tags: { runtime: 'webview' } },

--- a/packages/webview-app/src/config/sentry.ts
+++ b/packages/webview-app/src/config/sentry.ts
@@ -45,6 +45,6 @@ export function setOnboardingTags(snapshot: OnboardingTagSnapshot): void {
 export function clearOnboardingTags(): void {
   if (!isSentryEnabled) return;
   for (const key of COHORT_TAG_KEYS) {
-    setTag(key, null);
+    setTag(key, undefined);
   }
 }

--- a/packages/webview-app/src/main.tsx
+++ b/packages/webview-app/src/main.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 
 import { App } from './App';
+import { initSentry } from './config/sentry';
 import { BridgeProvider } from './providers/BridgeProvider';
 import { installAssetPathShim } from './utils/assetPathShim';
 
@@ -14,6 +15,7 @@ import './fonts.css';
 import './recovery.css';
 import './reset.css';
 
+initSentry();
 installAssetPathShim();
 globalThis.Buffer = Buffer;
 

--- a/packages/webview-app/src/observability/observedAnalytics.ts
+++ b/packages/webview-app/src/observability/observedAnalytics.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { tagsFromAnalyticsEvent } from '@selfxyz/mobile-sdk-alpha/browser';
+import { OnboardingEvents } from '@selfxyz/mobile-sdk-alpha/constants/analytics';
+
+import { clearOnboardingTags, setOnboardingTags } from '../config/sentry';
+
+/**
+ * Mirrors the RN host's cohort-tag side effect (app/src/services/analytics.ts):
+ * clear the cohort tags on the terminal `Onboarding: Ended` event, otherwise
+ * stamp the WebView Sentry scope with the snapshot derived from the event.
+ */
+export function recordCohortTags(eventName: string, properties?: Record<string, unknown>): void {
+  if (eventName === OnboardingEvents.ENDED) {
+    clearOnboardingTags();
+    return;
+  }
+  setOnboardingTags(tagsFromAnalyticsEvent(eventName, properties));
+}
+
+type TrackingAdapter = {
+  // Method shorthand (not a function-typed property) so the parameter is
+  // checked bivariantly — this lets both the bridge adapter (`event: string`)
+  // and the SDK adapter (`event: KnownEventName`) satisfy the constraint.
+  trackEvent?(event: string, payload?: Record<string, unknown>): void;
+};
+
+/**
+ * Decorates an analytics adapter so every tracked event updates the WebView
+ * Sentry cohort tags before delegating to the underlying delivery. Used for
+ * both the UI-facing adapter and the SDK client adapter so cohort tags are set
+ * regardless of which path emits an onboarding event.
+ */
+export function withCohortTags<A extends TrackingAdapter>(adapter: A): A {
+  return {
+    ...adapter,
+    trackEvent(event: string, payload?: Record<string, unknown>) {
+      recordCohortTags(event, payload);
+      (adapter.trackEvent as TrackingAdapter['trackEvent'])?.(event, payload);
+    },
+  } as A;
+}

--- a/packages/webview-app/src/providers/SelfClientProvider.tsx
+++ b/packages/webview-app/src/providers/SelfClientProvider.tsx
@@ -7,7 +7,7 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useRef } fr
 import { useNavigate } from 'react-router-dom';
 
 import type { DocumentsAdapter, SelfClient } from '@selfxyz/mobile-sdk-alpha/browser';
-import { createListenersMap, createSelfClient } from '@selfxyz/mobile-sdk-alpha/browser';
+import { createListenersMap, createSelfClient, createWebAnalyticsAdapter } from '@selfxyz/mobile-sdk-alpha/browser';
 import type {
   BridgeAnalyticsAdapter,
   BridgeBiometricsAdapter,
@@ -24,6 +24,7 @@ import {
   createSdkAdapters,
 } from '@selfxyz/webview-bridge/adapters';
 
+import { withCohortTags } from '../observability/observedAnalytics';
 import { ensureSecret } from '../utils/secretManager';
 import { useBridge } from './BridgeProvider';
 import { useVerificationRequest } from './VerificationRequestProvider';
@@ -57,6 +58,7 @@ export const SelfClientProvider: React.FC<{ children: React.ReactNode }> = ({ ch
       bridge,
       navigate: stableNavigate,
       goBack: stableGoBack,
+      analytics: withCohortTags(createWebAnalyticsAdapter()),
     });
 
     const { map: listeners } = createListenersMap();
@@ -76,7 +78,7 @@ export const SelfClientProvider: React.FC<{ children: React.ReactNode }> = ({ ch
       lifecycle: bridgeLifecycleAdapter(bridge),
       haptic: bridgeHapticAdapter(bridge),
       biometrics: bridgeBiometricsAdapter(bridge),
-      analytics: consoleAnalyticsAdapter(),
+      analytics: withCohortTags(consoleAnalyticsAdapter()),
       documents,
     };
   }, [bridge, stableNavigate, stableGoBack]);

--- a/packages/webview-bridge/src/adapters/sdk-adapter-map.ts
+++ b/packages/webview-bridge/src/adapters/sdk-adapter-map.ts
@@ -4,6 +4,7 @@
 
 import type {
   Adapters,
+  AnalyticsAdapter,
   AuthAdapter,
   CryptoAdapter,
   NavigationAdapter,
@@ -24,10 +25,15 @@ export interface CreateSdkAdaptersOpts {
   bridge: WebViewBridge;
   navigate: (path: string) => void;
   goBack: () => void;
+  /**
+   * Optional analytics adapter override. The WebView app passes a cohort-tag
+   * observed adapter here (WIA-12); defaults to the console/endpoint adapter.
+   */
+  analytics?: AnalyticsAdapter;
 }
 
 export function createSdkAdapters(opts: CreateSdkAdaptersOpts): Adapters {
-  const { bridge, navigate, goBack } = opts;
+  const { bridge, navigate, goBack, analytics } = opts;
   const bridgeCrypto = bridgeCryptoAdapter(bridge);
 
   const crypto: CryptoAdapter = {
@@ -57,6 +63,6 @@ export function createSdkAdapters(opts: CreateSdkAdaptersOpts): Adapters {
     auth,
     documents: createKeychainDocumentsAdapter(bridge),
     navigation,
-    analytics: createWebAnalyticsAdapter(),
+    analytics: analytics ?? createWebAnalyticsAdapter(),
   };
 }

--- a/specs/projects/sdk/workstreams/webview-in-app/SPEC-OBSERVABILITY.html
+++ b/specs/projects/sdk/workstreams/webview-in-app/SPEC-OBSERVABILITY.html
@@ -98,12 +98,12 @@
 
   <h3>In scope</h3>
   <ul>
-    <li>Sentry browser SDK initialization inside <code>webview-app</code>.</li>
+    <li>Sentry React SDK initialization inside <code>webview-app</code> via <code>@sentry/react</code>.</li>
     <li>Cohort-tag continuity: same key set, same source mappings, same sanitization, same
       terminal-event clear semantics as ANA-13.</li>
     <li>PII masking inside the WebView DOM: equivalents to the RN-side <code>PrivacyMask</code> wrappers
       on biometric capture / NFC / data-confirmation / Aadhaar / KYC-verified screens.</li>
-    <li>Session Replay configuration in the browser SDK matching the RN baseline
+    <li>Session Replay configuration in the React SDK matching the RN baseline
       (<code>maskAllText</code>, <code>maskAllImages</code>, <code>maskAllVectors</code>).</li>
     <li><code>beforeSend</code> redact list parity with ANA-13.</li>
     <li>ANA-15's <code>attempt_id</code> footer ported to the webview-app screens that replace
@@ -133,9 +133,9 @@
   selfClient.trackEvent ─┬─→ bridge.analytics.trackEvent  ──→ RN Host: _track ──→ Segment / Mixpanel
                         │                                                  └──→ Sentry RN SDK
                         ├─→ setOnboardingTags · webview                    (cohort tags)
-                        │       └─→ Sentry browser SDK
+                        │       └─→ Sentry React SDK
                         └─→ Session Replay · web
-                                └─→ Sentry browser SDK
+                                └─→ Sentry React SDK
 
 RN Host · Self app                                          ──→ Mobile Session Replay
                                                                        └─→ Sentry project
@@ -146,8 +146,10 @@ Both SDKs → single Sentry project (correlation by attempt_id)</pre>
 <section id="decisions">
   <h2>Decisions</h2>
   <ol>
-    <li><strong>One Sentry project, two SDKs.</strong> The WebView runs <code>@sentry/browser</code>
-      with the same DSN as the RN host's <code>@sentry/react-native</code>. A <code>runtime</code> tag
+    <li><strong>One Sentry project, two SDKs.</strong> The WebView runs <code>@sentry/react</code>
+      with the same DSN as the RN host's <code>@sentry/react-native</code>. Use the React package,
+      not bare <code>@sentry/browser</code>, so the WebView can use the React error-boundary/profiler
+      integration and match the host web config package. A <code>runtime</code> tag
       (<code>rn-host</code> | <code>webview</code>) is set at SDK init on each side and is never
       cleared.</li>
     <li><strong>Mixpanel/Segment stay RN-host-only.</strong> The WebView's
@@ -156,16 +158,20 @@ Both SDKs → single Sentry project (correlation by attempt_id)</pre>
       Segment or Mixpanel.</li>
     <li><strong>Cohort tags are set on both sides, from one mapping module.</strong> The
       <code>OnboardingTagSnapshot</code> type, <code>tagsFromAnalyticsEvent</code> mapping, and
-      <code>setOnboardingTags</code>/<code>clearOnboardingTags</code> setters move from
-      <code>app/src/observability/onboardingContext.ts</code> to
-      <code>packages/mobile-sdk-alpha/</code>. The RN host and the WebView each import the mapping and
-      wire it to their respective Sentry SDK. Tag keys, mappings, sanitization, and the terminal-event
-      clear list (<code>Onboarding: Completed | Failed | Recovered</code>) are identical on both sides.</li>
-    <li><strong>PII redact list and <code>beforeSend</code> are duplicated, not shared.</strong> The
-      redact regex (<code>passport|mrz|dg\d|chip|aadhaar|name|dob|birth|photo</code>) is defined as a
-      constant exported from <code>packages/mobile-sdk-alpha/</code> and each side wires it into its
-      own <code>beforeSend</code>. The reason for duplicating the wiring (but not the constant) is that
-      browser and RN Sentry SDKs expose <code>beforeSend</code> differently.</li>
+      cohort key list move from <code>app/src/observability/onboardingContext.ts</code> to
+      <code>packages/mobile-sdk-alpha/</code>. Concrete setters do not move wholesale because
+      <code>packages/mobile-sdk-alpha/src/</code> cannot import <code>@sentry/react-native</code>.
+      The RN host keeps runtime-local <code>setOnboardingTags</code>/<code>clearOnboardingTags</code>
+      wrappers around <code>@sentry/react-native</code>; the WebView adds equivalent wrappers around
+      <code>@sentry/react</code>. Tag keys, mappings, sanitization, and the terminal-event clear
+      semantic (<code>Onboarding: Ended</code>) are identical on both sides.</li>
+    <li><strong>PII redact list is extracted from the live RN config.</strong> WIA-12 moves the current
+      <code>SENSITIVE_KEY_PATTERN</code> from <code>app/src/config/sentry.ts</code> into
+      <code>packages/mobile-sdk-alpha/</code> and imports it back into RN. Do not recreate the older
+      ANA-13 regex; the live pattern also covers name variants such as
+      <code>first_name</code>/<code>given_name</code>/<code>holder_name</code> and
+      <code>date_of_birth</code>. Each side still wires its own <code>beforeSend</code> because the RN
+      and React Sentry SDKs expose runtime-specific integration points.</li>
     <li><strong>WebView Session Replay matches RN baseline.</strong> <code>maskAllText: true</code>,
       <code>maskAllInputs: true</code>, replay sample rate matches the RN configuration (10% session,
       100% on error). DOM nodes carrying biometric content opt in to additional masking via a
@@ -176,13 +182,13 @@ Both SDKs → single Sentry project (correlation by attempt_id)</pre>
       Sentry by <code>attempt_id:&lt;uuid&gt;</code> to pull every event (RN host + WebView) for one
       attempt. No second correlation key is introduced.</li>
     <li><strong>No cross-bridge exception forwarding.</strong> A JS error inside the WebView is captured
-      by <code>@sentry/browser</code> directly; it is not serialized over the bridge to the RN host.
+      by <code>@sentry/react</code> directly; it is not serialized over the bridge to the RN host.
       The shared project + cohort tag taxonomy is enough to keep the forensic trail joined.</li>
     <li><strong>ANA-15's footer ports to webview-app, ANA-15 itself does not ship against RN.</strong>
       Per the umbrella's Cross-Workstream Dependencies note, ANA-15 is re-homed under
-      <code>WIA-14</code>. The shared <code>getCurrentAttemptId()</code> accessor in
-      <code>mobile-sdk-alpha</code> (added by ANA-15) is consumed; the React Native component is
-      rewritten as a webview-app component using Euclid tokens.</li>
+      <code>WIA-14</code>. The shared <code>getCurrentAttemptId()</code> accessor does not exist yet;
+      WIA-14 must add it to <code>mobile-sdk-alpha</code> before rendering the footer. The React Native
+      component is rewritten as a webview-app component using Euclid tokens.</li>
   </ol>
 </section>
 
@@ -196,11 +202,11 @@ Both SDKs → single Sentry project (correlation by attempt_id)</pre>
       new tag requires editing that module and is observable to both runtimes simultaneously.</li>
     <li>PII never enters a Sentry tag. Tag values pass through <code>sanitizeTagValue</code> on both
       sides. The redact regex applied in <code>beforeSend</code> matches on both sides.</li>
-    <li>Cohort tags clear on <code>Onboarding: Completed | Failed | Recovered</code> on both sides. A
-      long-lived session that completes one attempt and starts another does not leak tags from the prior
-      attempt.</li>
+    <li>Cohort tags clear on <code>Onboarding: Ended</code> on both sides. A long-lived session that
+      completes one attempt and starts another does not leak tags from the prior attempt.</li>
     <li>The WebView's <code>AnalyticsAdapter</code> has no path to Mixpanel/Segment when the WebView
-      runs inside the RN host. The only telemetry the WebView ships directly is Sentry (browser SDK).</li>
+      runs inside the RN host. The only telemetry the WebView ships directly is Sentry
+      (<code>@sentry/react</code>).</li>
     <li>Session Replay does not record screens between the WebView's <code>lifecycle.ready</code> and
       the first attempt-bootstrapping event unless <code>maskAllText</code>/<code>maskAllInputs</code>
       are on. The default is always-on masking; the WebView never disables it.</li>
@@ -212,15 +218,20 @@ Both SDKs → single Sentry project (correlation by attempt_id)</pre>
   <table>
     <thead><tr><th>ID</th><th>Title</th><th>Status</th></tr></thead>
     <tbody>
-      <tr><td>WIA-12</td><td>WebView Sentry browser SDK + cohort tags + redact list</td><td><span class="status pending">Pending</span></td></tr>
-      <tr><td>WIA-13</td><td>WebView Session Replay (web SDK) with mask wrappers</td><td><span class="status pending">Pending</span></td></tr>
-      <tr><td>WIA-14</td><td>Re-home ANA-15 <code>attempt_id</code> footer onto webview-app error screens</td><td><span class="status pending">Pending</span></td></tr>
+      <tr><td>WIA-12</td><td>WebView Sentry React SDK + cohort tags + redact list (<a href="./plans/WIA-12-webview-sentry-cohort-tags.html">plan</a>)</td><td><span class="status pending">Pending</span></td></tr>
+      <tr><td>WIA-13</td><td>WebView Session Replay (<code>@sentry/react</code>) with mask wrappers</td><td><span class="status pending">Pending</span></td></tr>
+      <tr><td>WIA-14</td><td>Re-home ANA-15 <code>attempt_id</code> footer; add missing <code>getCurrentAttemptId()</code> accessor first</td><td><span class="status pending">Pending</span></td></tr>
     </tbody>
   </table>
   <p>
     Migration of the cohort-tag mapping module into <code>mobile-sdk-alpha</code> ships with
     <code>WIA-12</code> (not a separate plan); the RN-side import path update is part of the same PR so
     there is no window where the two sides diverge.
+  </p>
+  <p>
+    <code>WIA-14</code> has a missing prerequisite: no <code>getCurrentAttemptId()</code> accessor
+    exists in <code>mobile-sdk-alpha</code> as of WIA-12 planning. The WIA-14 plan must add that
+    accessor before porting ANA-15's footer.
   </p>
 </section>
 

--- a/specs/projects/sdk/workstreams/webview-in-app/plans/WIA-12-webview-sentry-cohort-tags.html
+++ b/specs/projects/sdk/workstreams/webview-in-app/plans/WIA-12-webview-sentry-cohort-tags.html
@@ -149,8 +149,11 @@
       <code>OnboardingTagSnapshot</code>, cohort key list, <code>tagsFromAnalyticsEvent</code>,
       <code>sanitizeTagValue</code>, <code>SENSITIVE_KEY_PATTERN</code>, <code>REDACTED</code>, and
       redaction helper.</li>
-    <li><code>packages/mobile-sdk-alpha/src/index.ts</code> and the browser entrypoint if needed —
-      export the pure helpers needed by RN and WebView.</li>
+    <li>Pure helpers are exposed via dedicated subpath entrypoints rather than the package root:
+      <code>@selfxyz/mobile-sdk-alpha/observability</code> for the RN host and
+      <code>@selfxyz/mobile-sdk-alpha/browser</code> for the WebView app. The root
+      <code>src/index.ts</code> is intentionally left unchanged to keep the cohort helpers off the
+      main barrel.</li>
     <li><code>app/src/config/sentry.ts</code> — import the shared redaction pattern/helper instead of
       owning the regex.</li>
     <li><code>app/src/observability/onboardingContext.ts</code> — keep only RN-specific

--- a/specs/projects/sdk/workstreams/webview-in-app/plans/WIA-12-webview-sentry-cohort-tags.html
+++ b/specs/projects/sdk/workstreams/webview-in-app/plans/WIA-12-webview-sentry-cohort-tags.html
@@ -1,0 +1,329 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>WIA-12 — WebView Sentry React SDK, cohort tags, and redact parity</title>
+<style>
+  :root {
+    --bg: #fafbfc;
+    --surface: #ffffff;
+    --surface-alt: #f6f8fa;
+    --border: #d1d9e0;
+    --border-soft: #e1e4e8;
+    --text: #1f2328;
+    --muted: #656d76;
+    --accent: #0969da;
+    --accent-soft: #ddf4ff;
+    --high: #cf222e;
+    --high-soft: #ffebe9;
+    --med: #9a6700;
+    --med-soft: #fff8c5;
+    --done: #1a7f37;
+    --done-soft: #dafbe1;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font: 14px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    color: var(--text);
+    background: var(--bg);
+  }
+  code, pre, kbd { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; font-size: 0.9em; }
+  code { background: var(--surface-alt); padding: 1px 5px; border-radius: 4px; border: 1px solid var(--border-soft); }
+  pre { background: var(--surface-alt); padding: 12px 14px; border-radius: 6px; border: 1px solid var(--border-soft); overflow: auto; }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  header.topbar {
+    position: sticky; top: 0; z-index: 100;
+    background: var(--surface); border-bottom: 1px solid var(--border);
+    padding: 12px 24px;
+    display: flex; align-items: center; gap: 12px; flex-wrap: wrap;
+  }
+  header h1 { margin: 0; font-size: 16px; font-weight: 600; }
+  .pill {
+    font-size: 11px; padding: 2px 8px; border-radius: 999px; border: 1px solid var(--border); background: var(--surface-alt);
+  }
+  .pill.draft { color: var(--med); background: var(--med-soft); border-color: var(--med); }
+  .pill.high { color: var(--high); background: var(--high-soft); border-color: var(--high); }
+  .pill.scope { color: var(--accent); background: var(--accent-soft); border-color: var(--accent); }
+  .pill.active { color: var(--accent); background: var(--accent-soft); border-color: var(--accent); }
+  .pill.done { color: var(--done); background: var(--done-soft); border-color: var(--done); }
+  .spacer { flex: 1; }
+  .layout { display: grid; grid-template-columns: 220px minmax(0, 1fr); gap: 32px; max-width: 1100px; margin: 0 auto; padding: 24px; }
+  nav.toc { position: sticky; top: 64px; align-self: start; font-size: 13px; }
+  nav.toc h4 { margin: 0 0 6px 0; font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; }
+  nav.toc a { display: block; padding: 3px 0; color: var(--text); }
+  main { min-width: 0; }
+  main section { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 18px 22px; margin-bottom: 16px; }
+  main h2 { margin: 0 0 10px 0; font-size: 16px; }
+  main h3 { margin: 16px 0 6px 0; font-size: 13px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; }
+  main p { margin: 6px 0 10px 0; }
+  main ul, main ol { margin: 6px 0 10px 18px; padding: 0; }
+  main li { margin: 3px 0; }
+  table { border-collapse: collapse; width: 100%; margin: 8px 0; font-size: 13px; }
+  th, td { text-align: left; padding: 6px 10px; border-bottom: 1px solid var(--border-soft); }
+  th { background: var(--surface-alt); font-weight: 600; }
+  .status { font-size: 11px; padding: 2px 8px; border-radius: 999px; display: inline-block; white-space: nowrap; border: 1px solid var(--border); background: var(--surface-alt); color: var(--muted); }
+  .status.done { color: var(--done); background: var(--done-soft); border-color: var(--done); }
+  .status.active { color: var(--accent); background: var(--accent-soft); border-color: var(--accent); }
+  .status.pending { color: var(--muted); }
+  .callout { border-left: 3px solid var(--accent); background: var(--accent-soft); padding: 8px 12px; border-radius: 0 6px 6px 0; margin: 10px 0; }
+  .callout.warn { border-left-color: var(--high); background: var(--high-soft); }
+  .callout.note { border-left-color: var(--med); background: var(--med-soft); }
+  .arrow { color: var(--muted); }
+  .check { list-style: none; margin-left: 0; }
+  .check li::before { content: "☐ "; color: var(--muted); }
+</style>
+</head>
+<body>
+
+<header class="topbar">
+  <h1>WIA-12 · WebView Sentry React SDK, cohort tags, and redact parity</h1>
+  <span class="pill active">Ready</span>
+  <span class="pill high">Priority: High</span>
+  <span class="pill scope">Scope: mobile-sdk-alpha · app · webview-app</span>
+  <span class="pill">Target: &lt;1,500 LOC</span>
+  <span class="pill">2026-06-02</span>
+  <span class="spacer"></span>
+  <div>
+    <a href="../SPEC-OBSERVABILITY.html">↑ Observability Contract</a>
+  </div>
+</header>
+
+<div class="layout">
+
+<nav class="toc">
+  <h4>On this page</h4>
+  <a href="#context">Context</a>
+  <a href="#decisions">Decisions</a>
+  <a href="#files">Files modified</a>
+  <a href="#implementation">Implementation</a>
+  <a href="#tests">Tests</a>
+  <a href="#oos">Out of scope</a>
+  <a href="#validation">Validation</a>
+  <a href="#done">Done criteria</a>
+</nav>
+
+<main>
+
+<section id="context">
+  <h2>Context</h2>
+  <p>
+    <strong>You are adding the WebView-side Sentry surface.</strong> WIA-09 added RN-host load
+    diagnostics in <code>app/src/config/sentry.ts</code>, including <code>runtime: rn-host</code>,
+    <code>webview_source</code>, and the live PII key redaction pattern. <code>webview-app</code> still
+    has no Sentry dependency or cohort-tag wiring, so WebView errors cannot be searched by the same
+    <code>attempt_id</code> / document cohort tags as RN-host events.
+  </p>
+  <p>
+    You are extracting shared pure observability helpers into <code>mobile-sdk-alpha</code>. You are not
+    implementing Session Replay masking (<code>WIA-13</code>) or the attempt footer
+    (<code>WIA-14</code>).
+  </p>
+</section>
+
+<section id="decisions">
+  <h2>Decisions</h2>
+  <ol>
+    <li>Use <code>@sentry/react</code>, not <code>@sentry/browser</code>, in
+      <code>packages/webview-app</code>. This matches the React + Vite app shape and allows React
+      error-boundary/profiler integration.</li>
+    <li>Extract the live RN redaction pattern from <code>app/src/config/sentry.ts</code>; do not define
+      a new shorter regex. The current pattern is:</li>
+  </ol>
+  <pre>/passport|mrz|dg\d|chip|aadhaar|(?:first|last|full|given|family|holder|sur)_?name|name_?(?:first|last|of_?holder|holder)|date_?of_?birth|dob|birth|photo/i</pre>
+  <ol start="3">
+    <li>Split <code>app/src/observability/onboardingContext.ts</code> instead of moving it wholesale.
+      <code>packages/mobile-sdk-alpha/src/</code> must remain platform-agnostic and cannot import
+      <code>@sentry/react-native</code>.</li>
+    <li>Runtime-specific Sentry setters stay runtime-specific. RN uses
+      <code>@sentry/react-native</code>; WebView uses <code>@sentry/react</code>.</li>
+  </ol>
+</section>
+
+<section id="files">
+  <h2>Files Modified</h2>
+  <ul>
+    <li><code>packages/mobile-sdk-alpha/src/observability/onboardingContext.ts</code> (new) — pure
+      <code>OnboardingTagSnapshot</code>, cohort key list, <code>tagsFromAnalyticsEvent</code>,
+      <code>sanitizeTagValue</code>, <code>SENSITIVE_KEY_PATTERN</code>, <code>REDACTED</code>, and
+      redaction helper.</li>
+    <li><code>packages/mobile-sdk-alpha/src/index.ts</code> and the browser entrypoint if needed —
+      export the pure helpers needed by RN and WebView.</li>
+    <li><code>app/src/config/sentry.ts</code> — import the shared redaction pattern/helper instead of
+      owning the regex.</li>
+    <li><code>app/src/observability/onboardingContext.ts</code> — keep only RN-specific
+      <code>setOnboardingTags</code> / <code>clearOnboardingTags</code> wrappers plus re-exports if
+      existing app importers need them.</li>
+    <li><code>app/src/services/analytics.ts</code> — keep behavior identical; update imports only if
+      the split requires it.</li>
+    <li><code>app/src/screens/dev/sections/SentryTestSection.tsx</code> — update imports only if the
+      split requires it.</li>
+    <li><code>packages/webview-app/package.json</code> — add <code>@sentry/react</code>.</li>
+    <li><code>packages/webview-app/src/config/sentry.ts</code> (new) — initialize Sentry, set
+      <code>runtime: webview</code>, apply <code>beforeSend</code> redaction, expose runtime-local
+      cohort tag setters.</li>
+    <li><code>packages/webview-app/src/main.tsx</code> or equivalent app bootstrap — call
+      <code>initSentry()</code> and wrap the React app if needed.</li>
+    <li><code>packages/mobile-sdk-alpha/src/adapters/browser/analytics.ts</code> — add a pure optional
+      <code>onTrackEvent</code> hook if needed; do not import Sentry.</li>
+    <li><code>packages/webview-bridge/src/adapters/sdk-adapter-map.ts</code> — allow the WebView app to
+      pass the observed analytics adapter into SDK adapter assembly if the hardcoded adapter blocks
+      WIA-12 wiring.</li>
+    <li><code>packages/webview-app/src/providers/SelfClientProvider.tsx</code> — install the
+      WebView-local observed analytics adapter so UI calls and SDK calls both update Sentry cohort tags
+      before delegating to existing analytics delivery.</li>
+  </ul>
+</section>
+
+<section id="implementation">
+  <h2>Implementation</h2>
+
+  <h3>1 · Extract pure shared helpers</h3>
+  <p>Create a platform-agnostic observability module in <code>mobile-sdk-alpha</code>:</p>
+  <ul>
+    <li>Move <code>OnboardingTagSnapshot</code>, the cohort key list, and
+      <code>tagsFromAnalyticsEvent()</code> out of
+      <code>app/src/observability/onboardingContext.ts</code>.</li>
+    <li>Move <code>sanitizeTagValue</code> from <code>app/src/config/sentry.ts</code> if it is pure and
+      does not depend on RN/Sentry. If it has runtime coupling, create a pure SDK equivalent and update
+      RN to use it.</li>
+    <li>Move the live <code>SENSITIVE_KEY_PATTERN</code> from <code>app/src/config/sentry.ts</code>
+      exactly as-is.</li>
+    <li>Export a redaction helper that can redact breadcrumb/event <code>data</code>,
+      <code>contexts</code>, and <code>extra</code> without importing a Sentry SDK.</li>
+  </ul>
+  <p class="callout warn">
+    Required constraint: no imports from <code>react-native</code>, <code>@sentry/react-native</code>,
+    <code>@sentry/react</code>, browser globals, or app aliases in the SDK module.
+  </p>
+
+  <h3>2 · Preserve RN behavior</h3>
+  <p>
+    Update <code>app/src/config/sentry.ts</code> to use the shared redaction pattern/helper. Keep
+    <code>captureWebViewLoadDiagnostic()</code> behavior unchanged:
+  </p>
+  <ul>
+    <li><code>runtime: rn-host</code></li>
+    <li><code>webview_source: bundle | dev-server</code></li>
+    <li><code>error_code: timeout | load_error | version_mismatch</code></li>
+    <li>existing warning/error level semantics</li>
+  </ul>
+  <p>
+    Update <code>app/src/observability/onboardingContext.ts</code> so it still exports the names current
+    RN importers use, but the concrete <code>Sentry.setTag()</code> calls remain in <code>app/</code>.
+  </p>
+
+  <h3>3 · Add WebView Sentry config</h3>
+  <p>Install <code>@sentry/react</code> in <code>packages/webview-app</code>.</p>
+  <p>Create a WebView Sentry config that:</p>
+  <ul>
+    <li>Initializes only when a DSN is configured for the WebView app.</li>
+    <li>Sets <code>runtime: webview</code> at init and never clears it.</li>
+    <li>Applies the shared redaction helper in <code>beforeSend</code>.</li>
+    <li>Exposes <code>setOnboardingTags(snapshot)</code> and <code>clearOnboardingTags()</code>
+      wrappers around <code>@sentry/react</code> tag APIs.</li>
+    <li>Does not forward WebView exceptions over the RN bridge.</li>
+  </ul>
+  <p class="callout">Do not add Session Replay in this PR; <code>WIA-13</code> owns replay sample rates and mask wrappers.</p>
+
+  <h3>4 · Wire cohort tags from WebView analytics</h3>
+  <p>
+    Hook the existing WebView analytics path. <code>packages/mobile-sdk-alpha/src/adapters/browser/analytics.ts</code>
+    already has <code>trackEvent(event, payload)</code>, so the WebView side has a clean interception
+    point. The SDK adapter may expose a pure callback hook, but the Sentry call itself must be wired
+    from <code>webview-app</code>.
+  </p>
+  <p>For every tracked onboarding event:</p>
+  <ul>
+    <li>Build a snapshot via shared <code>tagsFromAnalyticsEvent(eventName, properties)</code>.</li>
+    <li>Call WebView <code>setOnboardingTags(snapshot)</code> for non-terminal onboarding events from a
+      <code>webview-app</code> wrapper/callback.</li>
+    <li>Call WebView <code>clearOnboardingTags()</code> when the event is terminal from the same
+      runtime-local wrapper/callback.</li>
+    <li>Keep Mixpanel/Segment delivery RN-host-only through the bridge; do not add Segment or Mixpanel
+      to <code>webview-app</code>.</li>
+  </ul>
+  <p>
+    Terminal clear semantics must match RN. The current RN code clears on
+    <code>OnboardingEvents.ENDED</code> (<code>Onboarding: Ended</code>), not on a hand-maintained list
+    of outcome strings.
+  </p>
+  <p class="callout warn">
+    Required constraint: neither <code>packages/mobile-sdk-alpha/src/adapters/browser/analytics.ts</code>
+    nor <code>packages/webview-bridge/src/</code> imports <code>@sentry/react</code> or
+    <code>packages/webview-app/src/config/sentry</code>. Those packages can accept callbacks/adapters;
+    only <code>webview-app</code> owns concrete Sentry wiring.
+  </p>
+</section>
+
+<section id="tests">
+  <h2>Tests</h2>
+  <ul>
+    <li><code>packages/mobile-sdk-alpha/tests/observability/onboardingContext.test.ts</code> — pure
+      mapping, sanitization, redaction pattern coverage for live name/DOB variants, and terminal-event
+      helper if added.</li>
+    <li><code>app/tests/src/config/sentry.test.ts</code> — still proves RN redaction covers breadcrumbs,
+      contexts, and extra.</li>
+    <li><code>app/tests/src/observability/onboardingContext.test.ts</code> — now focuses on RN wrappers
+      calling <code>Sentry.setTag</code> / clear with sanitized values.</li>
+    <li><code>packages/webview-app</code> tests for Sentry config if the app has an established test
+      harness; otherwise add coverage at the SDK pure-helper layer and document the WebView config
+      manual validation.</li>
+  </ul>
+  <p class="callout warn">Avoid nested <code>require('react-native')</code> in tests.</p>
+</section>
+
+<section id="oos">
+  <h2>Out of Scope</h2>
+  <ul>
+    <li>Session Replay setup, sample rates, and DOM mask wrappers (<code>WIA-13</code>).</li>
+    <li><code>getCurrentAttemptId()</code> and attempt footer UI (<code>WIA-14</code>).</li>
+    <li>New cohort tag names or terminal semantics.</li>
+    <li>Sentry tracing/performance instrumentation.</li>
+    <li>Cross-bridge exception forwarding.</li>
+    <li>Adding Segment or Mixpanel to the WebView bundle.</li>
+  </ul>
+</section>
+
+<section id="validation">
+  <h2>Validation</h2>
+  <pre>yarn workspace @selfxyz/mobile-sdk-alpha test
+yarn workspace @selfxyz/mobile-sdk-alpha types
+yarn workspace @selfxyz/mobile-app test src/config/sentry src/observability/onboardingContext src/services/analytics
+yarn workspace @selfxyz/mobile-app types
+yarn workspace @selfxyz/webview-app build</pre>
+
+  <h3>Manual validation</h3>
+  <ol>
+    <li>Configure the WebView app with the same Sentry DSN as the RN host.</li>
+    <li>Start an onboarding attempt inside the WebView runtime.</li>
+    <li>Trigger a synthetic WebView error after an onboarding event carrying <code>attempt_id</code>.</li>
+    <li>Confirm the Sentry event has <code>runtime:webview</code>, <code>attempt_id:&lt;uuid&gt;</code>,
+      and the expected document cohort tags.</li>
+    <li>Confirm sensitive keys matching the live regex are redacted in <code>breadcrumbs</code>,
+      <code>contexts</code>, and <code>extra</code>.</li>
+    <li>Force a terminal onboarding event and verify cohort tags clear before the next attempt.</li>
+  </ol>
+</section>
+
+<section id="done">
+  <h2>Done Criteria</h2>
+  <ul>
+    <li>WebView errors arrive in the shared Sentry project with <code>runtime:webview</code>.</li>
+    <li>RN-host WIA-09 load diagnostics keep <code>runtime:rn-host</code> and the same redaction behavior.</li>
+    <li>Cohort tag mapping and redaction pattern have one pure source of truth in <code>mobile-sdk-alpha</code>.</li>
+    <li>No Sentry package is imported from <code>mobile-sdk-alpha/src/</code> outside runtime adapters.</li>
+    <li>No package imports from <code>packages/webview-app/src/</code>; WebView-specific Sentry wiring is
+      passed in via callbacks/adapters.</li>
+    <li>WebView uses <code>@sentry/react</code>, not <code>@sentry/browser</code>.</li>
+    <li>Existing RN importers continue to compile.</li>
+  </ul>
+</section>
+
+</main>
+</div>
+
+</body>
+</html>

--- a/yarn.lock
+++ b/yarn.lock
@@ -11919,6 +11919,7 @@ __metadata:
     "@selfxyz/euclid-core": "npm:1.4.6"
     "@selfxyz/mobile-sdk-alpha": "workspace:^"
     "@selfxyz/webview-bridge": "workspace:^"
+    "@sentry/react": "npm:^9.32.0"
     "@testing-library/react": "npm:^14.1.2"
     "@types/react": "npm:^18.3.4"
     "@types/react-dom": "npm:^18.3.0"


### PR DESCRIPTION
## Summary

- Extracts the PII redaction + tag-sanitization helpers out of the RN app's `sentry.ts` into a platform-agnostic SDK module so the RN host and WebView app share one implementation (no `react-native`, Sentry SDK, or browser globals in core).
- Adds onboarding **cohort tags** (`attempt_id`, branch, `document_country`/`document_type`, `signature_algorithm`, `csca_hash_algorithm`, `kyc_provider`) derived from analytics events, stamped onto the Sentry scope on both runtimes and cleared on `Onboarding: Ended`.
- Wires the WebView app's own `@sentry/react` init with a `runtime: webview` tag, PII-redacting `beforeSend`, and a `withCohortTags` analytics decorator applied to both the UI and SDK-client adapters.

## Changes

### SDK core (`packages/mobile-sdk-alpha`)
- New `src/observability/onboardingContext.ts`: `OnboardingTagSnapshot`, `COHORT_TAG_KEYS`, `tagsFromAnalyticsEvent`, `sanitizeTagValue`, `SENSITIVE_KEY_PATTERN`, `REDACTED`, and `redactSensitiveFields` — pure, SDK-agnostic.
- Exposed via dedicated subpath entrypoints: `/observability` (RN host) and re-exported from `/browser` (WebView). New `observability` build entry in `tsup.config.ts` + `package.json` export; root barrel intentionally unchanged.
- Tests: `tests/observability/onboardingContext.test.ts` (41 cases) covering tag mapping, sanitization, redaction, and key list.

### React Native app (`app/`)
- `src/config/sentry.ts` now imports `redactSensitiveFields`/`sanitizeTagValue` from the SDK and deletes its local copies (single source of truth).
- `src/observability/onboardingContext.ts` keeps only the RN-specific `setOnboardingTags`/`clearOnboardingTags` Sentry wrappers over the shared helpers.

### WebView app (`packages/webview-app`)
- New `src/config/sentry.ts` — `@sentry/react` init gated on `VITE_SENTRY_DSN`, `runtime: webview` tag, redacting `beforeSend`, plus `setOnboardingTags`/`clearOnboardingTags`. No tracing, no Session Replay (owned by WIA-13).
- New `src/observability/observedAnalytics.ts` — `withCohortTags` adapter decorator mirroring the RN host's cohort side effect.
- `main.tsx` calls `initSentry()` at startup; `SelfClientProvider` wraps both the web analytics adapter and the bridge console adapter with `withCohortTags`.

### WebView bridge
- `createSdkAdapters` accepts an optional `analytics` adapter override (defaults to the web analytics adapter) so the app can inject the cohort-tag observed adapter.

## Notes
- The live biometric parse path emits `csca_hash_algorithm`; the mapper reads that key directly (fixed a mismatch where it read `csca_hash_function`).
- Spec: `specs/projects/sdk/workstreams/webview-in-app/plans/WIA-12-webview-sentry-cohort-tags.html` and `SPEC-OBSERVABILITY.html`.

## Test Plan

- [x] `yarn lint && yarn types` pass (repo-wide)
- [x] `cd packages/mobile-sdk-alpha && yarn test` — observability suite 41/41
- [ ] `cd app && yarn jest:run` — RN host sentry/onboarding/analytics tests
- [ ] `cd packages/webview-app && yarn build` + vitest
- [ ] Manual: confirm cohort tags appear on Sentry events from a WebView onboarding run and clear on `Onboarding: Ended`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebView now initializes Sentry for client-side error telemetry and sets runtime tag "webview".
  * Cohort tagging: onboarding/KYC analytics events drive Sentry cohort tags; tags clear on onboarding completion.
  * Analytics adapters auto-update cohort tags before sending events.

* **Bug Fixes / Privacy**
  * Automatic redaction and sanitization of sensitive fields and tag values in telemetry.

* **Chores**
  * Shared observability utilities added to the SDK and exported for cross-platform use; tests and docs added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->