### PR TITLE
fix mobile deploy: drop --silent forwarded into vite by build:deps

### DIFF
--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -688,7 +688,7 @@ jobs:
         run: |
           echo "🏗️ Building SDK dependencies..."
           cd ${{ env.APP_PATH }}
-          yarn workspace @selfxyz/mobile-app run build:deps --silent || { echo "❌ Dependency build failed"; exit 1; }
+          yarn workspace @selfxyz/mobile-app run build:deps || { echo "❌ Dependency build failed"; exit 1; }
           echo "✅ Dependencies built successfully"
 
       # act won't work with macos, but you can test with `bundle exec fastlane ios ...`
@@ -1173,7 +1173,7 @@ jobs:
         run: |
           echo "🏗️ Building SDK dependencies..."
           cd ${{ env.APP_PATH }}
-          yarn workspace @selfxyz/mobile-app run build:deps --silent || { echo "❌ Dependency build failed"; exit 1; }
+          yarn workspace @selfxyz/mobile-app run build:deps || { echo "❌ Dependency build failed"; exit 1; }
           echo "✅ Dependencies built successfully"
 
       - name: Build AAB with Fastlane


### PR DESCRIPTION
## Summary

Mobile Deploy's **Build Dependencies** step fails on `release/staging-2026-06-09` ([run 27246493961](https://github.com/selfxyz/self/actions/runs/27246493961/job/80461651095)) with:

```
CACError: Unknown option `--silent`
```

Root cause: the workflow runs `yarn workspace @selfxyz/mobile-app run build:deps --silent`. `build:deps` is `yarn workspaces foreach --from @selfxyz/mobile-app --topological --recursive run build`, so Yarn forwards the trailing `--silent` into **every** workspace's `build` script. Since #2098 added `@selfxyz/rn-sdk` (and transitively `@selfxyz/webview-app`) to the app's dependency graph, that flag now lands on `vite build --silent` — vite's CLI has no `--silent` option and throws, aborting the whole dependency build.

The flag only suppressed log output and was tolerated by the previous (tsup-based) packages in the graph. Removing it from both invocations (iOS + Android) is the minimal fix; per-tool flags don't belong in a foreach-forwarded arg.

Not related to #2147 — that PR addresses the Play Store upload step, which this run never reaches.

## Test plan

- `build:deps` runs unmodified locally (`yarn workspace @selfxyz/mobile-app run build:deps` passes, including the webview-app vite build).
- Real validation: cherry-pick onto `release/staging-2026-06-09` (or re-cut the release) and re-dispatch Mobile Deploy — the Build Dependencies (Android) step should now pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated mobile app build workflow to provide more detailed build logs during dependency installation for iOS and Android builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->