### PR TITLE
fix CodeQL alerts and orphaned Play Store edit on upload retry

### DIFF
--- a/.github/workflows/mobile-bundle-analysis.yml
+++ b/.github/workflows/mobile-bundle-analysis.yml
@@ -1,5 +1,8 @@
 name: Mobile Bundle Analysis
 
+permissions:
+  contents: read
+
 env:
   RUBY_VERSION: 3.2
   JAVA_VERSION: 17

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -1,4 +1,8 @@
 name: Mobile CI
+
+permissions:
+  contents: read
+
 env:
   # Build environment versions
   # Node version is read from .nvmrc during workflow execution

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -449,48 +449,32 @@ jobs:
           # Verify the JS bundle inside the APK is Hermes bytecode, not plain JS.
           # A Hermes-enabled APK that ships a non-Hermes bundle will launch but
           # fail to mount JS — exactly the failure mode where Maestro never sees
-          # `home-screen-root`. Use the installed Hermes compiler to parse the
-          # bundle instead of hard-coding bytecode header bytes; the bytecode
-          # version changes across Hermes releases.
+          # `home-screen-root`. We identify Hermes by its bytecode magic number
+          # (first 8 bytes), which is a compile-time constant that has never
+          # changed across Hermes releases — only the version field that follows
+          # it does. This needs no hermesc binary, so it is independent of the
+          # runner OS and of where yarn hoists hermes-compiler.
           echo "🔍 Inspecting JS bundle format in APK..."
           BUNDLE_TMP=$(mktemp)
           if unzip -p "$APK_PATH" assets/index.android.bundle > "$BUNDLE_TMP" 2>/dev/null && [ -s "$BUNDLE_TMP" ]; then
             BUNDLE_SIZE=$(stat -f%z "$BUNDLE_TMP" 2>/dev/null || stat -c%s "$BUNDLE_TMP" 2>/dev/null || echo "unknown")
-            # hermes-compiler is a react-native transitive dep, so yarn
-            # hoisting decides where it materializes (app/node_modules vs the
-            # repo root, shifting as other workspaces change RN versions).
-            # Resolve it from the app workspace instead of hardcoding a path.
-            HERMESC_PKG="$(node -e "console.log(require('path').dirname(require.resolve('hermes-compiler/package.json', {paths: [require('path').resolve('app')]})))" 2>/dev/null || true)"
-            HERMESC_ROOT="${HERMESC_PKG:-app/node_modules/hermes-compiler}/hermesc"
-            case "$(uname -s)" in
-              Darwin*) HERMESC="$HERMESC_ROOT/osx-bin/hermesc" ;;
-              MINGW*|MSYS*|CYGWIN*) HERMESC="$HERMESC_ROOT/win64-bin/hermesc.exe" ;;
-              *) HERMESC="$HERMESC_ROOT/linux64-bin/hermesc" ;;
-            esac
-            HERMES_DUMP_TMP=$(mktemp)
-            HERMES_ERROR_TMP=$(mktemp)
             echo "📦 index.android.bundle size: $BUNDLE_SIZE bytes"
-            [ -x "$HERMESC" ] || {
-              echo "❌ Hermes compiler not found or not executable at $HERMESC"
-              echo "Cannot verify Android bundle bytecode format."
-              rm -f "$BUNDLE_TMP" "$HERMES_DUMP_TMP" "$HERMES_ERROR_TMP"
-              exit 1
-            }
-
-            if "$HERMESC" -b -dump-bytecode "$BUNDLE_TMP" > "$HERMES_DUMP_TMP" 2> "$HERMES_ERROR_TMP"; then
-              BYTECODE_VERSION=$(sed -n 's/^  Bytecode version number: //p' "$HERMES_DUMP_TMP" | head -1)
+            # Hermes bytecode header: bytes 0-7 = magic 0x1F1903C103BC1FC6
+            # (little-endian on disk), bytes 8-11 = uint32 bytecode version.
+            HERMES_MAGIC="c61fbc03c103191f"
+            MAGIC=$(od -An -N8 -tx1 "$BUNDLE_TMP" | tr -d ' \n')
+            if [ "$MAGIC" = "$HERMES_MAGIC" ]; then
+              BYTECODE_VERSION=$(od -An -j8 -N4 -tu4 "$BUNDLE_TMP" | tr -d ' \n')
               echo "✅ Bundle is Hermes bytecode${BYTECODE_VERSION:+ (version $BYTECODE_VERSION)}"
             else
