### PR TITLE
publish KMP SDK to mavenLocal before Android deploy build

### DIFF
--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -1216,12 +1216,15 @@ jobs:
           echo "✅ Dependencies built successfully"
 
       # rn-sdk's Android module declares compileOnly xyz.self.sdk:shared-android,
-      # which only exists in mavenLocal (see mobile-e2e.yml / rn-sdk-test-app-ci.yml)
+      # which only exists in mavenLocal. The script publishes only the Android
+      # publication — the aggregate publishToMavenLocal task pulls in the iOS
+      # metadata path, which fails an unrelated Gradle task-dependency check.
       - name: Publish KMP SDK to mavenLocal
         if: inputs.platform != 'ios'
         run: |
           chmod +x packages/kmp-sdk/gradlew
-          cd packages/kmp-sdk && ./gradlew :shared:publishToMavenLocal --quiet
+          cd ${{ env.APP_PATH }}
+          node scripts/publish-kmp-local.cjs
 
       - name: Build AAB with Fastlane
         if: inputs.platform != 'ios'

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -1215,6 +1215,14 @@ jobs:
           yarn workspace @selfxyz/mobile-app run build:deps || { echo "❌ Dependency build failed"; exit 1; }
           echo "✅ Dependencies built successfully"
 
+      # rn-sdk's Android module declares compileOnly xyz.self.sdk:shared-android,
+      # which only exists in mavenLocal (see mobile-e2e.yml / rn-sdk-test-app-ci.yml)
+      - name: Publish KMP SDK to mavenLocal
+        if: inputs.platform != 'ios'
+        run: |
+          chmod +x packages/kmp-sdk/gradlew
+          cd packages/kmp-sdk && ./gradlew :shared:publishToMavenLocal --quiet
+
       - name: Build AAB with Fastlane
         if: inputs.platform != 'ios'
         env:


### PR DESCRIPTION
## Summary

<!-- Brief description of changes -->

## Test plan

<!-- How was this tested? -->

---

### Native code checklist

<!-- Only if this PR touches Kotlin/Swift or the React Native module bridge. Delete this section otherwise. -->

Run each command and check the box only after it passes. Paste failures into the Test plan.

- [ ] `yarn lint && yarn types` pass
- [ ] Bridge contract tests pass: `cd app && yarn jest:run` and `yarn workspace @selfxyz/rn-sdk-test-app test`
- [ ] If `packages/mobile-sdk-alpha` touched: `cd packages/mobile-sdk-alpha && yarn test && yarn types` pass
- [ ] Diff of `.kt`/`.swift` reviewed — no business logic added (only hardware/OS access; logic lives in TypeScript)
- [ ] NativeModules bridge contract (method names, payload keys, error codes) unchanged, or the change is intentional and described in the summary

**Cannot be verified by an agent — flag for human QA:**

- [ ] Native builds (app + RN test app, iOS + Android) — relying on CI, or needs a human local build
- [ ] On-device smoke test of the affected flow (e.g. NFC passport read, MRZ camera scan) — **needs human**, or N/A if no runtime behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Android mobile build process by adding an Android-only pre-build step that prepares and publishes the Kotlin Multiplatform SDK to local build artifacts, reducing pre-build dependency issues and preventing unrelated Gradle task failures during Android app packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->