### PR TITLE
fix demo app SVG transformer entrypoint for iOS E2E builds

### DIFF
--- a/packages/mobile-sdk-demo/metro.config.cjs
+++ b/packages/mobile-sdk-demo/metro.config.cjs
@@ -28,7 +28,7 @@ const config = {
   ],
 
   transformer: {
-    babelTransformerPath: require.resolve('react-native-svg-transformer'),
+    babelTransformerPath: require.resolve('react-native-svg-transformer/react-native'),
     getTransformOptions: async () => ({
       transform: {
         experimentalImportSupport: false,


### PR DESCRIPTION
## Summary

- Point the mobile SDK demo app's Metro `babelTransformerPath` at `react-native-svg-transformer/react-native` instead of the package root, so SVG imports resolve through the React Native–specific transformer entrypoint and the demo app bundles correctly for the iOS E2E build.

## Changes

### Config/infra

- `packages/mobile-sdk-demo/metro.config.cjs`: use the `react-native-svg-transformer/react-native` entrypoint for `babelTransformerPath`.

## Test Plan

- [ ] iOS E2E build of the mobile SDK demo app bundles without SVG transformer resolution errors
- [ ] SVG assets render correctly in the demo app

🤖 Generated with [Claude Code](https://claude.com/claude-code)