### PR TITLE
fix demo app Metro React resolution under pnpm hoisted layout

### DIFF
--- a/packages/mobile-sdk-demo/metro.config.cjs
+++ b/packages/mobile-sdk-demo/metro.config.cjs
@@ -4,6 +4,7 @@
 
 const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
 const path = require('node:path');
+const fs = require('node:fs');
 const findYarnWorkspaceRoot = require('find-yarn-workspace-root');
 
 const defaultConfig = getDefaultConfig(__dirname);
@@ -11,6 +12,21 @@ const { assetExts, sourceExts } = defaultConfig.resolver;
 
 const projectRoot = __dirname;
 const workspaceRoot = findYarnWorkspaceRoot(__dirname) || path.resolve(__dirname, '../..');
+const escapeRegExp = value => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+// Block workspace-root React/RN copies only when this app's node_modules has its
+// own. That matters in the yarn-style layout where both can co-exist. Under
+// pnpm's hoisted layout (CI), React lives at the workspace root as the single
+// canonical copy, so blocking it unconditionally leaves nothing to resolve.
+const reactDupePackages = ['react', 'react-dom', 'react-native', 'scheduler'];
+const hasAppLocalReactCopies = reactDupePackages
+  .map(name => path.resolve(projectRoot, 'node_modules', name))
+  .every(modulePath => fs.existsSync(modulePath));
+const workspaceReactBlockList = hasAppLocalReactCopies
+  ? reactDupePackages.map(
+      name => new RegExp(`^${escapeRegExp(workspaceRoot)}/node_modules/${name}(/|$)`),
+    )
+  : [];
 
 /**
  * Modern Metro configuration for demo app using native workspace capabilities
@@ -45,11 +61,9 @@ const config = {
       /.*\/dist\/esm\/package\.json$/,
       /.*\/dist\/cjs\/package\.json$/,
       /.*\/build\/package\.json$/,
-      // Prevent duplicate React/React Native - block workspace root versions and use app's versions
-      new RegExp(`^${workspaceRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/node_modules/react(/|$)`),
-      new RegExp(`^${workspaceRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/node_modules/react-dom(/|$)`),
-      new RegExp(`^${workspaceRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/node_modules/react-native(/|$)`),
-      new RegExp(`^${workspaceRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/node_modules/scheduler(/|$)`),
+      // Prevent duplicate React/React Native - block workspace root versions only
+      // when this app carries its own copies (see workspaceReactBlockList above).
+      ...workspaceReactBlockList,
       new RegExp('packages/mobile-sdk-alpha/node_modules/react(/|$)'),
       new RegExp('packages/mobile-sdk-alpha/node_modules/react-dom(/|$)'),
       new RegExp('packages/mobile-sdk-alpha/node_modules/react-native(/|$)'),

--- a/packages/mobile-sdk-demo/metro.config.cjs
+++ b/packages/mobile-sdk-demo/metro.config.cjs
@@ -14,19 +14,16 @@ const projectRoot = __dirname;
 const workspaceRoot = findYarnWorkspaceRoot(__dirname) || path.resolve(__dirname, '../..');
 const escapeRegExp = value => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-// Block workspace-root React/RN copies only when this app's node_modules has its
-// own. That matters in the yarn-style layout where both can co-exist. Under
-// pnpm's hoisted layout (CI), React lives at the workspace root as the single
-// canonical copy, so blocking it unconditionally leaves nothing to resolve.
+// Block a workspace-root React/RN copy only when this app's node_modules carries
+// its own copy of that same package. That matters in the yarn-style layout where
+// both can co-exist. Under pnpm's hoisted layout (CI), React lives at the
+// workspace root as the single canonical copy, so blocking it leaves nothing to
+// resolve. Decided per-package: a partial-local install (e.g. local react/RN but
+// hoisted scheduler) still blocks the duplicates it actually has.
 const reactDupePackages = ['react', 'react-dom', 'react-native', 'scheduler'];
-const hasAppLocalReactCopies = reactDupePackages
-  .map(name => path.resolve(projectRoot, 'node_modules', name))
-  .every(modulePath => fs.existsSync(modulePath));
-const workspaceReactBlockList = hasAppLocalReactCopies
-  ? reactDupePackages.map(
-      name => new RegExp(`^${escapeRegExp(workspaceRoot)}/node_modules/${name}(/|$)`),
-    )
-  : [];
+const workspaceReactBlockList = reactDupePackages
+  .filter(name => fs.existsSync(path.resolve(projectRoot, 'node_modules', name)))
+  .map(name => new RegExp(`^${escapeRegExp(workspaceRoot)}/node_modules/${name}(/|$)`));
 
 /**
  * Modern Metro configuration for demo app using native workspace capabilities


### PR DESCRIPTION
## Summary

- The demo app's iOS E2E build failed in CI with `UnableToResolveError: Unable to resolve module react from packages/mobile-sdk-demo/index.js`. The Metro config unconditionally blocklisted the workspace-root `react`/`react-dom`/`react-native`/`scheduler` copies — a holdover from the Yarn layout where each package had its own local copies.
- Under pnpm's `hoisted` layout (what CI installs), React lives only at the workspace root as the single canonical copy, so blocking it left nothing to resolve. It only "worked" locally because of stale Yarn-era `node_modules` leftovers in the demo package.
- Mirrors the fix already shipped in the main app (`app/metro.config.cjs`): block the workspace-root React copies **only when this package carries its own local copies**, otherwise let Metro resolve from the hoisted root.

## Changes

### Config/infra

- `packages/mobile-sdk-demo/metro.config.cjs`: gate the workspace-root React/RN blockList entries behind a `hasAppLocalReactCopies` check (extracted as `workspaceReactBlockList`), so the hoisted root copy stays resolvable in clean installs. Adds an `escapeRegExp` helper and `node:fs` import.

## Test Plan

- [ ] iOS E2E build of the mobile SDK demo app bundles without the `Unable to resolve module react` error
- [ ] `node -e "require('./packages/mobile-sdk-demo/metro.config.cjs')"` loads without error
- [ ] App and demo continue to bundle locally (local layout still blocks root, uses local copies — unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build configuration now conditionally prevents duplicate React-related packages from being resolved from the workspace root only when the app has local React packages present. This replaces the prior always-on blocking behavior, reducing unnecessary package exclusions and improving local development and dependency resolution in multi-package workspaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->