### PR TITLE
bump: version 2.9.25

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -160,7 +160,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 161
-        versionName "2.9.24"
+        versionName "2.9.25"
         manifestPlaceholders = [appAuthRedirectScheme: 'com.proofofpassportapp']
         externalNativeBuild {
             cmake {

--- a/app/app.json
+++ b/app/app.json
@@ -4,7 +4,7 @@
   "expo": {
     "name": "Self App",
     "slug": "self-app",
-    "version": "2.9.24",
+    "version": "2.9.25",
     "platforms": ["ios", "android"],
     "ios": {
       "bundleIdentifier": "com.proofofpassportapp"

--- a/app/ios/Self.xcodeproj/project.pbxproj
+++ b/app/ios/Self.xcodeproj/project.pbxproj
@@ -619,7 +619,7 @@
 					"$(PROJECT_DIR)",
 					"$(PROJECT_DIR)/MoproKit/Libs",
 				);
-				MARKETING_VERSION = 2.9.24;
+				MARKETING_VERSION = 2.9.25;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -764,7 +764,7 @@
 					"$(PROJECT_DIR)",
 					"$(PROJECT_DIR)/MoproKit/Libs",
 				);
-				MARKETING_VERSION = 2.9.24;
+				MARKETING_VERSION = 2.9.25;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/app/ios/Self/Info.plist
+++ b/app/ios/Self/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.9.24</string>
+	<string>2.9.25</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@selfxyz/mobile-app",
-  "version": "2.9.24",
+  "version": "2.9.25",
   "private": true,
   "type": "module",
   "main": "index.js",

--- a/app/tests/src/config/sentry.test.ts
+++ b/app/tests/src/config/sentry.test.ts
@@ -136,7 +136,7 @@ describe('redactSensitiveFields (ANA-13)', () => {
       contexts: {
         os: { name: 'iOS', version: '17.4' },
         device: { name: 'iPhone 15', model: 'iPhone16,1' },
-        app: { app_name: 'Self', app_version: '2.9.24' },
+        app: { app_name: 'Self', app_version: '2.9.25' },
       },
     });
     const ctx = event.contexts as Record<string, Record<string, unknown>>;


### PR DESCRIPTION
## Summary

<!-- Brief description of changes -->

## Test plan

<!-- How was this tested? -->

---

### Native code checklist

<!-- Only if this PR touches Kotlin/Swift or the React Native module bridge. Delete this section otherwise. -->

Run each command and check the box only after it passes. Paste failures into the Test plan.

- [ ] `pnpm lint && pnpm types` pass
- [ ] Bridge contract tests pass: `cd app && pnpm jest:run` and `pnpm --filter @selfxyz/rn-sdk-test-app test`
- [ ] If `packages/mobile-sdk-alpha` touched: `pnpm --filter @selfxyz/mobile-sdk-alpha test && pnpm --filter @selfxyz/mobile-sdk-alpha types` pass
- [ ] Diff of `.kt`/`.swift` reviewed - no business logic added (only hardware/OS access; logic lives in TypeScript)
- [ ] NativeModules bridge contract (method names, payload keys, error codes) unchanged, or the change is intentional and described in the summary

**Cannot be verified by an agent - flag for human QA:**

- [ ] Native builds (app + RN test app, iOS + Android) - relying on CI, or needs a human local build
- [ ] On-device smoke test of the affected flow (e.g. NFC passport read, MRZ camera scan) - **needs human**, or N/A if no runtime behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Incremented application version to 2.9.25 across all platforms (Android, iOS, and app configuration).

* **Tests**
  * Updated version assertions to reflect the new release number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->