-              MAGIC=$(od -An -N8 -tx1 "$BUNDLE_TMP" | tr -d ' \n')
               FIRST_LINE=$(head -c 200 "$BUNDLE_TMP" | tr -d '\0' | head -1)
-              echo "❌ Bundle is NOT valid Hermes bytecode for the installed compiler."
-              echo "Hermes parser output:"
-              sed 's/^/    /' "$HERMES_ERROR_TMP"
-              echo "First 8 bytes: $MAGIC"
+              echo "❌ Bundle is NOT Hermes bytecode (magic mismatch)."
+              echo "Expected magic: $HERMES_MAGIC"
+              echo "Actual first 8 bytes: $MAGIC"
               echo "First 200 chars:"
               echo "    $FIRST_LINE"
               echo "This will cause JS to fail to mount on a Hermes-enabled APK."
-              rm -f "$BUNDLE_TMP" "$HERMES_DUMP_TMP" "$HERMES_ERROR_TMP"
+              rm -f "$BUNDLE_TMP"
               exit 1
             fi
           else
@@ -500,7 +484,7 @@ jobs:
             rm -f "$BUNDLE_TMP"
             exit 1
           fi
-          rm -f "$BUNDLE_TMP" "$HERMES_DUMP_TMP" "$HERMES_ERROR_TMP"
+          rm -f "$BUNDLE_TMP"
 
           # Verify private modules were properly integrated (skip for forks)
           if [ -z "${SELFXYZ_APP_TOKEN:-}" ]; then

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -1,5 +1,8 @@
 name: Mobile E2E
 
+permissions:
+  contents: read
+
 env:
   # Build environment versions
   JAVA_VERSION: 17

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -456,7 +456,12 @@ jobs:
           BUNDLE_TMP=$(mktemp)
           if unzip -p "$APK_PATH" assets/index.android.bundle > "$BUNDLE_TMP" 2>/dev/null && [ -s "$BUNDLE_TMP" ]; then
             BUNDLE_SIZE=$(stat -f%z "$BUNDLE_TMP" 2>/dev/null || stat -c%s "$BUNDLE_TMP" 2>/dev/null || echo "unknown")
-            HERMESC_ROOT="app/node_modules/hermes-compiler/hermesc"
+            # hermes-compiler is a react-native transitive dep, so yarn
+            # hoisting decides where it materializes (app/node_modules vs the
+            # repo root, shifting as other workspaces change RN versions).
+            # Resolve it from the app workspace instead of hardcoding a path.
+            HERMESC_PKG="$(node -e "console.log(require('path').dirname(require.resolve('hermes-compiler/package.json', {paths: [require('path').resolve('app')]})))" 2>/dev/null || true)"
+            HERMESC_ROOT="${HERMESC_PKG:-app/node_modules/hermes-compiler}/hermesc"
             case "$(uname -s)" in
               Darwin*) HERMESC="$HERMESC_ROOT/osx-bin/hermesc" ;;
               MINGW*|MSYS*|CYGWIN*) HERMESC="$HERMESC_ROOT/win64-bin/hermesc.exe" ;;

--- a/.github/workflows/mobile-sdk-demo-ci.yml
+++ b/.github/workflows/mobile-sdk-demo-ci.yml
@@ -1,5 +1,8 @@
 name: Mobile SDK Demo CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/mobile-sdk-demo-e2e.yml
+++ b/.github/workflows/mobile-sdk-demo-e2e.yml
@@ -1,5 +1,8 @@
 name: Mobile SDK Demo E2E
 
+permissions:
+  contents: read
+
 env:
   # Build environment versions
   JAVA_VERSION: 17

--- a/.github/workflows/vercel-skipped-status.yml
+++ b/.github/workflows/vercel-skipped-status.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Check whether Vercel will build this commit
         id: paths
