### PR TITLE
fix: avoid shadowing global window in useMultiTap

### DIFF
--- a/app/src/hooks/useMultiTap.ts
+++ b/app/src/hooks/useMultiTap.ts
@@ -42,10 +42,10 @@ export function useMultiTap({
   });
 
   return useCallback(() => {
-    const { thresholds: active, windowMs: window } = configRef.current;
+    const { thresholds: active, windowMs: tapWindowMs } = configRef.current;
     const now = Date.now();
     const s = state.current;
-    s.count = now - s.lastTapAt > window ? 1 : s.count + 1;
+    s.count = now - s.lastTapAt > tapWindowMs ? 1 : s.count + 1;
     s.lastTapAt = now;
 
     const maxTaps = Math.max(...active.map(t => t.taps));


### PR DESCRIPTION
## Summary

- Renames the `windowMs` destructure binding in `useMultiTap` from `window` to `tapWindowMs` so it no longer shadows the global `window`. Addresses a Greptile P2 review nit on #2181 (release-to-staging).
- Behavior is unchanged — purely a readability/static-analysis fix. The hook still uses a plain JS tap counter (no native gesture path), which is the change that resolved the Reanimated `_performOperations == nil` crash.

## Changes

### React Native app

- `app/src/hooks/useMultiTap.ts`: rename local `window` → `tapWindowMs` in the tap handler.

## Test Plan

- [x] `pnpm exec jest tests/src/hooks/useMultiTap.test.ts` passes (6/6)
- [ ] `pnpm lint && pnpm types`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal tap-detection logic to improve code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->