### PR TITLE
feat(qrcode): add explicit connecting step and revamp step UI

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -1,0 +1,50 @@
+name: Update Documentation
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+permissions:
+  contents: read
+  pull-requests: read
+concurrency:
+  group: docs-sync-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+jobs:
+  docs-sync:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository  # skip forks.
+    steps:
+      - name: Checkout docs-sync-agent
+        uses: actions/checkout@v4
+        with:
+          repository: kartikmehta8/flue-docs-sync-agent
+          ref: main
+          # token: ${{ secrets.AGENT_REPO_TOKEN }}   # ONLY if flue-docs-sync-agent is PRIVATE.
+
+      - name: Checkout docs repo
+        uses: actions/checkout@v4
+        with:
+          repository: kartikmehta8/self-docs
+          token: ${{ secrets.DOCS_REPO_PAT }}
+          path: docs-checkout
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - run: npm ci
+      - run: npm run build
+
+      - name: Run agent
+        env:
+          LLM_PROVIDER: ${{ vars.LLM_PROVIDER }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          DOCS_REPO: kartikmehta8/self-docs
+          DOCS_REPO_PAT: ${{ secrets.DOCS_REPO_PAT }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CODE_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          DOCS_REPO_DIR: docs-checkout
+        run: npm start

--- a/sdk/qrcode/README.md
+++ b/sdk/qrcode/README.md
@@ -187,7 +187,8 @@ For a more comprehensive and interactive example, please refer to the [playgroun
 1. Your application displays the QR code to the user
 2. The user scans the QR code with the Self app
 3. The Self app guides the user through the passport verification process
-4. The proof is generated and sent to your verification endpoint
-5. Upon successful verification, the `onSuccess` callback is triggered
+4. The QR state enters a dedicated `Connecting...` phase while the secure session is established
+5. The proof is generated and sent to your verification endpoint
+6. Upon successful verification, the `onSuccess` callback is triggered
 
 The QR code component displays the current verification status with an LED indicator and changes its appearance based on the verification state.

--- a/sdk/qrcode/components/DesktopFooter.tsx
+++ b/sdk/qrcode/components/DesktopFooter.tsx
@@ -9,10 +9,6 @@ import {
   desktopStatusSubtitleStyle,
   desktopStatusTextStyle,
   desktopStatusTitleStyle,
-  desktopStepIconStyle,
-  desktopStepInnerStyle,
-  desktopStepStyle,
-  desktopStepTextStyle,
 } from '../utils/styles.js';
 import { getDesktopStatusSubtitle, getDesktopStatusTitle, QRcodeSteps } from '../utils/utils.js';
 import {
@@ -24,6 +20,7 @@ import {
   SelfShieldIcon,
   WarningIcon,
 } from './icons.js';
+import InstructionList from './InstructionList.js';
 
 interface DesktopFooterProps {
   proofStep: number;
@@ -33,6 +30,7 @@ interface DesktopFooterProps {
 const INSTRUCTION_STEPS = [
   { icon: ScanIcon, text: 'Scan this QR code to get the Self app' },
   { icon: SelfShieldIcon, text: 'Verify an identity document in the Self app' },
+  { icon: BoltIcon, text: 'Connecting to Self...' },
   { icon: ReturnIcon, text: 'Rescan this QR code and prove your identity' },
 ];
 
@@ -58,19 +56,7 @@ const DesktopFooter = memo(({ proofStep, darkMode = false }: DesktopFooterProps)
   if (isInitialState) {
     return (
       <div style={desktopFooterStyle(darkMode)}>
-        {INSTRUCTION_STEPS.map((step, index) => {
-          const Icon = step.icon;
-          return (
-            <div key={index} style={desktopStepStyle(darkMode)}>
-              <div style={desktopStepInnerStyle()}>
-                <div style={desktopStepIconStyle(darkMode)}>
-                  <Icon size={18} />
-                </div>
-                <span style={desktopStepTextStyle(darkMode)}>{step.text}</span>
-              </div>
-            </div>
-          );
-        })}
+        <InstructionList steps={INSTRUCTION_STEPS} darkMode={darkMode} />
       </div>
     );
   }
@@ -86,7 +72,7 @@ const DesktopFooter = memo(({ proofStep, darkMode = false }: DesktopFooterProps)
           </div>
           <div style={desktopStatusTextStyle()}>
             <p style={desktopStatusTitleStyle(darkMode)}>{getDesktopStatusTitle(proofStep)}</p>
-            <p style={desktopStatusSubtitleStyle()}>{getDesktopStatusSubtitle()}</p>
+            <p style={desktopStatusSubtitleStyle()}>{getDesktopStatusSubtitle(proofStep)}</p>
           </div>
         </div>
       </div>

--- a/sdk/qrcode/components/InstructionList.tsx
+++ b/sdk/qrcode/components/InstructionList.tsx
@@ -1,0 +1,42 @@
+import React, { memo } from 'react';
+
+import {
+  desktopStepIconStyle,
+  desktopStepIndexStyle,
+  desktopStepInnerStyle,
+  desktopStepStyle,
+  desktopStepTextStyle,
+} from '../utils/styles.js';
+
+interface InstructionStep {
+  icon: React.ComponentType<{ size?: number }>;
+  text: string;
+}
+
+interface InstructionListProps {
+  steps: InstructionStep[];
+  darkMode?: boolean;
+}
+
+const InstructionList = memo(({ steps, darkMode = false }: InstructionListProps) => (
+  <>
+    {steps.map((step, index) => {
+      const Icon = step.icon;
+
+      return (
+        <div key={`${step.text}-${index}`} style={desktopStepStyle(darkMode)}>
+          <div style={desktopStepInnerStyle()}>
+            <div style={desktopStepIndexStyle(darkMode)}>{index + 1}</div>
+            <div style={desktopStepIconStyle(darkMode)}>
+              <Icon size={18} />
+            </div>
+            <span style={desktopStepTextStyle(darkMode)}>{step.text}</span>
+          </div>
+        </div>
+      );
+    })}
+  </>
+));
+
+export type { InstructionStep };
+export default InstructionList;

--- a/sdk/qrcode/components/MobileQRcode.tsx
+++ b/sdk/qrcode/components/MobileQRcode.tsx
@@ -4,10 +4,6 @@ import React, { memo } from 'react';
 import phoneMockup from '../assets/phone-mockup.png';
 import selfLogo from '../assets/self-logo.svg';
 import {
-  desktopStepIconStyle,
-  desktopStepInnerStyle,
-  desktopStepStyle,
-  desktopStepTextStyle,
   mobileCardStyle,
   mobileCtaButtonStyle,
   mobileCtaLogoStyle,
@@ -19,7 +15,8 @@ import {
   mobilePhoneSectionWrapperStyle,
 } from '../utils/styles.js';
 import DesktopHeader from './DesktopHeader.js';
-import { ArrowReturnIcon, DownloadIcon, VerifyIcon } from './icons.js';
+import { ArrowReturnIcon, BoltIcon, DownloadIcon, VerifyIcon } from './icons.js';
+import InstructionList from './InstructionList.js';
 
 interface MobileQRcodeProps {
   proofStep: number;
@@ -31,6 +28,7 @@ interface MobileQRcodeProps {
 const MOBILE_STEPS = [
   { icon: DownloadIcon, text: 'Download the Self Mobile app' },
   { icon: VerifyIcon, text: 'Verify your identity' },
+  { icon: BoltIcon, text: 'Connecting to Self...' },
   { icon: ArrowReturnIcon, text: 'Return to this application and click on the button below' },
 ];
 
@@ -43,19 +41,7 @@ const MobileQRcode = memo(({ qrValue, selfApp, darkMode = false }: MobileQRcodeP
       </div>
     </div>
     <div style={mobileFooterStyle()}>
-      {MOBILE_STEPS.map((step, index) => {
-        const Icon = step.icon;
-        return (
-          <div key={index} style={desktopStepStyle(darkMode)}>
-            <div style={desktopStepInnerStyle()}>
-              <div style={desktopStepIconStyle(darkMode)}>
-                <Icon size={18} />
-              </div>
-              <span style={desktopStepTextStyle(darkMode)}>{step.text}</span>
-            </div>
-          </div>
-        );
-      })}
+      <InstructionList steps={MOBILE_STEPS} darkMode={darkMode} />
     </div>
     <div style={mobileCtaSectionStyle(darkMode)}>
       <a href={qrValue} style={mobileCtaButtonStyle()}>

--- a/sdk/qrcode/utils/styles.ts
+++ b/sdk/qrcode/utils/styles.ts
@@ -214,6 +214,20 @@ export const desktopStepInnerStyle = (): React.CSSProperties => ({
   width: '100%',
 });
 
+export const desktopStepIndexStyle = (darkMode: boolean = false): React.CSSProperties => ({
+  width: '20px',
+  height: '20px',
+  borderRadius: '999px',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  fontSize: '12px',
+  fontWeight: 700,
+  color: darkMode ? '#94A3B8' : '#334155',
+  backgroundColor: darkMode ? '#3A3A3A' : '#E2E8F0',
+  flexShrink: 0,
+});
+
 export const desktopStepStyle = (darkMode: boolean = false): React.CSSProperties => ({
   backgroundColor: darkMode ? '#2A2A2A' : '#F8FAFC',
   borderRadius: '5px',

--- a/sdk/qrcode/utils/utils.ts
+++ b/sdk/qrcode/utils/utils.ts
@@ -14,14 +14,31 @@ export const QRcodeSteps = {
 export const getDesktopDescription = (appName: string): string =>
   `${appName} uses Self to verify identity without compromising your privacy.`;
 
-export const getDesktopStatusSubtitle = (): string => 'Verify the proof using the Self mobile app';
+export const getDesktopStatusSubtitle = (proofStep: number): string => {
+  switch (proofStep) {
+    case QRcodeSteps.MOBILE_CONNECTED:
+      return 'Establishing a secure connection with your Self app';
+    case QRcodeSteps.PROOF_GENERATION_STARTED:
+      return 'Generating your proof in the Self mobile app';
+    case QRcodeSteps.PROOF_GENERATED:
+      return 'Finishing up verification';
+    case QRcodeSteps.PROOF_VERIFIED:
+      return 'Identity proof successfully verified';
+    case QRcodeSteps.PROOF_GENERATION_FAILED:
+      return 'Proof verification failed. Please try again';
+    default:
+      return 'Verify the proof using the Self mobile app';
+  }
+};
 
 export const getDesktopStatusTitle = (proofStep: number): string => {
   switch (proofStep) {
     case QRcodeSteps.MOBILE_CONNECTED:
+      return 'Connecting...';
     case QRcodeSteps.PROOF_GENERATION_STARTED:
+      return 'Generating Proof';
     case QRcodeSteps.PROOF_GENERATED:
-      return 'Connecting to Self';
+      return 'Proof Generated';
     case QRcodeSteps.PROOF_VERIFIED:
       return 'Proof Verified';
     case QRcodeSteps.PROOF_GENERATION_FAILED:
@@ -62,8 +79,9 @@ export const getStatusText = (proofStep: number): string => {
     case QRcodeSteps.WAITING_FOR_MOBILE:
       return 'Prove your Self';
     case QRcodeSteps.MOBILE_CONNECTED:
+      return 'Connecting...';
     case QRcodeSteps.PROOF_GENERATION_STARTED:
-      return 'Connected to Self';
+      return 'Generating Proof...';
     case QRcodeSteps.PROOF_GENERATED:
       return 'Proof Generated';
     case QRcodeSteps.PROOF_VERIFIED:


### PR DESCRIPTION
## Summary
- add an explicit intermediate `Connecting...` step in the QR verification flow
- update desktop/mobile instruction lists to include the new connecting phase
- refactor duplicated step-list rendering into a shared `InstructionList` component
- improve status title/subtitle text so each proof step has clearer UI messaging
- add numbered step badges styling for clearer progressive guidance
- update qrcode README verification flow docs to reflect the extra step

## Why
This improves testability and user clarity by making the session establishment phase visible instead of collapsing it into generic connected/proof states.

## Notes
- Branch: `feat/qrcode-connecting-step`
- Commit: `a3f20f67`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Connecting to Self" phase to the QR code verification workflow.

* **Documentation**
  * Updated verification flow documentation to describe the new connection establishment phase.

* **Refactor**
  * Consolidated instruction list rendering for improved display consistency.
  * Enhanced status messages to provide step-specific feedback during verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->