### PR TITLE
switch Didit 4.x to autodetection variant to keep auto-capture

### DIFF
--- a/app/android/gradle.properties
+++ b/app/android/gradle.properties
@@ -60,5 +60,6 @@ android.suppressUnsupportedCompileSdk=35
 # Keep native libraries uncompressed for 16 KB page size support
 android.bundle.enableUncompressedNativeLibs=true
 
-# Use Didit Android SDK 'core' artifact (no NFC). Self ships its own passport NFC reader.
-diditSdkAndroidVariant=core
+# Use Didit Android SDK 'autodetection' variant: MediaPipe auto-capture, no NFC
+# (Self ships its own passport NFC reader). 4.x 'core' is manual-capture-only.
+diditSdkAndroidVariant=autodetection

--- a/app/android/gradle.properties
+++ b/app/android/gradle.properties
@@ -61,4 +61,4 @@ android.suppressUnsupportedCompileSdk=35
 android.bundle.enableUncompressedNativeLibs=true
 
 # Use Didit Android SDK 'core' artifact (no NFC). Self ships its own passport NFC reader.
-diditSdkAndroidNfcEnabled=false
+diditSdkAndroidVariant=core

--- a/app/ios/Podfile
+++ b/app/ios/Podfile
@@ -1,11 +1,11 @@
 source "https://cdn.cocoapods.org/"
 
-# Pin Didit to the Core variant — Self ships its own passport NFC reader.
-# DiditSDK/Core has no CoreNFC and no bundled OpenSSL.xcframework, avoiding the
-# OpenSSL conflict with SelfNFCPassportReader's OpenSSL-Universal dependency.
-# (The SDK 4.x legacy mapping for DIDIT_SDK_IOS_NFC_ENABLED=false resolves to
-# AutoDetection, not Core, so the variant must be set explicitly.)
-ENV["DIDIT_SDK_IOS_VARIANT"] ||= "core"
+# Pin Didit to the AutoDetection variant — Self ships its own passport NFC
+# reader. AutoDetection keeps MediaPipe auto document/face capture (bundled in
+# 3.x Core, split out in 4.x) but has no CoreNFC and no OpenSSL.xcframework,
+# avoiding the OpenSSL conflict with SelfNFCPassportReader's OpenSSL-Universal
+# dependency. Do not use "core": in 4.x it is manual-capture-only.
+ENV["DIDIT_SDK_IOS_VARIANT"] ||= "autodetection"
 
 use_frameworks!
 require "tmpdir"
@@ -173,10 +173,10 @@ target "Self" do
   pod "QKMRZScanner"
   pod "lottie-ios"
   # DiditSDK is not on CocoaPods trunk — reference the upstream podspec by tag.
-  # The wrapper (SdkReactNative.podspec) depends on DiditSDK/Core when
-  # DIDIT_SDK_IOS_VARIANT=core (set above). Keep this tag in sync with the
-  # exact DiditSDK version pinned by @didit-protocol/sdk-react-native.
-  pod 'DiditSDK/Core', :podspec => 'https://raw.githubusercontent.com/didit-protocol/sdk-ios/4.0.5/DiditSDK.podspec'
+  # The wrapper (SdkReactNative.podspec) depends on DiditSDK/AutoDetection when
+  # DIDIT_SDK_IOS_VARIANT=autodetection (set above). Keep this tag in sync with
+  # the exact DiditSDK version pinned by @didit-protocol/sdk-react-native.
+  pod 'DiditSDK/AutoDetection', :podspec => 'https://raw.githubusercontent.com/didit-protocol/sdk-ios/4.0.5/DiditSDK.podspec'
   pod 'OpenSSL-Universal', '~> 1.1.1900'
   pod "SwiftQRScanner", :git => "https://github.com/vinodiOS/SwiftQRScanner"
   # RNReactNativeHapticFeedback is handled by autolinking

--- a/app/ios/Podfile
+++ b/app/ios/Podfile
@@ -1,10 +1,11 @@
 source "https://cdn.cocoapods.org/"
 
-# Disable Didit's bundled NFC passport reader — Self ships its own. The wrapper
-# podspec consumes DiditSDK/Core (no CoreNFC, no bundled OpenSSL.xcframework)
-# when this env var is "false", which also avoids the OpenSSL conflict with
-# SelfNFCPassportReader's OpenSSL-Universal dependency.
-ENV["DIDIT_SDK_IOS_NFC_ENABLED"] ||= "false"
+# Pin Didit to the Core variant — Self ships its own passport NFC reader.
+# DiditSDK/Core has no CoreNFC and no bundled OpenSSL.xcframework, avoiding the
+# OpenSSL conflict with SelfNFCPassportReader's OpenSSL-Universal dependency.
+# (The SDK 4.x legacy mapping for DIDIT_SDK_IOS_NFC_ENABLED=false resolves to
+# AutoDetection, not Core, so the variant must be set explicitly.)
+ENV["DIDIT_SDK_IOS_VARIANT"] ||= "core"
 
 use_frameworks!
 require "tmpdir"
