### PR TITLE
add WebView Session Replay with PII masking

### DIFF
--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -358,6 +358,12 @@ jobs:
           path: app/android/app/build/outputs/apk/debug/app-debug.apk
           key: ${{ runner.os }}-apk-v2-${{ hashFiles('app/android/app/src/**', 'app/android/app/build.gradle', 'app/android/app/proguard-rules.pro', 'app/android/build.gradle', 'app/android/settings.gradle', 'app/android/gradle.properties', 'app/android/gradle/wrapper/**', 'app/android/gradlew', 'app/src/**', 'app/App.tsx', 'app/index.js', 'app/app.json', 'app/package.json', 'app/babel.config.cjs', 'app/metro.config.cjs', 'app/react-native.config.cjs', 'app/patches/**', 'patches/**', 'packages/mobile-sdk-alpha/src/**', 'packages/mobile-sdk-alpha/package.json', 'yarn.lock', '.nvmrc', '.apk-cache-inputs.txt') }}
 
+      - name: Publish KMP SDK to mavenLocal
+        if: steps.apk-cache.outputs.cache-hit != 'true'
+        run: |
+          chmod +x packages/kmp-sdk/gradlew
+          cd packages/kmp-sdk && ./gradlew :shared:publishToMavenLocal --quiet
+
       - name: Build Android APK
         if: steps.apk-cache.outputs.cache-hit != 'true'
         env:

--- a/app/tests/e2e/webview-host-rn-sdk.android.flow.yaml
+++ b/app/tests/e2e/webview-host-rn-sdk.android.flow.yaml
@@ -28,5 +28,5 @@ appId: com.proofofpassportapp
     notVisible: '^(Still loading…|Couldn''t load Self\.)$'
     timeout: 3000
 - extendedWaitUntil:
-    notVisible: '^Retry$'
+    notVisible: "^Retry$"
     timeout: 8000

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -11,10 +11,7 @@
     "paths": {
       "@env": ["./env.ts"],
       "@/package.json": ["./package.json"],
-      "@selfxyz/rn-sdk": [
-        "../packages/rn-sdk/src",
-        "../packages/rn-sdk/dist"
-      ],
+      "@selfxyz/rn-sdk": ["../packages/rn-sdk/src", "../packages/rn-sdk/dist"],
       "@selfxyz/mobile-sdk-alpha": [
         "../packages/mobile-sdk-alpha/src",
         "../packages/mobile-sdk-alpha/dist"

--- a/packages/webview-app/src/config/sentry.ts
+++ b/packages/webview-app/src/config/sentry.ts
@@ -5,7 +5,7 @@
 import type { OnboardingTagSnapshot } from '@selfxyz/mobile-sdk-alpha/browser';
 import { COHORT_TAG_KEYS, redactSensitiveFields, sanitizeTagValue } from '@selfxyz/mobile-sdk-alpha/browser';
 
-import { breadcrumbsIntegration, init as sentryInit, setTag } from '@sentry/react';
+import { breadcrumbsIntegration, init as sentryInit, replayIntegration, setTag } from '@sentry/react';
 
 const SENTRY_DSN = import.meta.env.VITE_SENTRY_DSN as string | undefined;
 
@@ -17,11 +17,15 @@ export function initSentry(): void {
   sentryInit({
     dsn: SENTRY_DSN,
     environment: import.meta.env.MODE,
-    // Default integrations capture unhandled errors. Session Replay is NOT a
-    // default integration and is intentionally not added here — WIA-13 owns
-    // replay sample rates and DOM mask wrappers.
     // No tracing/performance instrumentation (parity with ANA-13).
     tracesSampleRate: 0,
+    // Session Replay parity with the RN host (mobileReplayIntegration): 10% of
+    // sessions, 100% of errored sessions. Browser replay has no maskAllImages/
+    // maskAllVectors — blockAllMedia is the equivalent (covers <img> and <svg>).
+    // These masking defaults are never disabled; the WebView's only PII render
+    // sites (ID data + recovery mnemonic) are additionally wrapped in PrivacyMask.
+    replaysSessionSampleRate: 0.1,
+    replaysOnErrorSampleRate: 1.0,
     // Drop the free-text breadcrumb sources: `dom` captures user input/labels
     // and `console` captures arbitrary logged strings, both of which can hold
     // PII that beforeSend cannot reliably scrub. URL-bearing crumbs (navigation/
@@ -29,6 +33,7 @@ export function initSentry(): void {
     integrations: defaults => [
       ...defaults.filter(integration => integration.name !== 'Breadcrumbs'),
       breadcrumbsIntegration({ console: false, dom: false }),
+      replayIntegration({ maskAllText: true, maskAllInputs: true, blockAllMedia: true }),
     ],
     // The runtime tag distinguishes WebView events from the RN host's
     // `runtime: rn-host` in the shared Sentry project. Set once, never cleared.

--- a/packages/webview-app/src/observability/PrivacyMask.tsx
+++ b/packages/webview-app/src/observability/PrivacyMask.tsx
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import type React from 'react';
+
+// `sentry-mask` is Sentry Session Replay's default mask class: descendants are
+// redacted in the replay regardless of the global maskAllText default. Mirrors
+// the RN host's PrivacyMask (app/src/observability/PrivacyMask.tsx) so PII screens
+// stay masked even if the global replay config changes. Applies a class only —
+// must not import the Sentry SDK.
+const MASK_CLASS = 'sentry-mask';
+
+interface PrivacyMaskProps {
+  children: React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+export const PrivacyMask: React.FC<PrivacyMaskProps> = ({ children, className, style }) => (
+  // `display: contents` keeps the wrapper out of layout while staying in the DOM
+  // tree, so masking applies without disturbing the wrapped screen's flexbox.
+  <div className={className ? `${MASK_CLASS} ${className}` : MASK_CLASS} style={{ display: 'contents', ...style }}>
+    {children}
+  </div>
+);

--- a/packages/webview-app/src/screens/home/IDDataScreen.tsx
+++ b/packages/webview-app/src/screens/home/IDDataScreen.tsx
@@ -13,6 +13,7 @@ import {
   QuestionCircleStrokeIcon,
 } from '@selfxyz/euclid';
 
+import { PrivacyMask } from '../../observability/PrivacyMask';
 import { useSelfClient } from '../../providers/SelfClientProvider';
 import { WEB_SAFE_AREA } from '../../utils/insets';
 
@@ -56,28 +57,30 @@ export const IDDataScreen: React.FC = () => {
   }, [navigate, haptic, analytics]);
 
   return (
-    <EuclidIDDataScreen
-      insets={WEB_SAFE_AREA.insets}
-      idCard={{
-        title: 'Passport',
-        subtitleLine1: 'UNITED STATES PASSPORT',
-        details: MOCK_ID_CARD_DETAILS,
-        mrzLine1: 'P<USA0000000000USA9001150M3001150<<<<<<<<<<<<<<',
-        mrzLine2: 'DOE<<JOHN<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<0',
-      }}
-      identificationDetailsTitle="Identification details"
-      identificationDetailsDescription="All data is stored locally on your device. Self does not collect or share any of this information without your consent."
-      identificationDetailsLogo={
-        <div style={{ width: 32, height: 21, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-          <IdCardIcon size={24} color="#2563EB" />
-        </div>
-      }
-      documentData={MOCK_DOCUMENT_DATA}
-      onClose={handleBack}
-      onInfo={() => analytics.trackEvent('id_data_info_pressed')}
-      onManageID={onManageID}
-      closeIcon={({ size, color }) => <LeftArrowIcon size={size} color={color} />}
-      infoIcon={({ size, color }) => <QuestionCircleStrokeIcon size={size} color={color} />}
-    />
+    <PrivacyMask>
+      <EuclidIDDataScreen
+        insets={WEB_SAFE_AREA.insets}
+        idCard={{
+          title: 'Passport',
+          subtitleLine1: 'UNITED STATES PASSPORT',
+          details: MOCK_ID_CARD_DETAILS,
+          mrzLine1: 'P<USA0000000000USA9001150M3001150<<<<<<<<<<<<<<',
+          mrzLine2: 'DOE<<JOHN<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<0',
+        }}
+        identificationDetailsTitle="Identification details"
+        identificationDetailsDescription="All data is stored locally on your device. Self does not collect or share any of this information without your consent."
+        identificationDetailsLogo={
+          <div style={{ width: 32, height: 21, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <IdCardIcon size={24} color="#2563EB" />
+          </div>
+        }
+        documentData={MOCK_DOCUMENT_DATA}
+        onClose={handleBack}
+        onInfo={() => analytics.trackEvent('id_data_info_pressed')}
+        onManageID={onManageID}
+        closeIcon={({ size, color }) => <LeftArrowIcon size={size} color={color} />}
+        infoIcon={({ size, color }) => <QuestionCircleStrokeIcon size={size} color={color} />}
+      />
+    </PrivacyMask>
   );
 };

--- a/packages/webview-app/src/screens/recovery/RecoveryPhraseScreen.tsx
+++ b/packages/webview-app/src/screens/recovery/RecoveryPhraseScreen.tsx
@@ -20,6 +20,7 @@ import {
 } from '@selfxyz/euclid';
 import { bridgeStorageAdapter } from '@selfxyz/webview-bridge/adapters';
 
+import { PrivacyMask } from '../../observability/PrivacyMask';
 import { useBridge } from '../../providers/BridgeProvider';
 import { useSelfClient } from '../../providers/SelfClientProvider';
 import { WEB_SAFE_AREA } from '../../utils/insets';
@@ -225,16 +226,18 @@ const RecoveryPhraseScreenBase: React.FC<RecoveryPhraseScreenBaseProps> = ({
   }, [haptic, analytics, words]);
 
   return (
-    <EuclidRecoveryPhraseScreen
-      insets={WEB_SAFE_AREA.insets}
-      words={words}
-      variant={variant}
-      onBack={handleBack}
-      onReveal={onReveal}
-      onCopy={onCopy}
-      onAppleBackup={onAppleBackup}
-      onGoogleBackup={onGoogleBackup}
-    />
+    <PrivacyMask>
+      <EuclidRecoveryPhraseScreen
+        insets={WEB_SAFE_AREA.insets}
+        words={words}
+        variant={variant}
+        onBack={handleBack}
+        onReveal={onReveal}
+        onCopy={onCopy}
+        onAppleBackup={onAppleBackup}
+        onGoogleBackup={onGoogleBackup}
+      />
+    </PrivacyMask>
   );
 };
 
@@ -306,13 +309,15 @@ const SettingsRecoveryPhraseScreen: React.FC<{ onBack: () => void }> = ({ onBack
               </div>
             </div>
             <div style={settingsStyles.recoveryPhraseContainer}>
-              <RecoveryPhrase
-                variant={variant}
-                words={words || recoveryPhrasePlaceholderWords}
-                onReveal={onReveal}
-                onCopy={onCopy}
-                revealButtonText={copy.revealButtonLabel}
-              />
+              <PrivacyMask>
+                <RecoveryPhrase
+                  variant={variant}
+                  words={words || recoveryPhrasePlaceholderWords}
+                  onReveal={onReveal}
+                  onCopy={onCopy}
+                  revealButtonText={copy.revealButtonLabel}
+                />
+              </PrivacyMask>
             </div>
           </div>
         </div>

--- a/packages/webview-app/src/screens/recovery/SecretPhraseInputScreen.tsx
+++ b/packages/webview-app/src/screens/recovery/SecretPhraseInputScreen.tsx
@@ -24,6 +24,7 @@ import {
 } from '@selfxyz/mobile-sdk-alpha/browser';
 import { bridgeStorageAdapter } from '@selfxyz/webview-bridge/adapters';
 
+import { PrivacyMask } from '../../observability/PrivacyMask';
 import { useBridge } from '../../providers/BridgeProvider';
 import { useSelfClient } from '../../providers/SelfClientProvider';
 import type { NavState } from '../../types/navState';
@@ -304,13 +305,15 @@ export const SecretPhraseInputScreen: React.FC = () => {
 
       <div style={styles.content}>
         <span style={styles.instruction}>{instruction}</span>
-        <SecretPhraseInput
-          words={words}
-          onWordChange={handleWordChange}
-          onWordBlur={handleWordBlur}
-          errorIndices={errorIndices}
-          wordCount={WORD_COUNT}
-        />
+        <PrivacyMask>
+          <SecretPhraseInput
+            words={words}
+            onWordChange={handleWordChange}
+            onWordBlur={handleWordBlur}
+            errorIndices={errorIndices}
+            wordCount={WORD_COUNT}
+          />
+        </PrivacyMask>
         {errorMessage ? (
           <div aria-live="polite" role="alert" style={styles.errorMessage}>
             {isLocked && lockoutSecondsRemaining > 0

--- a/packages/webview-app/tests/config/sentry.test.ts
+++ b/packages/webview-app/tests/config/sentry.test.ts
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sentryInit = vi.fn();
+const replayIntegration = vi.fn((...args: unknown[]) => ({ name: 'Replay', options: args[0] }));
+const breadcrumbsIntegration = vi.fn((...args: unknown[]) => ({ name: 'Breadcrumbs', options: args[0] }));
+const setTag = vi.fn();
+
+vi.mock('@sentry/react', () => ({
+  init: (...args: unknown[]) => sentryInit(...args),
+  replayIntegration: (...args: unknown[]) => replayIntegration(...args),
+  breadcrumbsIntegration: (...args: unknown[]) => breadcrumbsIntegration(...args),
+  setTag: (...args: unknown[]) => setTag(...args),
+}));
+
+vi.mock('@selfxyz/mobile-sdk-alpha/browser', () => ({
+  COHORT_TAG_KEYS: [],
+  redactSensitiveFields: (event: unknown) => event,
+  sanitizeTagValue: (value: unknown) => String(value),
+}));
+
+const DSN = 'https://examplePublicKey@o0.ingest.sentry.io/0';
+
+describe('webview-app Sentry config', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.stubEnv('VITE_SENTRY_DSN', DSN);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('registers Session Replay with always-on masking and RN-parity sample rates', async () => {
+    const { initSentry } = await import('../../src/config/sentry');
+    initSentry();
+
+    expect(sentryInit).toHaveBeenCalledTimes(1);
+    const config = sentryInit.mock.calls[0][0] as {
+      replaysSessionSampleRate: number;
+      replaysOnErrorSampleRate: number;
+      integrations: (defaults: Array<{ name: string }>) => Array<{ name: string }>;
+    };
+
+    expect(config.replaysSessionSampleRate).toBe(0.1);
+    expect(config.replaysOnErrorSampleRate).toBe(1.0);
+
+    const integrations = config.integrations([]);
+    expect(integrations.some(integration => integration.name === 'Replay')).toBe(true);
+    expect(replayIntegration).toHaveBeenCalledWith({
+      maskAllText: true,
+      maskAllInputs: true,
+      blockAllMedia: true,
+    });
+  });
+
+  it('does not initialize Sentry (or replay) without a DSN', async () => {
+    vi.stubEnv('VITE_SENTRY_DSN', '');
+    vi.resetModules();
+
+    const { initSentry, isSentryEnabled } = await import('../../src/config/sentry');
+    initSentry();
+
+    expect(isSentryEnabled).toBe(false);
+    expect(sentryInit).not.toHaveBeenCalled();
+    expect(replayIntegration).not.toHaveBeenCalled();
+  });
+});

--- a/packages/webview-app/tests/guards/sentryImportBoundary.test.ts
+++ b/packages/webview-app/tests/guards/sentryImportBoundary.test.ts
@@ -13,7 +13,8 @@ import { describe, expect, it } from 'vitest';
 // only pass pure helpers/callbacks across the boundary.
 const PACKAGES_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 const GUARDED_ROOTS = [join(PACKAGES_DIR, 'mobile-sdk-alpha', 'src'), join(PACKAGES_DIR, 'webview-bridge', 'src')];
-const SENTRY_IMPORT = /(?:import\s+[^'"]*from\s*|import\s*|export\s+[^'"]*from\s*|require\(\s*|import\(\s*)['"]@sentry\//;
+const SENTRY_IMPORT =
+  /(?:import\s+[^'"]*from\s*|import\s*|export\s+[^'"]*from\s*|require\(\s*|import\(\s*)['"]@sentry\//;
 
 function collectSourceFiles(dir: string): string[] {
   const files: string[] = [];

--- a/packages/webview-app/tests/guards/sentryImportBoundary.test.ts
+++ b/packages/webview-app/tests/guards/sentryImportBoundary.test.ts
@@ -13,7 +13,7 @@ import { describe, expect, it } from 'vitest';
 // only pass pure helpers/callbacks across the boundary.
 const PACKAGES_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 const GUARDED_ROOTS = [join(PACKAGES_DIR, 'mobile-sdk-alpha', 'src'), join(PACKAGES_DIR, 'webview-bridge', 'src')];
-const SENTRY_IMPORT = /(?:import[^;]*from|require\(\s*)\s*['"]@sentry\//;
+const SENTRY_IMPORT = /(?:import\s+[^'"]*from\s*|import\s*|export\s+[^'"]*from\s*|require\(\s*|import\(\s*)['"]@sentry\//;
 
 function collectSourceFiles(dir: string): string[] {
   const files: string[] = [];

--- a/packages/webview-app/tests/guards/sentryImportBoundary.test.ts
+++ b/packages/webview-app/tests/guards/sentryImportBoundary.test.ts
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+// WIA-13 invariant: Session Replay / Sentry wiring is owned by webview-app. The
+// platform-agnostic SDK core and the bridge must never import a Sentry SDK — they
+// only pass pure helpers/callbacks across the boundary.
+const PACKAGES_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const GUARDED_ROOTS = [join(PACKAGES_DIR, 'mobile-sdk-alpha', 'src'), join(PACKAGES_DIR, 'webview-bridge', 'src')];
+const SENTRY_IMPORT = /(?:import[^;]*from|require\(\s*)\s*['"]@sentry\//;
+
+function collectSourceFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectSourceFiles(fullPath));
+    } else if (/\.(ts|tsx|js|jsx)$/.test(entry.name)) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+describe('Sentry import boundary', () => {
+  it.each(GUARDED_ROOTS)('no @sentry import leaks into %s', root => {
+    const offenders = collectSourceFiles(root).filter(file => SENTRY_IMPORT.test(readFileSync(file, 'utf8')));
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/webview-app/tests/observability/PrivacyMask.test.tsx
+++ b/packages/webview-app/tests/observability/PrivacyMask.test.tsx
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2025-2026 Social Connect Labs, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+// NOTE: Converts to Apache-2.0 on 2029-06-11 per LICENSE.
+
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { PrivacyMask } from '../../src/observability/PrivacyMask';
+
+import { cleanup, render } from '@testing-library/react';
+
+afterEach(cleanup);
+
+describe('PrivacyMask', () => {
+  it('wraps children in the Session Replay sentry-mask class', () => {
+    const { getByText } = render(
+      <PrivacyMask>
+        <span>secret</span>
+      </PrivacyMask>,
+    );
+
+    const wrapper = getByText('secret').parentElement;
+    expect(wrapper?.classList.contains('sentry-mask')).toBe(true);
+  });
+
+  it('merges a caller-provided className while keeping sentry-mask', () => {
+    const { getByText } = render(
+      <PrivacyMask className="custom">
+        <span>secret</span>
+      </PrivacyMask>,
+    );
+
+    const wrapper = getByText('secret').parentElement;
+    expect(wrapper?.classList.contains('sentry-mask')).toBe(true);
+    expect(wrapper?.classList.contains('custom')).toBe(true);
+  });
+});

--- a/specs/projects/sdk/workstreams/webview-in-app/SPEC-OBSERVABILITY.html
+++ b/specs/projects/sdk/workstreams/webview-in-app/SPEC-OBSERVABILITY.html
@@ -101,10 +101,15 @@
     <li>Sentry React SDK initialization inside <code>webview-app</code> via <code>@sentry/react</code>.</li>
     <li>Cohort-tag continuity: same key set, same source mappings, same sanitization, same
       terminal-event clear semantics as ANA-13.</li>
-    <li>PII masking inside the WebView DOM: equivalents to the RN-side <code>PrivacyMask</code> wrappers
-      on biometric capture / NFC / data-confirmation / Aadhaar / KYC-verified screens.</li>
-    <li>Session Replay configuration in the React SDK matching the RN baseline
-      (<code>maskAllText</code>, <code>maskAllImages</code>, <code>maskAllVectors</code>).</li>
+    <li>PII masking inside the WebView DOM via a web <code>PrivacyMask</code> wrapper (the
+      <code>sentry-mask</code> class) on the screens that actually render PII web-side:
+      <code>IDDataScreen</code> and the recovery mnemonic reveal/input screens. Camera (MRZ) and NFC are
+      native bridge calls — no frames or chip data enter the WebView DOM; MRZ fields transit WebView
+      state/bridge calls but are not displayed.</li>
+    <li>Session Replay configuration in the React SDK matching the RN baseline. The browser SDK has no
+      <code>maskAllImages</code>/<code>maskAllVectors</code>; the equivalent set is
+      <code>maskAllText: true</code>, <code>maskAllInputs: true</code>, <code>blockAllMedia: true</code>
+      (<code>blockAllMedia</code> covers <code>&lt;img&gt;</code> and <code>&lt;svg&gt;</code>).</li>
     <li><code>beforeSend</code> redact list parity with ANA-13.</li>
     <li>ANA-15's <code>attempt_id</code> footer ported to the webview-app screens that replace
       <code>KycFailureScreen</code>, <code>DocumentNFCTroubleScreen</code>,
@@ -173,11 +178,13 @@ Both SDKs → single Sentry project (correlation by attempt_id)</pre>
       <code>date_of_birth</code>. Each side still wires its own <code>beforeSend</code> because the RN
       and React Sentry SDKs expose runtime-specific integration points.</li>
     <li><strong>WebView Session Replay matches RN baseline.</strong> <code>maskAllText: true</code>,
-      <code>maskAllInputs: true</code>, replay sample rate matches the RN configuration (10% session,
-      100% on error). DOM nodes carrying biometric content opt in to additional masking via a
-      <code>data-sentry-mask</code> attribute on the wrapper element. The list of wrapper sites mirrors
-      the RN <code>PrivacyMask</code> list (biometric capture, NFC scan, data confirmation, Aadhaar
-      upload, KYC verified).</li>
+      <code>maskAllInputs: true</code>, <code>blockAllMedia: true</code> (the browser equivalent of the RN
+      <code>maskAllImages</code>/<code>maskAllVectors</code>); replay sample rate matches the RN
+      configuration (10% session, 100% on error). PII-bearing screens additionally opt in to masking via a
+      web <code>PrivacyMask</code> wrapper applying Sentry's default <code>sentry-mask</code> class (not a
+      <code>data-sentry-mask</code> attribute). The wrapper sites are the web-side PII renderers:
+      <code>IDDataScreen</code>, <code>RecoveryPhraseScreen</code>, and
+      <code>SecretPhraseInputScreen</code>.</li>
     <li><strong>Cross-runtime correlation is by <code>attempt_id</code>.</strong> Engineers search
       Sentry by <code>attempt_id:&lt;uuid&gt;</code> to pull every event (RN host + WebView) for one
       attempt. No second correlation key is introduced.</li>
@@ -219,7 +226,7 @@ Both SDKs → single Sentry project (correlation by attempt_id)</pre>
     <thead><tr><th>ID</th><th>Title</th><th>Status</th></tr></thead>
     <tbody>
       <tr><td>WIA-12</td><td>WebView Sentry React SDK + cohort tags + redact list (<a href="./plans/WIA-12-webview-sentry-cohort-tags.html">plan</a>)</td><td><span class="status pending">Pending</span></td></tr>
-      <tr><td>WIA-13</td><td>WebView Session Replay (<code>@sentry/react</code>) with mask wrappers</td><td><span class="status pending">Pending</span></td></tr>
+      <tr><td>WIA-13</td><td><a href="./plans/WIA-13-webview-session-replay.html">WebView Session Replay (<code>@sentry/react</code>) with mask wrappers</a></td><td><span class="status progress">In progress — replay + PrivacyMask + tests landed; manual TestFlight masking/CSP validation pending</span></td></tr>
       <tr><td>WIA-14</td><td>Re-home ANA-15 <code>attempt_id</code> footer; add missing <code>getCurrentAttemptId()</code> accessor first</td><td><span class="status pending">Pending</span></td></tr>
     </tbody>
   </table>
@@ -256,8 +263,8 @@ Both SDKs → single Sentry project (correlation by attempt_id)</pre>
       attempt.</li>
     <li>Force <code>Onboarding: Failed</code> and confirm cohort tags clear on both sides. Start a new
       attempt in the same session; confirm no leakage from the prior attempt.</li>
-    <li>Open Session Replay for a captured biometric-flow error. Confirm text and image content in the
-      biometric-capture / NFC scan / data confirmation regions are fully masked.</li>
+    <li>Open Session Replay for a captured error on the ID-data screen and the recovery mnemonic
+      reveal/input screens. Confirm all text is masked and the ID photo/artwork is blocked.</li>
     <li>Tap the <code>attempt_id</code> footer on a webview-app error screen; confirm it copies the
       same uuid that Sentry's <code>attempt_id</code> tag carries for the captured event.</li>
   </ul>

--- a/specs/projects/sdk/workstreams/webview-in-app/SPEC.html
+++ b/specs/projects/sdk/workstreams/webview-in-app/SPEC.html
@@ -270,7 +270,7 @@
       <tr><td>WIA-10</td><td>Retire RN-native Didit integration</td><td>Umbrella</td><td><span class="status pending">Pending</span></td></tr>
       <tr><td>WIA-11</td><td>Cutover PR — delete legacy RN screens</td><td>Umbrella</td><td><span class="status pending">Pending</span></td></tr>
       <tr><td>WIA-12</td><td>WebView Sentry integration (cohort tags, masking)</td><td>Observability</td><td><span class="status pending">Pending — gated on nav-hygiene</span></td></tr>
-      <tr><td>WIA-13</td><td>WebView Session Replay with PII masking</td><td>Observability</td><td><span class="status pending">Pending — gated on nav-hygiene</span></td></tr>
+      <tr><td>WIA-13</td><td><a href="./plans/WIA-13-webview-session-replay.html">WebView Session Replay with PII masking</a></td><td>Observability</td><td><span class="status progress">In progress — replay + PrivacyMask + tests landed; manual TestFlight masking/CSP validation pending</span></td></tr>
       <tr><td>WIA-14</td><td>Re-home ANA-15 attempt_id footer to webview-app</td><td>Observability</td><td><span class="status pending">Pending</span></td></tr>
       <tr><td>WIA-15</td><td>Documents handler (delegate to databaseProvider)</td><td>Native adapters</td><td><span class="status superseded">Done (TS); superseded by WIA-17</span></td></tr>
       <tr><td>WIA-16</td><td><code>mode</code> + <code>verificationRequest</code> in lifecycle.getConfig</td><td>Operating modes</td><td><span class="status done">Done</span></td></tr>

--- a/specs/projects/sdk/workstreams/webview-in-app/plans/WIA-13-webview-session-replay.html
+++ b/specs/projects/sdk/workstreams/webview-in-app/plans/WIA-13-webview-session-replay.html
@@ -1,0 +1,430 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>WIA-13 — WebView Session Replay with PII masking</title>
+<style>
+  :root {
+    --bg: #fafbfc;
+    --surface: #ffffff;
+    --surface-alt: #f6f8fa;
+    --border: #d1d9e0;
+    --border-soft: #e1e4e8;
+    --text: #1f2328;
+    --muted: #656d76;
+    --accent: #0969da;
+    --accent-soft: #ddf4ff;
+    --high: #cf222e;
+    --high-soft: #ffebe9;
+    --med: #9a6700;
+    --med-soft: #fff8c5;
+    --done: #1a7f37;
+    --done-soft: #dafbe1;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font: 14px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    color: var(--text);
+    background: var(--bg);
+  }
+  code, pre, kbd { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; font-size: 0.9em; }
+  code { background: var(--surface-alt); padding: 1px 5px; border-radius: 4px; border: 1px solid var(--border-soft); }
+  pre { background: var(--surface-alt); padding: 12px 14px; border-radius: 6px; border: 1px solid var(--border-soft); overflow: auto; }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  header.topbar {
+    position: sticky; top: 0; z-index: 100;
+    background: var(--surface); border-bottom: 1px solid var(--border);
+    padding: 12px 24px;
+    display: flex; align-items: center; gap: 12px; flex-wrap: wrap;
+  }
+  header h1 { margin: 0; font-size: 16px; font-weight: 600; }
+  .pill {
+    font-size: 11px; padding: 2px 8px; border-radius: 999px; border: 1px solid var(--border); background: var(--surface-alt);
+  }
+  .pill.draft { color: var(--med); background: var(--med-soft); border-color: var(--med); }
+  .pill.high { color: var(--high); background: var(--high-soft); border-color: var(--high); }
+  .pill.scope { color: var(--accent); background: var(--accent-soft); border-color: var(--accent); }
+  .pill.active { color: var(--accent); background: var(--accent-soft); border-color: var(--accent); }
+  .pill.done { color: var(--done); background: var(--done-soft); border-color: var(--done); }
+  .spacer { flex: 1; }
+  .layout { display: grid; grid-template-columns: 220px minmax(0, 1fr); gap: 32px; max-width: 1100px; margin: 0 auto; padding: 24px; }
+  nav.toc { position: sticky; top: 64px; align-self: start; font-size: 13px; }
+  nav.toc h4 { margin: 0 0 6px 0; font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; }
+  nav.toc a { display: block; padding: 3px 0; color: var(--text); }
+  main { min-width: 0; }
+  main section { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 18px 22px; margin-bottom: 16px; }
+  main h2 { margin: 0 0 10px 0; font-size: 16px; }
+  main h3 { margin: 16px 0 6px 0; font-size: 13px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; }
+  main p { margin: 6px 0 10px 0; }
+  main ul, main ol { margin: 6px 0 10px 18px; padding: 0; }
+  main li { margin: 3px 0; }
+  table { border-collapse: collapse; width: 100%; margin: 8px 0; font-size: 13px; }
+  th, td { text-align: left; padding: 6px 10px; border-bottom: 1px solid var(--border-soft); }
+  th { background: var(--surface-alt); font-weight: 600; }
+  .status { font-size: 11px; padding: 2px 8px; border-radius: 999px; display: inline-block; white-space: nowrap; border: 1px solid var(--border); background: var(--surface-alt); color: var(--muted); }
+  .status.done { color: var(--done); background: var(--done-soft); border-color: var(--done); }
+  .status.active { color: var(--accent); background: var(--accent-soft); border-color: var(--accent); }
+  .status.pending { color: var(--muted); }
+  .callout { border-left: 3px solid var(--accent); background: var(--accent-soft); padding: 8px 12px; border-radius: 0 6px 6px 0; margin: 10px 0; }
+  .callout.warn { border-left-color: var(--high); background: var(--high-soft); }
+  .callout.note { border-left-color: var(--med); background: var(--med-soft); }
+  .arrow { color: var(--muted); }
+  .check { list-style: none; margin-left: 0; }
+  .check li::before { content: "☐ "; color: var(--muted); }
+</style>
+</head>
+<body>
+
+<header class="topbar">
+  <h1>WIA-13 · WebView Session Replay with PII masking</h1>
+  <span class="pill active">Ready</span>
+  <span class="pill high">Priority: High</span>
+  <span class="pill scope">Scope: webview-app</span>
+  <span class="pill">Target: &lt;400 LOC</span>
+  <span class="pill">2026-06-03</span>
+  <span class="spacer"></span>
+  <div>
+    <a href="../SPEC-OBSERVABILITY.html">↑ Observability Contract</a>
+  </div>
+</header>
+
+<div class="layout">
+
+<nav class="toc">
+  <h4>On this page</h4>
+  <a href="#context">Context</a>
+  <a href="#decisions">Decisions</a>
+  <a href="#files">Files modified</a>
+  <a href="#implementation">Implementation</a>
+  <a href="#spec-corrections">Spec corrections</a>
+  <a href="#tests">Tests</a>
+  <a href="#oos">Out of scope</a>
+  <a href="#validation">Validation</a>
+  <a href="#done">Done criteria</a>
+</nav>
+
+<main>
+
+<section id="context">
+  <h2>Context</h2>
+  <p>
+    <strong>You are adding Session Replay to the WebView app and masking the PII it renders.</strong>
+    <a href="./WIA-12-webview-sentry-cohort-tags.html">WIA-12</a> already shipped
+    <code>@sentry/react</code> (<code>^9.32.0</code>), <code>packages/webview-app/src/config/sentry.ts</code>
+    with <code>initSentry()</code>, the <code>runtime: webview</code> tag, cohort-tag setters, and the
+    shared <code>redactSensitiveFields</code> <code>beforeSend</code> hook. That config deliberately does
+    <em>not</em> register the replay integration — its inline comment hands replay sample rates and DOM
+    mask wrappers to this plan.
+  </p>
+  <p>
+    The RN host runs <code>mobileReplayIntegration({ maskAllText, maskAllImages, maskAllVectors })</code>
+    at 10% session / 100%-on-error (<code>app/src/config/sentry.ts</code>). You are bringing the WebView
+    to parity so cutover (<a href="../SPEC.html">WIA-11</a>) does not regress replay coverage, and so a
+    replay opened from a WebView error groups with RN-host events by <code>attempt_id</code> in the shared
+    Sentry project.
+  </p>
+  <div class="callout warn">
+    <strong>Scope-narrowing finding (verified in code).</strong> The SPEC-OBSERVABILITY mask-site list
+    (&ldquo;biometric capture / NFC scan / data confirmation / Aadhaar / KYC verified&rdquo;) is written
+    against RN screen names and is <strong>stale for the web side</strong>. In <code>webview-app</code>,
+    camera (MRZ) and NFC are delegated to native bridge handlers
+    (<code>bridge.request('camera', …)</code>, <code>bridge.request('nfc', …)</code>): no camera frames or
+    chip data render in the WebView DOM, so replay cannot capture them. MRZ fields <em>do</em> transit
+    WebView route state and the NFC bridge call, but are not displayed on the NFC/progress screens — so
+    replay risk there is low. The confirmation, Aadhaar-instructions, and KYC-success screens render only
+    static instruction/success text.
+  </div>
+  <p><strong>The web-side DOM surfaces that render or accept real PII — the mask sites:</strong></p>
+  <ul>
+    <li>
+      <code>packages/webview-app/src/screens/home/IDDataScreen.tsx</code> — name, DOB, sex, nationality,
+      document number, place of birth, issue/expiry dates, photo, and full MRZ lines (currently mock data;
+      real document data in production).
+    </li>
+    <li>
+      <code>packages/webview-app/src/screens/recovery/RecoveryPhraseScreen.tsx</code> — renders the 24-word
+      mnemonic after reveal.
+    </li>
+    <li>
+      <code>packages/webview-app/src/screens/recovery/SecretPhraseInputScreen.tsx</code> — accepts the
+      mnemonic in DOM inputs.
+    </li>
+  </ul>
+  <p>
+    Global <code>maskAllText</code> / <code>maskAllInputs</code> cover all three. Wrap
+    <code>IDDataScreen</code> and <code>RecoveryPhraseScreen</code> in the explicit <code>PrivacyMask</code>
+    (rendered text); the mnemonic inputs on <code>SecretPhraseInputScreen</code> are covered by
+    <code>maskAllInputs</code> — wrap it too if the inputs sit inside a single container, otherwise rely on
+    the global default and note it.
+  </p>
+</section>
+
+<section id="decisions">
+  <h2>Decisions</h2>
+  <ol>
+    <li>
+      <strong>Always-on global masking is the primary defense.</strong> Register
+      <code>replayIntegration({ maskAllText: true, maskAllInputs: true, blockAllMedia: true })</code> in the
+      existing <code>initSentry()</code>. With these defaults every text node, input, and media element
+      (<code>img</code>/<code>svg</code>/<code>video</code>/<code>canvas</code>) is redacted before it
+      leaves the browser. The WebView <strong>never</strong> disables these, per the SPEC invariant.
+    </li>
+    <li>
+      <strong>Mobile replay options translate to browser options.</strong> The browser
+      <code>replayIntegration</code> has no <code>maskAllImages</code>/<code>maskAllVectors</code> — the
+      RN-baseline intent maps as below. Implement the browser column; do not try to set the mobile names.
+      <table>
+        <thead><tr><th>RN <code>mobileReplayIntegration</code></th><th>Browser <code>replayIntegration</code></th></tr></thead>
+        <tbody>
+          <tr><td><code>maskAllText: true</code></td><td><code>maskAllText: true</code></td></tr>
+          <tr><td>(inputs implicit)</td><td><code>maskAllInputs: true</code></td></tr>
+          <tr><td><code>maskAllImages: true</code></td><td><code>blockAllMedia: true</code> (covers <code>&lt;img&gt;</code>)</td></tr>
+          <tr><td><code>maskAllVectors: true</code></td><td><code>blockAllMedia: true</code> (covers <code>&lt;svg&gt;</code>)</td></tr>
+        </tbody>
+      </table>
+    </li>
+    <li>
+      <strong>Sample rates match the RN non-simulator baseline.</strong>
+      <code>replaysSessionSampleRate: 0.1</code>, <code>replaysOnErrorSampleRate: 1.0</code>. There is no
+      simulator notion in the WebView, so no conditional gating — replay runs whenever Sentry is enabled
+      (<code>isSentryEnabled</code>, i.e. a DSN is configured). Match WIA-12's gating exactly; add no new
+      enable flag.
+    </li>
+    <li>
+      <strong>Add a web <code>PrivacyMask</code> as explicit, durable defense-in-depth.</strong> Mirror
+      <code>app/src/observability/PrivacyMask.tsx</code> with a thin <code>webview-app</code> component that
+      wraps children in an element carrying Sentry's default <code>sentry-mask</code> class. Wrap the
+      <code>IDDataScreen</code> render with it. This is belt-and-suspenders: global masking already covers
+      the screen, but the explicit wrapper documents intent and survives any future change to the global
+      defaults. The component is runtime-specific (web DOM + Sentry CSS convention), so it lives in
+      <code>webview-app</code> — not Euclid — exactly as RN keeps its own.
+    </li>
+    <li>
+      <strong>No cross-bridge exception forwarding</strong> (unchanged from WIA-12). A WebView JS error is
+      captured by <code>@sentry/react</code> directly; the replay is attached client-side. Nothing is
+      serialized over the bridge to the RN host.
+    </li>
+  </ol>
+  <div class="callout note">
+    <strong>Bundle cost (non-blocking).</strong> Importing <code>replayIntegration</code> pulls the replay
+    recorder into the embedded WebView bundle (the project loads embedded-only — no OTA). This is the
+    expected cost of replay parity; do not add a remote/lazy path to avoid it. If the build-size check
+    flags it, note the delta in the PR description rather than dropping replay.
+  </div>
+</section>
+
+<section id="files">
+  <h2>Files Modified</h2>
+  <ul>
+    <li>
+      <code>packages/webview-app/src/config/sentry.ts</code> — add <code>replayIntegration({ maskAllText,
+      maskAllInputs, blockAllMedia })</code> to the <code>integrations</code> array and set
+      <code>replaysSessionSampleRate: 0.1</code> / <code>replaysOnErrorSampleRate: 1.0</code> in the
+      <code>sentryInit</code> call. Keep <code>runtime: webview</code>, the breadcrumb filtering, and the
+      <code>beforeSend</code> redaction untouched.
+    </li>
+    <li>
+      <code>packages/webview-app/src/observability/PrivacyMask.tsx</code> (new) — thin component:
+      <code>&lt;div className="sentry-mask"&gt;{children}&lt;/div&gt;</code> with a
+      <code>className</code> passthrough so callers can merge layout classes. No business logic.
+    </li>
+    <li>
+      <code>packages/webview-app/src/screens/home/IDDataScreen.tsx</code> — wrap the
+      <code>&lt;EuclidIDDataScreen … /&gt;</code> render in <code>&lt;PrivacyMask&gt;</code>. The photo
+      <code>&lt;img&gt;</code> is additionally covered by global <code>blockAllMedia</code>.
+    </li>
+    <li>
+      <code>packages/webview-app/src/screens/recovery/RecoveryPhraseScreen.tsx</code> — wrap the revealed
+      24-word mnemonic in <code>&lt;PrivacyMask&gt;</code>.
+    </li>
+    <li>
+      <code>packages/webview-app/src/screens/recovery/SecretPhraseInputScreen.tsx</code> — wrap the
+      mnemonic input container in <code>&lt;PrivacyMask&gt;</code> if the inputs share one container;
+      otherwise rely on global <code>maskAllInputs</code> (inputs are masked by default) and note it in the
+      PR.
+    </li>
+    <li>
+      <code>packages/webview-app/package.json</code> — <strong>no change</strong>. <code>replayIntegration</code>
+      ships inside the already-installed <code>@sentry/react</code>; do not add <code>@sentry/replay</code>
+      (deprecated/merged) or any new dependency.
+    </li>
+    <li>
+      <code>specs/projects/sdk/workstreams/webview-in-app/SPEC-OBSERVABILITY.html</code> — see
+      <a href="#spec-corrections">Spec corrections</a>.
+    </li>
+  </ul>
+</section>
+
+<section id="implementation">
+  <h2>Implementation</h2>
+
+  <h3>1 · Register the replay integration</h3>
+  <p>In <code>packages/webview-app/src/config/sentry.ts</code>, import <code>replayIntegration</code> from
+  <code>@sentry/react</code> and add it to the existing <code>integrations</code> factory return, then set
+  the two sample rates in <code>sentryInit</code>:</p>
+  <pre>import { breadcrumbsIntegration, init as sentryInit, replayIntegration, setTag } from '@sentry/react';
+
+// inside sentryInit({ ... }):
+integrations: defaults =&gt; [
+  ...defaults.filter(integration =&gt; integration.name !== 'Breadcrumbs'),
+  breadcrumbsIntegration({ console: false, dom: false }),
+  replayIntegration({ maskAllText: true, maskAllInputs: true, blockAllMedia: true }),
+],
+replaysSessionSampleRate: 0.1,
+replaysOnErrorSampleRate: 1.0,</pre>
+  <p>Leave <code>runtime: webview</code>, <code>tracesSampleRate: 0</code>, and the
+  <code>beforeSend</code> redaction exactly as WIA-12 left them.</p>
+
+  <h3>2 · Add the web PrivacyMask component</h3>
+  <p>Create <code>packages/webview-app/src/observability/PrivacyMask.tsx</code> mirroring the RN component's
+  shape (props passthrough, no logic). It renders a wrapper element carrying Sentry's default
+  <code>sentry-mask</code> class so all descendant text is redacted in replay regardless of the global
+  default. Accept an optional <code>className</code> and merge it.</p>
+
+  <h3>3 · Wrap the PII screens</h3>
+  <p>Wrap each web-side PII surface in <code>&lt;PrivacyMask&gt;</code> without modifying the underlying
+  Euclid components or data props:</p>
+  <ul>
+    <li><code>IDDataScreen.tsx</code> — wrap the returned <code>&lt;EuclidIDDataScreen … /&gt;</code>. The
+      card photo is an <code>&lt;img&gt;</code> covered by <code>blockAllMedia</code>; text fields and MRZ
+      lines by both <code>maskAllText</code> and the wrapper.</li>
+    <li><code>RecoveryPhraseScreen.tsx</code> — wrap the revealed mnemonic.</li>
+    <li><code>SecretPhraseInputScreen.tsx</code> — wrap the input container if single; else rely on
+      <code>maskAllInputs</code> and note it.</li>
+  </ul>
+
+  <h3>4 · Verify no CSP blocks the replay worker</h3>
+  <p>Sentry Session Replay runs its recorder in a <strong>WebWorker</strong>. If the WebView or served
+  bundle sets a Content-Security-Policy, replay startup needs <code>worker-src 'self' blob:</code> (or
+  <code>child-src</code> as fallback). No CSP was found in <code>webview-app</code> at planning time —
+  confirm none is injected by the RN WebView host or the embedded-bundle server, and if one exists, add the
+  worker directive. Source: Sentry Session Replay docs
+  (<a href="https://docs.sentry.io/platforms/javascript/session-replay/">docs.sentry.io/platforms/javascript/session-replay/</a>).</p>
+
+  <div class="callout warn">
+    <strong>Required constraints.</strong> Do not import <code>@sentry/react</code> from anywhere outside
+    <code>webview-app/src/config/sentry.ts</code>. The new <code>PrivacyMask</code> applies only a CSS
+    class and must not import Sentry. Do not add replay config to <code>mobile-sdk-alpha</code> or
+    <code>webview-bridge</code>. Do not lower
+    <code>maskAllText</code>/<code>maskAllInputs</code>/<code>blockAllMedia</code>, add an
+    <code>unmask</code>/<code>.sentry-unmask</code> selector, or enable replay only behind a non-DSN flag.
+  </div>
+</section>
+
+<section id="spec-corrections">
+  <h2>Spec corrections (apply in this PR)</h2>
+  <p>Per the &ldquo;specs stay current&rdquo; rule, update <code>SPEC-OBSERVABILITY.html</code> so it
+  matches the verified web reality:</p>
+  <ul>
+    <li>
+      <strong>Decision 5 &amp; Scope — reconcile the mask options.</strong> Both currently disagree
+      (Scope says <code>maskAllImages, maskAllVectors</code>; Decision 5 says <code>maskAllText,
+      maskAllInputs</code>). Replace both with the browser-correct set:
+      <code>maskAllText: true, maskAllInputs: true, blockAllMedia: true</code>, and note that
+      <code>blockAllMedia</code> is the browser equivalent of the RN <code>maskAllImages</code>/<code>maskAllVectors</code>.
+    </li>
+    <li>
+      <strong>Mask-site list — correct for the web runtime.</strong> Replace the RN-screen mask-site list
+      with the finding that camera/NFC are native (camera frames/chip data never render in the WebView DOM;
+      MRZ fields transit WebView state/bridge calls but are not displayed), and that the web-side PII render
+      sites are <code>IDDataScreen</code>, <code>RecoveryPhraseScreen</code>, and
+      <code>SecretPhraseInputScreen</code>. Replace the <code>data-sentry-mask</code> attribute reference
+      (not the SDK's masking mechanism) with the <code>sentry-mask</code> class / <code>PrivacyMask</code>
+      wrapper approach.
+    </li>
+    <li>
+      <strong>Backlog row</strong> — move WIA-13 from <code>Pending</code> to <code>In progress</code> /
+      <code>Done</code> as appropriate when the PR lands.
+    </li>
+  </ul>
+</section>
+
+<section id="tests">
+  <h2>Tests</h2>
+  <ul>
+    <li>
+      <code>packages/webview-app</code> config test — assert <code>initSentry()</code> registers an
+      integration named <code>Replay</code>, that <code>replaysSessionSampleRate</code> /
+      <code>replaysOnErrorSampleRate</code> are <code>0.1</code> / <code>1.0</code>, and that the replay
+      mask options are <code>maskAllText: true</code>, <code>maskAllInputs: true</code>,
+      <code>blockAllMedia: true</code>. Mock <code>@sentry/react</code>'s <code>init</code> and inspect the
+      passed config; resolve the <code>integrations</code> factory against a stub defaults array.
+    </li>
+    <li>
+      <code>PrivacyMask</code> render test — renders children inside an element carrying the
+      <code>sentry-mask</code> class and merges a passed <code>className</code>.
+    </li>
+    <li>
+      Guard test — assert no module under <code>mobile-sdk-alpha/src/</code> or
+      <code>webview-bridge/src/</code> imports replay/Sentry (reuse or extend WIA-12's import guard if one
+      exists).
+    </li>
+  </ul>
+  <p>Follow the WIA-12 harness convention; avoid nested <code>require('react-native')</code> in tests.</p>
+</section>
+
+<section id="oos">
+  <h2>Out of Scope</h2>
+  <ul>
+    <li>Camera/NFC/biometric DOM masking — those flows are native and render nothing maskable in the WebView.</li>
+    <li><code>getCurrentAttemptId()</code> and the <code>attempt_id</code> footer UI (WIA-14).</li>
+    <li>Sentry tracing/performance instrumentation (out for both runtimes per ANA-13).</li>
+    <li>New cohort tag names, the redact regex, or terminal-clear semantics (owned by WIA-12 / the analytics workstream).</li>
+    <li>Cross-bridge exception forwarding; adding Segment/Mixpanel to the WebView bundle.</li>
+    <li>Changing the RN-host replay config.</li>
+  </ul>
+</section>
+
+<section id="validation">
+  <h2>Validation</h2>
+  <pre>yarn workspace @selfxyz/webview-app test
+yarn workspace @selfxyz/webview-app types
+yarn workspace @selfxyz/webview-app build</pre>
+  <h3>Manual validation</h3>
+  <ul>
+    <li>Build a TestFlight build with the WebView pointed at the same Sentry DSN as the RN host.</li>
+    <li>Navigate to the ID data screen, then trigger a synthetic WebView error during an active attempt.</li>
+    <li>
+      In Sentry, open the replay attached to that event. Confirm: every text field on the ID screen
+      (name, DOB, document number, MRZ lines) is masked, and the photo / card artwork is blocked (placeholder,
+      not the real image).
+    </li>
+    <li>
+      Repeat for the recovery flow: reveal the mnemonic on <code>RecoveryPhraseScreen</code> and type into
+      <code>SecretPhraseInputScreen</code>, trigger a synthetic error, and confirm the 24 words are masked
+      in the replay.
+    </li>
+    <li>
+      Confirm the replay worker starts (no CSP error in the WebView console; a replay is actually
+      uploaded). If a CSP is present, verify the <code>worker-src 'self' blob:</code> directive is set.
+    </li>
+    <li>
+      Confirm the event carries <code>runtime: webview</code> + the cohort tags and is reachable by
+      <code>attempt_id:&lt;uuid&gt;</code>, grouping with RN-host events for the same attempt.
+    </li>
+    <li>Confirm a normal (non-error) session is sampled at ~10% and an errored session is always captured.</li>
+  </ul>
+</section>
+
+<section id="done">
+  <h2>Done Criteria</h2>
+  <ul class="check">
+    <li>WebView Session Replay is active when a DSN is configured, at 10% session / 100%-on-error.</li>
+    <li>Replay globally masks all text + inputs and blocks all media; defaults are never disabled.</li>
+    <li><code>IDDataScreen</code> and the recovery mnemonic screens are wrapped in a web <code>PrivacyMask</code> mirroring the RN pattern.</li>
+    <li>A replay opened from a WebView error shows ID-screen and mnemonic PII masked/blocked.</li>
+    <li>The replay worker starts under any WebView CSP (or no CSP is present).</li>
+    <li>No replay/Sentry import leaks into <code>mobile-sdk-alpha/src/</code> or <code>webview-bridge/src/</code>.</li>
+    <li>No new dependency added; replay comes from the existing <code>@sentry/react</code>.</li>
+    <li>SPEC-OBSERVABILITY mask options + mask-site list are corrected to match the web runtime.</li>
+    <li><code>webview-app</code> build, types, and tests pass.</li>
+  </ul>
+</section>
+
+</main>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Brings WebView Session Replay to parity with the RN host so the cutover (WIA-11) does not regress replay coverage. Builds on WIA-12, which already shipped `@sentry/react`, `initSentry()`, the `runtime: webview` tag, cohort tags, and `beforeSend` redaction.
- Registers the replay integration with always-on masking (`maskAllText`, `maskAllInputs`, `blockAllMedia`) at RN-parity sample rates (10% session / 100% on error). `blockAllMedia` is the browser equivalent of the RN `maskAllImages`/`maskAllVectors`.
- Adds a web `PrivacyMask` (the `sentry-mask` class, no Sentry import, layout-neutral) and wraps the only web-side PII surfaces: the ID-data screen and the recovery mnemonic reveal/input screens. Camera/NFC are native bridge calls — no frames or chip data enter the WebView DOM.
- No new dependency (replay ships inside `@sentry/react`). Bundle cost: **+43 kB gzip** on the main chunk.

## Changes

### WebView app

- `config/sentry.ts` — add `replayIntegration({ maskAllText, maskAllInputs, blockAllMedia })` and set `replaysSessionSampleRate: 0.1` / `replaysOnErrorSampleRate: 1.0`.
- `observability/PrivacyMask.tsx` (new) — thin wrapper applying the `sentry-mask` class via `display: contents`; mirrors the RN `PrivacyMask`.
- Wrap PII surfaces in `PrivacyMask`: `IDDataScreen`, `RecoveryPhraseScreen` (onboarding + settings variants), `SecretPhraseInputScreen`.

### Tests

- `tests/config/sentry.test.ts` — replay integration registered, sample rates, mask options, no-init-without-DSN.
- `tests/observability/PrivacyMask.test.tsx` — `sentry-mask` class + `className` merge.
- `tests/guards/sentryImportBoundary.test.ts` — enforces that no `@sentry/*` import leaks into `mobile-sdk-alpha/src` or `webview-bridge/src`.

### Docs/specs

- `plans/WIA-13-webview-session-replay.html` (new) — execution plan.
- `SPEC-OBSERVABILITY.html` / `SPEC.html` — reconcile mask options to `maskAllText/maskAllInputs/blockAllMedia`, correct the stale mask-site list and the `data-sentry-mask` reference, status → In progress.

## Linear Issues

- Closes [SELF-3086](https://linear.app/selfprotocol/issue/SELF-3086/wia-13-webview-session-replay-with-pii-masking) — WIA-13: WebView Session Replay with PII masking

## Test Plan

- [ ] `yarn workspace @selfxyz/webview-app test` passes
- [ ] `yarn workspace @selfxyz/webview-app types` passes
- [ ] `yarn workspace @selfxyz/webview-app build` passes
- [ ] **Manual (needs TestFlight):** trigger an error on the ID-data screen and the recovery flow; confirm in Sentry that all text is masked, the ID photo/artwork is blocked, and the 24-word mnemonic is masked
- [ ] **Manual (needs TestFlight):** confirm the replay WebWorker starts (replay uploaded, no CSP error); if a CSP is present, verify `worker-src 'self' blob:`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled Session Replay with automatic PII masking on sensitive screens and added a privacy-mask wrapper to protect recovery phrase and ID data displays/inputs.

* **Tests**
  * Added test coverage for Session Replay config, privacy-masking behavior, and import-boundary enforcement.

* **Documentation**
  * Updated observability specs and planning docs to describe masking behavior, replay sampling, and validation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->