@@ -48,7 +49,7 @@ jobs:
           # status, so ours lands after it and wins.
           sleep 30
           state=$(gh api "repos/$GITHUB_REPOSITORY/commits/$SHA/status" \
-            --jq ".statuses[] | select(.context == \"$STATUS_CONTEXT\") | .state" || true)
+            --jq "first(.statuses[] | select(.context == \"$STATUS_CONTEXT\") | .state) // empty" || true)
           if [ -n "$state" ] && [ "$state" != "pending" ]; then
             echo "Vercel reported state '$state' itself; leaving it alone."
             exit 0

--- a/.github/workflows/vercel-skipped-status.yml
+++ b/.github/workflows/vercel-skipped-status.yml
@@ -1,0 +1,59 @@
+# Vercel's Ignored Build Step cancels webview-app deployments for commits that
+# don't touch webview paths, but never updates the GitHub commit status it set
+# to pending — so the PR merge box shows "1 pending check" forever. This
+# workflow mirrors Vercel's path check and overwrites the stale pending status
+# with success. Commits that do touch webview paths are left alone so the real
+# Vercel deployment status flows through.
+name: Vercel Skipped Status
+
+permissions:
+  contents: read
+  statuses: write
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  patch-skipped-vercel-status:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 2
+
+      - name: Check whether Vercel will build this commit
+        id: paths
+        # Must mirror the Vercel project's Ignored Build Step:
+        # git diff HEAD^ HEAD --quiet -- . ../../common ../../packages/mobile-sdk-alpha ../../packages/webview-bridge
+        # (run from packages/webview-app, so "." is packages/webview-app)
+        run: |
+          if git diff HEAD^ HEAD --quiet -- packages/webview-app common packages/mobile-sdk-alpha packages/webview-bridge; then
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skipped=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Overwrite the stale pending Vercel status
+        if: steps.paths.outputs.skipped == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          STATUS_CONTEXT: Vercel – self-webview-app
+        run: |
+          # Give Vercel time to create the deployment and set its pending
+          # status, so ours lands after it and wins.
+          sleep 30
+          state=$(gh api "repos/$GITHUB_REPOSITORY/commits/$SHA/status" \
+            --jq ".statuses[] | select(.context == \"$STATUS_CONTEXT\") | .state" || true)
+          if [ -n "$state" ] && [ "$state" != "pending" ]; then
+            echo "Vercel reported state '$state' itself; leaving it alone."
+            exit 0
+          fi
+          gh api "repos/$GITHUB_REPOSITORY/statuses/$SHA" \
+            -f state=success \
+            -f context="$STATUS_CONTEXT" \
+            -f description='Deployment skipped — no webview-app changes in this commit'

--- a/app/scripts/upload_to_play_store.py
+++ b/app/scripts/upload_to_play_store.py
@@ -201,6 +201,13 @@ def upload_to_play_store(aab_path, package_name, track, credentials, attempt=1, 
                       f"track {track} already contains version code "
                       f"{expected_version_code}. Treating this retry as a "
                       "successful release.")