@@ -173,8 +174,9 @@ target "Self" do
   pod "lottie-ios"
   # DiditSDK is not on CocoaPods trunk — reference the upstream podspec by tag.
   # The wrapper (SdkReactNative.podspec) depends on DiditSDK/Core when
-  # DIDIT_SDK_IOS_NFC_ENABLED=false (set above).
-  pod 'DiditSDK/Core', :podspec => 'https://raw.githubusercontent.com/didit-protocol/sdk-ios/3.5.1/DiditSDK.podspec'
+  # DIDIT_SDK_IOS_VARIANT=core (set above). Keep this tag in sync with the
+  # exact DiditSDK version pinned by @didit-protocol/sdk-react-native.
+  pod 'DiditSDK/Core', :podspec => 'https://raw.githubusercontent.com/didit-protocol/sdk-ios/4.0.5/DiditSDK.podspec'
   pod 'OpenSSL-Universal', '~> 1.1.1900'
   pod "SwiftQRScanner", :git => "https://github.com/vinodiOS/SwiftQRScanner"
   # RNReactNativeHapticFeedback is handled by autolinking

--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -12,7 +12,7 @@ PODS:
   - boost (1.84.0)
   - BVLinearGradient (2.8.3):
     - React-Core
-  - DiditSDK/Core (4.0.5)
+  - DiditSDK/AutoDetection (4.0.5)
   - DoubleConversion (1.1.6)
   - EXApplication (55.0.14):
     - ExpoModulesCore
@@ -3442,7 +3442,7 @@ PODS:
     - Yoga
   - SdkReactNative (4.0.5):
     - boost
-    - DiditSDK/Core (= 4.0.5)
+    - DiditSDK/AutoDetection (= 4.0.5)
     - DoubleConversion
     - fast_float
     - fmt
@@ -3490,7 +3490,7 @@ PODS:
 DEPENDENCIES:
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
   - BVLinearGradient (from `../node_modules/react-native-linear-gradient`)
