### PR TITLE
fix moible deploy

### DIFF
--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -637,7 +637,7 @@ jobs:
         run: |
           echo "🏗️ Building SDK dependencies..."
           cd ${{ env.APP_PATH }}
-          pnpm --filter @selfxyz/mobile-app run build:deps --silent || { echo "❌ Dependency build failed"; exit 1; }
+          pnpm --filter @selfxyz/mobile-app run build:deps || { echo "❌ Dependency build failed"; exit 1; }
           echo "✅ Dependencies built successfully"
 
       # act won't work with macos, but you can test with `bundle exec fastlane ios ...`
@@ -1107,7 +1107,7 @@ jobs:
         run: |
           echo "🏗️ Building SDK dependencies..."
           cd ${{ env.APP_PATH }}
-          pnpm --filter @selfxyz/mobile-app run build:deps --silent || { echo "❌ Dependency build failed"; exit 1; }
+          pnpm --filter @selfxyz/mobile-app run build:deps || { echo "❌ Dependency build failed"; exit 1; }
           echo "✅ Dependencies built successfully"
 
       # rn-sdk's Android module declares compileOnly xyz.self.sdk:shared-android,


### PR DESCRIPTION
## Summary

<!-- Brief description of changes -->

## Test plan

<!-- How was this tested? -->

---

### Native code checklist

<!-- Only if this PR touches Kotlin/Swift or the React Native module bridge. Delete this section otherwise. -->

Run each command and check the box only after it passes. Paste failures into the Test plan.

- [ ] `yarn lint && yarn types` pass
- [ ] Bridge contract tests pass: `cd app && yarn jest:run` and `yarn workspace @selfxyz/rn-sdk-test-app test`
- [ ] If `packages/mobile-sdk-alpha` touched: `cd packages/mobile-sdk-alpha && yarn test && yarn types` pass
- [ ] Diff of `.kt`/`.swift` reviewed — no business logic added (only hardware/OS access; logic lives in TypeScript)
- [ ] NativeModules bridge contract (method names, payload keys, error codes) unchanged, or the change is intentional and described in the summary

**Cannot be verified by an agent — flag for human QA:**

- [ ] Native builds (app + RN test app, iOS + Android) — relying on CI, or needs a human local build
- [ ] On-device smoke test of the affected flow (e.g. NFC passport read, MRZ camera scan) — **needs human**, or N/A if no runtime behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

No user-facing changes in this release. This update addresses internal build workflow configuration to enhance build process visibility during development and deployment cycles.

* **Chores**
  * Updated mobile app deployment workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->