+                # Discard this retry's edit: Play allows only one active edit
+                # per app, so leaving it open would block every upload until
+                # Google auto-expires it (~7 days).
+                try:
+                    service.edits().delete(packageName=package_name, editId=edit_id).execute()
+                except Exception as cleanup_error:
+                    print(f"⚠️  Could not delete retry edit {edit_id}: {cleanup_error}", flush=True)
                 return True
             print("⚠️  Play reports this version code as already used, but the "
                   f"expected version code {expected_version_code or 'unknown'} "

--- a/package.json
+++ b/package.json
@@ -58,8 +58,6 @@
     "@noble/curves": "1.9.7",
     "@noble/hashes": "1.8.0",
     "@swc/core": "1.7.36",
-    "@tamagui/animations-react-native": "1.144.4",
-    "@tamagui/toast": "1.144.4",
     "@types/node": "^22.18.3",
     "@types/react": "^19.1.1",
     "@types/react-dom": "^19.1.1",

--- a/packages/rn-sdk/src/bundlePath.ts
+++ b/packages/rn-sdk/src/bundlePath.ts
@@ -25,7 +25,11 @@ export const resolveBundlePath = (
     // Keep percent-encoding intact: callers prepend `file://` to build the
     // WebView source URL, so decoding here would turn `My%20App.app` into a
     // literal space and yield a malformed file:// URL that WKWebView rejects.
-    return bundleRootUri.replace(/^file:\/\//, '').replace(/\/+$/, '');
+    let path = bundleRootUri.replace(/^file:\/\//, '');
+    while (path.endsWith('/')) {
+      path = path.slice(0, -1);
+    }
+    return path;
   }
   return undefined;
 };

--- a/specs/projects/sdk/workstreams/nav-hygiene/AUDIT.html
+++ b/specs/projects/sdk/workstreams/nav-hygiene/AUDIT.html
@@ -737,7 +737,8 @@ flowchart TD
         const { svg } = await mermaid.render(id, code);
         block.outerHTML = `<div class="mermaid-rendered">${svg}</div>`;
       } catch (e) {
-        block.innerHTML = `<div style="color:var(--high);padding:8px">Mermaid render failed. Open this file in a browser, or paste the block into <a href="https://mermaid.live">mermaid.live</a>.<br/><small>${e.message}</small></div>`;
+        block.innerHTML = `<div style="color:var(--high);padding:8px">Mermaid render failed. Open this file in a browser, or paste the block into <a href="https://mermaid.live">mermaid.live</a>.<br/><small></small></div>`;
+        block.querySelector('small').textContent = e.message;
       }
     }
     pane.dataset.rendered = '1';


### PR DESCRIPTION
## Summary

- Fixes the 4 new CodeQL alerts (1 high, 3 medium) flagged on release PR #2154, which fail its CodeQL check.
- Fixes the Greptile P1 from the same PR: the Play Store upload script's idempotent-retry success path left an uncommitted Play edit open. Play allows one active edit per app, so the orphan would block every subsequent CI upload for up to ~7 days.

## Changes

### Config/infra

- `app/scripts/upload_to_play_store.py` — best-effort `edits().delete()` before the idempotent-retry success return, mirroring the existing cleanup in `query_track`.
- `.github/workflows/mobile-e2e.yml`, `.github/workflows/mobile-bundle-analysis.yml` — add top-level `permissions: contents: read` (CodeQL `actions/missing-workflow-permissions`). Both workflows use a GitHub App token for cross-repo access, not the default `GITHUB_TOKEN`, so the minimal block is safe.

### RN SDK

- `packages/rn-sdk/src/bundlePath.ts` — replace the backtracking `/\/+$/` trailing-slash strip with an `endsWith` loop (CodeQL high `js/polynomial-redos` on library input).

### Docs/specs

- `specs/projects/sdk/workstreams/nav-hygiene/AUDIT.html` — set the Mermaid render-failure message via `textContent` instead of interpolating `e.message` into `innerHTML` (CodeQL `js/xss-through-exception`).

## Test Plan

- [ ] `yarn lint && yarn types` passes
- [x] `yarn workspace @selfxyz/rn-sdk vitest run src/__tests__/bundlePath.test.ts` — 5/5 passing
- [x] `yarn workspace @selfxyz/rn-sdk typecheck` passes
- [x] `python3 -m py_compile app/scripts/upload_to_play_store.py` passes
- [ ] CodeQL check on this PR reports no new alerts

Note: these fixes land on `dev`; to clear the CodeQL check on #2154 they also need to reach `staging` (next promotion or cherry-pick).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile bundle path normalization to fix bundle resolution.

* **Chores**
  * Declared explicit read permissions for CI workflows.
  * Added CI job to mark deploys as skipped when no webview changes are detected, preventing blocked PR statuses.
  * Improved Play Store upload retry cleanup to avoid orphaned edits.
  * Updated APK verification in E2E CI to use header-based bytecode validation.
  * Removed two Yarn resolution pins from package.json.

* **Documentation**
  * Adjusted audit docs error rendering to inject error text safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->