-  - DiditSDK/Core (from `https://raw.githubusercontent.com/didit-protocol/sdk-ios/4.0.5/DiditSDK.podspec`)
+  - DiditSDK/AutoDetection (from `https://raw.githubusercontent.com/didit-protocol/sdk-ios/4.0.5/DiditSDK.podspec`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - EXApplication (from `../node_modules/expo-application/ios`)
   - EXConstants (from `../node_modules/expo-constants/ios`)
@@ -4083,7 +4083,7 @@ SPEC CHECKSUMS:
   RNScreens: 7c9bd0eafa89f9a57dfb2cf69112fdc5298d474b
   RNSentry: 06242a8b32437eff96f4e2e48d9e780e65ccd686
   RNSVG: 14a9b979bfb8fc5b90c03de67409f399f847b3b3
-  SdkReactNative: c09cc8ae7bd819f1b4681b9ef0697caa3cb0611f
+  SdkReactNative: be345ffe0dc9624ef7e1fa759a83a27f4ce3de0f
   segment-analytics-react-native: ab16aeb1731acc05670dcec1aaed13b6bcbc1b6d
   SelfNFCPassportReader: 8b53f9d483e0dd1f1a275953e3dc6dfc733694c5
   selfxyz-rn-sdk: 10a6f99e70be61f7b9f7f2a3b2975dbf0ad9f351
@@ -4094,6 +4094,6 @@ SPEC CHECKSUMS:
   SwiftyTesseract: 1f3d96668ae92dc2208d9842c8a59bea9fad2cbb
   Yoga: e9fea23bf9b2766818ce9a8df72f584bf5ad36cd
 
-PODFILE CHECKSUM: f89d18f77e52cf128acaf016dba241a8ebe7432e
+PODFILE CHECKSUM: 7375a9098249b50f3237490775ff8342867de51e
 
 COCOAPODS: 1.16.2

--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -12,7 +12,7 @@ PODS:
   - boost (1.84.0)
   - BVLinearGradient (2.8.3):
     - React-Core
-  - DiditSDK/Core (3.5.1)
+  - DiditSDK/Core (4.0.5)
   - DoubleConversion (1.1.6)
   - EXApplication (55.0.14):
     - ExpoModulesCore
@@ -3440,9 +3440,9 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - SdkReactNative (3.3.2):
+  - SdkReactNative (4.0.5):
     - boost
-    - DiditSDK/Core (~> 3.5)
+    - DiditSDK/Core (= 4.0.5)
     - DoubleConversion
     - fast_float
     - fmt
@@ -3490,7 +3490,7 @@ PODS:
 DEPENDENCIES:
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
   - BVLinearGradient (from `../node_modules/react-native-linear-gradient`)
-  - DiditSDK/Core (from `https://raw.githubusercontent.com/didit-protocol/sdk-ios/3.5.1/DiditSDK.podspec`)
+  - DiditSDK/Core (from `https://raw.githubusercontent.com/didit-protocol/sdk-ios/4.0.5/DiditSDK.podspec`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - EXApplication (from `../node_modules/expo-application/ios`)
   - EXConstants (from `../node_modules/expo-constants/ios`)
@@ -3664,7 +3664,7 @@ EXTERNAL SOURCES:
   BVLinearGradient:
     :path: "../node_modules/react-native-linear-gradient"
   DiditSDK:
-    :podspec: https://raw.githubusercontent.com/didit-protocol/sdk-ios/3.5.1/DiditSDK.podspec
+    :podspec: https://raw.githubusercontent.com/didit-protocol/sdk-ios/4.0.5/DiditSDK.podspec
   DoubleConversion:
     :podspec: "../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec"
   EXApplication:
@@ -3936,22 +3936,22 @@ SPEC CHECKSUMS:
   AppAuth: 1c1a8afa7e12f2ec3a294d9882dfa5ab7d3cb063
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
-  BVLinearGradient: cb006ba232a1f3e4f341bb62c42d1098c284da70
-  DiditSDK: 27173cbfc13db575640538a978d3ecf983b047ba
+  BVLinearGradient: 880f91a7854faff2df62518f0281afb1c60d49a3
+  DiditSDK: 1c48cbef9127ac9068e65fb758e04999e31ea375
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
-  EXApplication: ab5a9ca485adce8be81309a5172d1565e9d7467f
-  EXConstants: dadbeba983acc30f855a919658a2b34fbd86615d
-  Expo: 405a5b0aacf5d1954ea19a164b519f520bf68f43
-  ExpoAdapterGoogleSignIn: ab4d9fc38cb91077a4138d178395525ec65d0c2e
-  ExpoAsset: 7721c5c4ae2a7c3c8147a046727ac6c020b05648
-  ExpoCamera: 1f783af198ebb299f430758c86af8339cf7d63a9
-  ExpoDomWebView: b2e9d601f9cb77d3c97da73234e175b64be91928
-  ExpoFileSystem: 61e663d0bbd1a973d324530d1d6ee559a5e5192c
-  ExpoFont: a7e34a75bdfb703fa07a0e87807f836236608c76
-  ExpoKeepAwake: d0eb7a0719500d2a43fbf29b6f79e84d70c75ebf
-  ExpoLogBox: 617da77cbc083627692b2ea050a3666808aef2cd
-  ExpoModulesCore: 08e767f43da6e4f0a56cabb59d5b447a12134f98
-  ExpoModulesJSI: bbd6d912b19ba7455d95b2c2fd3bc73459f8cba9
+  EXApplication: c2dcab659064299662da96cc6032c4334b79777f
+  EXConstants: 255fd9f72f94bfccaed1d161edac04a552baa8d9
+  Expo: 7b4c36d6a1689b1a68761efd41f1808ebd836a78
+  ExpoAdapterGoogleSignIn: 3332ac2d96d803350f53f84047244b35e2efc994
+  ExpoAsset: 9d035bcc19d8688e9ddb2c579c50c8f83824188e
+  ExpoCamera: e0c3cc31cca60c3f1f6a4c8460ee58623bf2dad7
+  ExpoDomWebView: 317a0d188cfdb850fc6fd2a43a2fc132dfd171ee
+  ExpoFileSystem: ce9db64ae67e6dcc8db42365e499f9fcc4fbe8ec
+  ExpoFont: 21550be2946ea5bbf50f1a20b31facd19ba4150c
+  ExpoKeepAwake: 45e456e29335bbd400554646a2f29e628c24072e
+  ExpoLogBox: efb519c2c43697a0638151efd53c3ddc2f6200dc
+  ExpoModulesCore: 8a478df460bb1285ebce2ecd535b57a384edfd99
+  ExpoModulesJSI: 4f6e665f2801be06fecf7a912946ed33d64d15fc
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: 3bcb3055086e5d90a12f0fe1668e79f6eceabc17
   Firebase: 6a8f201c61eda24e98f1ce2b44b1b9c2caf525cc
@@ -3975,7 +3975,7 @@ SPEC CHECKSUMS:
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   hermes-engine: 85d1dfac6a09d00a2ebe76179c258c1215f2cde9
   lottie-ios: 8f959969761e9c45d70353667d00af0e5b9cadb3
-  lottie-react-native: e542fe4b6e8eddcf893d5a8cef9f8b5c6d2f7331
+  lottie-react-native: a2e73ead497511a11d9b5dc520e79343f17529ed
   Mixpanel-swift: e9bef28a9648faff384d5ba6f48ecc2787eb24c0
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   OpenSSL-Universal: 84efb8a29841f2764ac5403e0c4119a28b713346
@@ -3986,114 +3986,114 @@ SPEC CHECKSUMS:
   RCTDeprecation: c7d33f6bc08dbb8be7dfa70d219bfb034480a406
   RCTRequired: 42b13c9504609bae9a9f65673a6b4fcbd8d07bd1
   RCTSwiftUI: cef2010e1e5e699600b2064d3aa702e53c35816c
-  RCTSwiftUIWrapper: 18f0f0601b556e27593928c36697d5f651db760f
+  RCTSwiftUIWrapper: dc8026f15059e65ae5f23ce8b7032f52318e04bb
   RCTTypeSafety: c5fd6a8092bee25eaa31d4cca03794e902b5fdfd
   React: 6c36d83b2afecc1d45ec2a637158750edad20d87
   React-callinvoker: 813372c3165324939d57b849f2db0c99390b9aac
-  React-Core: b2a189a7e16fc88a768908152201f14379708ac0
-  React-CoreModules: 7ff1464d8c75a63c4028571217e4f4d01b008919
-  React-cxxreact: 06aed26685cbd29a55d1648a14f13491549cea9d
+  React-Core: 497da2fa08060213b5b265b38cb64af2e0f0526c
+  React-CoreModules: 255a3150b3a24c8628ef050e7ae448d198dd003b
+  React-cxxreact: e6a1142898716d391d27bd7d05091fca0046e2c5
   React-debug: 2233bb5bc031fe8dfb43d320f907d30fd806c916
-  React-defaultsnativemodule: 8789f6909cbe4168530205651ff3d8bb37ab1804
-  React-domnativemodule: c0617a3935de3d1253743822d05c74371e304e36
-  React-Fabric: bf1bc57cbadda2ed24c58c105931bfc2ddbb9dc3
-  React-FabricComponents: 213b169045fe6d1a2d770684eba95ead04eebe1b
-  React-FabricImage: 62eacd410a24b46841d26a448f712e1894f716e2
-  React-featureflags: dc72c24429f541f9b452e585906c38e873db4b4d
-  React-featureflagsnativemodule: bd56afad1dccd0beab5b6e7c0d82cce227409aa3
-  React-graphics: 138ade7adcdc81af93caceae45a17b9002d9873f
-  React-hermes: f241babdb4e8595933d856ab78f5d5d49218cac0
-  React-idlecallbacksnativemodule: cff02831f4fc3bf1ad9655f323a38195fd4c1ffd
-  React-ImageManager: 3b6ba10bd79616141fe10fd456c2089be409f6de
-  React-intersectionobservernativemodule: 5d81fd060120d91932d2ebd2b38be3436591eb47
-  React-jserrorhandler: b6aab46da066ce676589a13b0ecb443dd111f4bc
-  React-jsi: ee1dbc3b2635ce07783e6638656c0b472573bb48
-  React-jsiexecutor: 05fe7918c713a64a39474915f725fe0e61d65309
-  React-jsinspector: 16c831b281c23733684ac1fdc06ef63bba6152b0
-  React-jsinspectorcdp: a010c4cd959138d35936e0c8518f4d91d433004d
-  React-jsinspectornetwork: 1325a05bcf0f1ffc9913dd318935d927b5cccc67
-  React-jsinspectortracing: 55107028cf38bfb871ddb68c35e3be65c06005be
-  React-jsitooling: 1a044a33269f5d708e13b9b9050cd2c23b764d00
-  React-jsitracing: dd208bbb018a207bb2b963382e95ec77629e899b
-  React-logger: cf2064f903777a5bdca904c4265f17396d4d8568
-  React-Mapbuffer: 6a42f63da7904746685b9f2785ef0e3e22f2d345
-  React-microtasksnativemodule: 3f487e67e2e57ed19b0b450356b6080bf37827de
-  React-mutationobservernativemodule: c719720b2b995b81cae45c9635c6ecfbd8b1f25a
-  react-native-app-auth: e21c8ee920876b960e38c9381971bd189ebea06b
-  react-native-biometrics: 43ed5b828646a7862dbc7945556446be00798e7d
-  react-native-blur: b83ffbc5380d8bd2f06804b4b0e848be3507e65c
-  react-native-cloud-storage: 70b358ddb1ab755c0093b0077ad7b4b8bcd332b2
-  react-native-compat: bcc3c754c04b17f0f1005ba4ea5252f16fcc7b32
-  react-native-date-picker: 64ccae6c3a8104a168cef950fea8e1fe616cda82
-  react-native-get-random-values: d16467cf726c618e9c7a8c3c39c31faa2244bbba
-  react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
-  react-native-nfc-manager: c8891e460b4943b695d63f7f4effc6345bbefc83
-  react-native-passkey: e45fd30bce18e25b8973788964dc3b0d724c1d57
-  react-native-safe-area-context: eda63a662750758c1fdd7e719c9f1026c8d161cb
-  react-native-sqlite-storage: 0c84826214baaa498796c7e46a5ccc9a82e114ed
-  react-native-webview: cdce419e8022d0ef6f07db21890631258e7a9e6e
-  React-NativeModulesApple: b917ca8e4702a3c7f283be6c5ebbdf0af8516c61
-  React-networking: fd886fda5c01a731b6d2d8660bf8632047a3ca4e
+  React-defaultsnativemodule: f8fef92ce6f3765e37b66ceced1bd6c6f68f7952
+  React-domnativemodule: 66e9cf653feb869e33f3d836a74daf4754df1fc5
+  React-Fabric: bfcd201bfee5146393ef60843ffc02cdef4fdf17
+  React-FabricComponents: d791cd2fdeb9ee2d0bfd518fb40ffb23206df8e6
+  React-FabricImage: 749d0eda525cebde235102c5f8244c5e28caa580
+  React-featureflags: c8e838569981fd1268b639a1aa5284d3e7df8cb1
+  React-featureflagsnativemodule: 31995fbde26ffaecff131ba09c5233a2336b89a2
+  React-graphics: 7b366fc8941af144d63f3723a759f7972fc605ce
+  React-hermes: 85101b86c76672bdfc78def14feb93c15445f029
+  React-idlecallbacksnativemodule: 61973db102366540882abe405fa03e8f95e276ec
+  React-ImageManager: 3bc17b513f24f86da87d267c6fd12565afa691e6
+  React-intersectionobservernativemodule: fcbd7fb8df6b89f066761588c2efb16ae5eb3eb9
+  React-jserrorhandler: edd3b71a42cd112ef5beabe688ffae3d2388c316
+  React-jsi: abd0559cbfcd75539f61bc6ee3ae1e72c38b8727
+  React-jsiexecutor: e96ff30c2e7ab4c1a1652e6a48d44f80b774b411
+  React-jsinspector: f1bc4dd9fadce298b1bf1fe231755d35b0cd05dd
+  React-jsinspectorcdp: 64f0de8e1e12300b72f5d1808986ba556de261a5
+  React-jsinspectornetwork: ffe1a08a9526e4144b763fe985235323c107735d
+  React-jsinspectortracing: 4116ee19c18f9bb18e8598d66414d0485d27df41
+  React-jsitooling: dc291dcd7d73c44672cc636959518852ba56ffe3
+  React-jsitracing: f1b12235ea14ad46f4eccbf6779f16da873aa667
+  React-logger: 532b0b1405e20c08146a739fbaf6fd16fd771291
+  React-Mapbuffer: 2b2363c1fc7602da5e9289c2c712a226f0c784c4
+  React-microtasksnativemodule: ce677db9502ff6a19c9a623a8bd8250eabd38ee3
+  React-mutationobservernativemodule: 8d57f3695f679fbe01e7587f47036d8ac2ceb33e
+  react-native-app-auth: 9b0a0e3ca279c3426a451e2607c8483808b8ed4a
+  react-native-biometrics: 352e5a794bfffc46a0c86725ea7dc62deb085bdc
+  react-native-blur: 981b2ec64b3084ecf98812333f2a8c6e83643a1e
+  react-native-cloud-storage: ac9d899109c3dd9bc78c11a37bec2e905f756838
+  react-native-compat: e24e458b1bd4928ec70df8b2a02930fa4f25f837
+  react-native-date-picker: d1d607499ff9f2e1231f902b4bda70595d71253e
+  react-native-get-random-values: 21325b2244dfa6b58878f51f9aa42821e7ba3d06
+  react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
+  react-native-nfc-manager: ef3b44c4f1975ab16d6109bb1671ab68068aba58
+  react-native-passkey: 9bbbff0f66694665507ffe1426419a9ca09f4d2a
+  react-native-safe-area-context: 7e0ba374906d8f5009aaf96cd19d4866d8de342b
+  react-native-sqlite-storage: f6d515e1c446d1e6d026aa5352908a25d4de3261
+  react-native-webview: 5887b6094417c75a9bee446261f89c32adf6b602
+  React-NativeModulesApple: 9d5e4036b19438ae2626ddfd816224d5b626193d
+  React-networking: dce788e5934ba3077621b7460b2fa6b8a1afc599
   React-oscompat: 4524d8ccb12b7f07beb12e2ea9c5ea55b55d604b
-  React-perflogger: 2b2a2bc9173796cc58fece00d3df1c99b39c2b8e
-  React-performancecdpmetrics: f429b2e52df3c685b370174a72de83ac18a507f8
-  React-performancetimeline: 668440472cf7d7bdedd143df19300eddb7349ca3
+  React-perflogger: ccc20d34acfe74605f0f2d2a414fddf731b14bd1
+  React-performancecdpmetrics: 68b63fe04e3b2c734dd73877af7d83f91f092cf2
+  React-performancetimeline: f95a3f94226db5dc9f6d777e13b4004a21b97ac8
   React-RCTActionSheet: e1c8afe045a25f3a8d73da52bb28e6186718e206
-  React-RCTAnimation: 7681b2367405b53d4e91ac76b36bd8fb1ce50a53
-  React-RCTAppDelegate: e8d05c439051bd6860638e59fc8fb81cf3ac0f9b
-  React-RCTBlob: fa0e5ab89883e4bf5eb05e534b68ce2951ca514b
-  React-RCTFabric: 349e43b824b57abd6a927f76d314906970abd10d
-  React-RCTFBReactNativeSpec: 63a19207a5df13c3302fe55ca075774059bf7b15
-  React-RCTImage: 8d32ede0e9f07aa7a446a54e924f23b3347d2960
-  React-RCTLinking: ef0c625de1ce2b78189cb65391888628b5d2d6ed
-  React-RCTNetwork: 5e6a3678c23c0b8c4e2b69e85551215f1fcfe2b2
-  React-RCTRuntime: 1d05620bbf1864e532f627fd7cd6421c2a6ca091
-  React-RCTSettings: c7f2c32bee82c3f4e757d779fff3c2bf47cc7e46
-  React-RCTText: cc134029a95773223502a9aeac47300586426ca5
-  React-RCTVibration: 9ed48065a50d4a4311aed5c17272061f2cae910b
+  React-RCTAnimation: f350cac40fbf4d2f7269c50a4809812a51e7143a
+  React-RCTAppDelegate: c7e4dd9a3a94f348a9c9e3f6ec30a2fa45713d0b
+  React-RCTBlob: 8215edb879697c37ebc3d93d44210c136b0f8f12
+  React-RCTFabric: 6889017ee93557eb9032d0764384e816f1a27140
+  React-RCTFBReactNativeSpec: 31bb98685269647f8cef19e5f1decaa30a23472d
+  React-RCTImage: 55ce5873af9d447dde76711c84ea545688eb5e01
+  React-RCTLinking: 803e8a4356dc848d1cff0882e70b81c2c28f67e1
+  React-RCTNetwork: 5e13fe88a73150e7cd7eff989a55b5c1c7e4b701
+  React-RCTRuntime: 3ff3cb07332ad0dc029a449029fd23e60777a030
+  React-RCTSettings: 3a6fd39c7169fe408f6cf16d939ba7910b02fe6e
+  React-RCTText: 5a2c8addcbe6d3d36636407423d9969012fcdaa7
+  React-RCTVibration: 460b55fcd5ae2f028e9910ccad192f5ffea1d6b8
   React-rendererconsistency: 345e67ceac81704cab35ca5f801ad1661b593121
-  React-renderercss: f35b5778f9bd261a86095848152c2a2c9502b2c7
-  React-rendererdebug: 2dfeef9bbc4b8b80acae1bf1a03a7928daf89a92
-  React-RuntimeApple: 40d6558ab7dbf25b506da18852c8385da329967a
-  React-RuntimeCore: 942e1e98e27631e4c8e5c94f8d590f3c96aec6d2
-  React-runtimeexecutor: 17f189fa2d15661afcbbd5a0364edbcd477cb8ae
-  React-RuntimeHermes: d8069161558d2c2a728e307e6fd29d9b9036cd9a
-  React-runtimescheduler: 5c845952ec91506065708414a034ebd4ea4150ed
-  React-timing: a1841068ce1738ece7dc4e4fb7f26757d56bec13
-  React-utils: 792dd487537d43052fe2effa88bfaee6588076d4
-  React-webperformancenativemodule: 4ec1e48bc997139f69b6ac3a127266ccb28a29bf
-  ReactAppDependencyProvider: 87593e9dfdba8dac1d7b2af1af05f0eff2a05684
-  ReactCodegen: abdbaf78aa315eb8331bf6d60bae1af65f8ded6f
-  ReactCommon: e3671aa40073668776ada8a2c328060613e33d00
-  RNAppleAuthentication: a89c9804592b38ed4ab11f0aee68d05ba12ad432
-  RNCAsyncStorage: fd44f4b03e007e642e98df6726737bc66e9ba609
-  RNCClipboard: e560338bf6cc4656a09ff90610b62ddc0dbdad65
-  RNDeviceInfo: 4c852998208b60dc192ae3529e5867817719ad1e
-  RNFBAnalytics: 03c83ba4617a3754c99e66267983efcc908932a9
-  RNFBApp: a448037d2df74af9d374a0b765be12ff1e844dc0
-  RNFBMessaging: 0f0498a95c605e3afcf13ac5f349d0b201ea65f6
-  RNFBRemoteConfig: 4eb5fc9f21dc324153c7d3f5b48c935ab9031876
-  RNGestureHandler: 445f4e60308b44ab423660b37073afc01977f48c
-  RNGoogleSignin: 32eac25be182674a2838c8bf6908c0296fe3bb5d
-  RNInAppBrowser: 904d24dc75e8e6c6c98a3160329192608946f9df
-  RNKeychain: 76d042fc1dfba47f3945920bc82e0bce9ad1ff55
-  RNLocalize: c46dd4008dc8990a098fcafd6ee051122a1ccfda
-  RNPermissions: b469cd9fd82c7e45b04b8620da719c05b97f8ddb
-  RNReactNativeHapticFeedback: b6a8971d44e0802c97a729c934f96c53c5cb1e97
-  RNScreens: 0e35897693c6f1aa38627dc1b4c37c7450e4b902
-  RNSentry: adbde98523a92f127f7ac2834cb25a71589f2763
-  RNSVG: d9938e7f6ea1616124dd2d64b933322ac2059e05
-  SdkReactNative: 1bc6a7467202311b7ac795d84c9b1905c3c089c9
-  segment-analytics-react-native: 8ab9c49df1859bbd6be93cf90a91ade17f20a0aa
+  React-renderercss: 1c0217ca565d5d3ecdc94790212e4880136a8ade
+  React-rendererdebug: 898827d7a295139b5cb62b4e0926639c26523b56
+  React-RuntimeApple: ee8d63ae394a9fd48322e47a171d3284608c44e1
+  React-RuntimeCore: 8fb60eb518c1ddfb8bea9c994c8f91a3206ae691
+  React-runtimeexecutor: 208fba0e9b8391d87a53e0093aab3d56caf53e0f
+  React-RuntimeHermes: f28e1daccfd6d6326abdccc826e680a974ee1ee7
+  React-runtimescheduler: 3da698a55d0846be56efba4bd629175a41895c1d
+  React-timing: bb887a93f6b94349d0041e9c4f82e88e83182439
+  React-utils: a36dceee2a227a70210e5da9875d2fbc1225e828
+  React-webperformancenativemodule: 8593225a4402c869430aa57beb268819eb1374e2
+  ReactAppDependencyProvider: 5bf52020fdc0d0a337068ea42d4a6676ce4a04bc
+  ReactCodegen: e2313c1a77ba92c3c46e9760359fd455f69f233e
+  ReactCommon: 59575b2aafe69272fc335fdef552219e4055f43c
+  RNAppleAuthentication: d6fe579e5f43cf8db54bdc48518bccea61c592a4
+  RNCAsyncStorage: 8857fb173af29664cb90897903902dc8533e36cc
+  RNCClipboard: 4eea71d801c880175c12f6ab14332ca86fed935f
+  RNDeviceInfo: d79872e11c8e9c4de0d65b0ee6e0cee719f37fea
+  RNFBAnalytics: caec446c723d33cfdcf75aab53fa1287e499b2d0
+  RNFBApp: fda4a8b08fe31bea8492808106aa638d1bb595b7
+  RNFBMessaging: 099972ab397d61815f32610514b0573d1db2b1e1
+  RNFBRemoteConfig: ce28355c29a432ac29c9a9d10816a906c0fee938
+  RNGestureHandler: 74b18017f93098e8a5b325f9f502bf7f10d3c4fe
+  RNGoogleSignin: ca05a4eb8b125c8a7bf93e1679f008faa0e5090c
+  RNInAppBrowser: b53e6f6072c931115bc22ac9dc9510ac2cbea62d
+  RNKeychain: d0bdaca4688ae123909b137de08491f49a6cf6b1
+  RNLocalize: 096957145ff922e7f7b82bb24e0785f8818f6bac
+  RNPermissions: 44c5b899744fdfb7f55d1a9a893e92fcb6d5d379
+  RNReactNativeHapticFeedback: 227085091b30478ba4438ad2203ca9629cc85b43
+  RNScreens: 7c9bd0eafa89f9a57dfb2cf69112fdc5298d474b
+  RNSentry: 06242a8b32437eff96f4e2e48d9e780e65ccd686
+  RNSVG: 14a9b979bfb8fc5b90c03de67409f399f847b3b3
+  SdkReactNative: c09cc8ae7bd819f1b4681b9ef0697caa3cb0611f
+  segment-analytics-react-native: ab16aeb1731acc05670dcec1aaed13b6bcbc1b6d
   SelfNFCPassportReader: 8b53f9d483e0dd1f1a275953e3dc6dfc733694c5
-  selfxyz-rn-sdk: 979043eba7cb1ca128d9e6bfbe970c5737be2a51
+  selfxyz-rn-sdk: 10a6f99e70be61f7b9f7f2a3b2975dbf0ad9f351
   Sentry: 5c3f67235d4c16fcfab43158a8c1502a18fece9a
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  sovran-react-native: a3ad3f8ff90c2002b2aa9790001a78b0b0a38594
+  sovran-react-native: eec37f82e4429f0e3661f46aaf4fcd85d1b54f60
   SwiftQRScanner: e85a25f9b843e9231dab89a96e441472fe54a724
   SwiftyTesseract: 1f3d96668ae92dc2208d9842c8a59bea9fad2cbb
   Yoga: e9fea23bf9b2766818ce9a8df72f584bf5ad36cd
 
-PODFILE CHECKSUM: bdee3995d30648e8e5e19197fe140d8a809fdbaf
+PODFILE CHECKSUM: f89d18f77e52cf128acaf016dba241a8ebe7432e
 
 COCOAPODS: 1.16.2

--- a/app/package.json
+++ b/app/package.json
@@ -91,7 +91,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.29.2",
-    "@didit-protocol/sdk-react-native": "^3.3.2",
+    "@didit-protocol/sdk-react-native": "^4.0.5",
     "@ethersproject/shims": "^5.8.0",
     "@invertase/react-native-apple-authentication": "^2.5.1",
     "@noble/hashes": "^1.5.0",

--- a/app/package.json
+++ b/app/package.json
@@ -91,7 +91,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.29.2",
-    "@didit-protocol/sdk-react-native": "^4.0.5",
+    "@didit-protocol/sdk-react-native": "4.0.5",
     "@ethersproject/shims": "^5.8.0",
     "@invertase/react-native-apple-authentication": "^2.5.1",
     "@noble/hashes": "^1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3792,7 +3792,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@didit-protocol/sdk-react-native@npm:^4.0.5":
+"@didit-protocol/sdk-react-native@npm:4.0.5":
   version: 4.0.5
   resolution: "@didit-protocol/sdk-react-native@npm:4.0.5"
   peerDependencies:
@@ -11494,7 +11494,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.29.2"
     "@babel/preset-react": "npm:^7.28.5"
     "@babel/runtime": "npm:^7.29.2"
-    "@didit-protocol/sdk-react-native": "npm:^4.0.5"
+    "@didit-protocol/sdk-react-native": "npm:4.0.5"
     "@ethersproject/shims": "npm:^5.8.0"
     "@invertase/react-native-apple-authentication": "npm:^2.5.1"
     "@noble/hashes": "npm:^1.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3792,9 +3792,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@didit-protocol/sdk-react-native@npm:^3.3.2":
-  version: 3.3.2
-  resolution: "@didit-protocol/sdk-react-native@npm:3.3.2"
+"@didit-protocol/sdk-react-native@npm:^4.0.5":
+  version: 4.0.5
+  resolution: "@didit-protocol/sdk-react-native@npm:4.0.5"
   peerDependencies:
     "@expo/config-plugins": ">=7.0.0"
     react: "*"
@@ -3802,7 +3802,7 @@ __metadata:
   peerDependenciesMeta:
     "@expo/config-plugins":
       optional: true
-  checksum: 10c0/73d100e5fad2137a36c301f5d06e02b46e2637c74ad5fd747c8c023e006df9d69644054d2602cbe670ce7bd38f08834857f1368cc79a6065c74b95d827af59e5
+  checksum: 10c0/3808d13ae4e3193d3713f08c73610a915af165d1118431ae68e86a22d2456a738514146c493a06ffc1a7c3c98b92ca056a1ed9e517aa8e012dd4f674b9ad07bd
   languageName: node
   linkType: hard
 
@@ -11494,7 +11494,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.29.2"
     "@babel/preset-react": "npm:^7.28.5"
     "@babel/runtime": "npm:^7.29.2"
-    "@didit-protocol/sdk-react-native": "npm:^3.3.2"
+    "@didit-protocol/sdk-react-native": "npm:^4.0.5"
     "@ethersproject/shims": "npm:^5.8.0"
     "@invertase/react-native-apple-authentication": "npm:^2.5.1"
     "@noble/hashes": "npm:^1.5.0"


### PR DESCRIPTION
## Summary

- Follow-up to #2168, which merged the Didit 4.0.5 upgrade pinned to the `core` variant — in 4.x, `core` is **manual-capture-only**, regressing the KYC document/face capture UX. 3.x "core" (what we shipped before the upgrade) bundled MediaPipe auto-capture; 4.x split that into a separate `autodetection` variant.
- Switch both platforms to the `autodetection` variant. Verified upstream it vendors **no CoreNFC and no OpenSSL.xcframework** (iOS) and no NFC artifact (Android), so the original reason for avoiding the full variant — the OpenSSL conflict with SelfNFCPassportReader's OpenSSL-Universal — stays resolved. Self continues to ship its own passport NFC reader.
- Exact-pin `@didit-protocol/sdk-react-native` to `4.0.5` (no caret): the RN wrapper requires the native DiditSDK at an exact version and the Podfile references the upstream podspec by tag, so the JS and native layers must move in lockstep.

## Changes

### Config/infra

- `app/ios/Podfile` — `DIDIT_SDK_IOS_VARIANT=core` → `autodetection`; pod subspec `DiditSDK/Core` → `DiditSDK/AutoDetection` (same 4.0.5 podspec tag).
- `app/android/gradle.properties` — `diditSdkAndroidVariant=core` → `autodetection`; resolves `me.didit:didit-sdk-autodetection:4.0.5` (wraps `didit-sdk-core:4.0.5` + MediaPipe `tasks-vision`).
- `app/package.json` — `^4.0.5` → `4.0.5` exact (+ `yarn.lock`).
- `app/ios/Podfile.lock` — regenerated; resolves `DiditSDK/AutoDetection (= 4.0.5)`.

## Test Plan

- [x] `yarn types` passes (app)
- [x] KYC service tests pass (`app/tests/src/integrations/kyc`, 6/6)
- [x] `pod install` clean; Podfile.lock resolves `DiditSDK/AutoDetection (= 4.0.5)` — no NFC/OpenSSL subspec pulled in
- [x] Android wrapper module compiles; runtime classpath resolves `didit-sdk-autodetection:4.0.5`
- [x] Full iOS simulator build passes locally (`xcodebuild` Debug, iphonesimulator) against the AutoDetection xcframework
- [ ] On-device KYC smoke test: confirm document capture **auto-triggers** (the behavior this PR restores vs. `core`'s manual-only capture)

### Native Consolidation Checklist

- [ ] CONTRACTS.md reviewed - no unintended contract changes
- [ ] Layer 1 bridge contract tests pass (`cd app && yarn jest:run` / `yarn workspace @selfxyz/rn-sdk-test-app test`)
- [ ] Layer 3 builds pass (app iOS, RN test app iOS, RN test app Android)
- [ ] Layer 4 manual smoke test signed off (if consolidation PR)
- [ ] No new native business logic added (logic belongs in TypeScript)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
