### PR TITLE
add Turborepo orchestration for root build/test/lint/types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,9 @@ packages/self-sdk-swift/Sources/SelfSdkSwift/Resources/self-sdk-web/
 app/build/*
 packages/mobile-sdk-alpha-source/android/.gradle/*
 
+# Turborepo
+.turbo/
+
 # Python
 __pycache__/
 *.py[cod]

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "audit:tech-debt": "node scripts/audit/tech-debt-baseline.mjs",
-    "build": "pnpm -r --if-present --filter \"!@selfxyz/contracts\" --filter \"!@selfxyz/circuits\" --filter \"!mobile-sdk-demo\" --filter \"!@selfxyz/kmp-sdk\" --filter \"!@selfxyz/kmp-sdk-test-app\" run build",
+    "build": "node scripts/turbo-tasks.cjs build",
     "build:demo": "pnpm --filter mobile-sdk-demo build",
     "build:mobile-sdk": "pnpm --filter @selfxyz/mobile-sdk-alpha build",
     "build:sdk-android": "./scripts/build-webview-bundle.sh && cd packages/native-shell-android && ./gradlew assembleRelease",
@@ -39,7 +39,7 @@
     "kmp:lint": "pnpm --filter @selfxyz/kmp-sdk-test-app lint",
     "kmp:start": "bash scripts/kmp-start.sh",
     "kmp:test": "pnpm --filter @selfxyz/kmp-sdk test",
-    "lint": "pnpm lint:pnpm-version && pnpm lint:ci-sentinel && pnpm lint:headers && pnpm -r --if-present --filter \"!self-workspace-root\" run lint",
+    "lint": "pnpm lint:pnpm-version && pnpm lint:ci-sentinel && pnpm lint:headers && node scripts/turbo-tasks.cjs lint",
     "lint:ci-sentinel": "python3 scripts/ci/add-force-run-sentinel.py --check",
     "lint:headers": "node scripts/check-duplicate-headers.cjs . && node scripts/check-license-headers.mjs . --check",
     "lint:headers:fix": "node scripts/check-duplicate-headers.cjs . && node scripts/check-license-headers.mjs . --fix",
@@ -51,9 +51,9 @@
     "prepare": "husky",
     "reinstall-app": "pnpm install && (cd app && pnpm clean:watchman && pnpm clean:build && pnpm clean:ios && pnpm clean:xcode && pnpm clean:pod-cache && pnpm clean:android-deps && pnpm clean:ruby && pnpm clean:node) && pnpm install && pnpm --filter @selfxyz/mobile-app run install-app",
     "sort-package-jsons": "find . -name 'package.json' -not -path './node_modules/*' -not -path './*/node_modules/*' | xargs pnpm dlx sort-package-json",
-    "test": "pnpm -r --if-present run test",
+    "test": "node scripts/turbo-tasks.cjs test",
     "test:license-headers": "cd scripts/tests && node check-license-headers.test.mjs",
-    "types": "pnpm -r --if-present --filter \"!@selfxyz/contracts\" --filter \"!@selfxyz/common\" --filter \"!@selfxyz/mobile-app\" run types"
+    "types": "node scripts/turbo-tasks.cjs types"
   },
   "dependencies": {
     "@babel/runtime": "^7.29.7",
@@ -69,6 +69,7 @@
     "knip": "^6.14.2",
     "prettier": "^3.8.3",
     "tsx": "^4.22.3",
+    "turbo": "^2.5.0",
     "typescript": "^5.9.3"
   },
   "packageManager": "pnpm@11.7.0+sha512.19cc852c120c7125760f2443ee6be0ca5b40f9f50598de1a09a1f177503e010e57c23c77646e01e761de59bf874fb22a3398c33ab9691fc13eb946b6f0f4d620",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       tsx:
         specifier: ^4.22.3
         version: 4.22.3
+      turbo:
+        specifier: ^2.5.0
+        version: 2.9.18
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -8306,6 +8309,36 @@ packages:
     resolution: {integrity: sha512-Y8cK9aggNRsqJVaKUlEYs4s7CvQ1b1ta2DVPyAimb0I2qhzjNk+A+mxvll/klL0RlfuIUei8BF7YWiua4kQqww==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  '@turbo/darwin-64@2.9.18':
+    resolution: {integrity: sha512-9f27peFu16ur8c0v9nUFUEyBnbKuuFsUTjHFWfmwGfzySBXbHwzU44QhZon6Mznz0cHsIr3984NQj/bVrnGSRw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@turbo/darwin-arm64@2.9.18':
+    resolution: {integrity: sha512-9A6TMRq/Ib+QnbhLlgkhOm+624wO4pzSQ/yQviQfWHOlFvaYxdnIAYmu2H6TS6y7kSVL0DvzNe04NbESTOzFVQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@turbo/linux-64@2.9.18':
+    resolution: {integrity: sha512-zCdIDtz69AnbYh913elJRRoF3QY5aa2HNnf+4rAkc7bQ+tWujiDkCNV7stazOUPggaDvhKIf2Z87qHftTeXSkw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@turbo/linux-arm64@2.9.18':
+    resolution: {integrity: sha512-Va1kXI04naMgYwqv/5Dfa36dTDx8015U7oaQAjrXa45ua9OoFjSV4OmvkML4EmXvUclQHCiBRbY8bvd0jV7eAg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@turbo/windows-64@2.9.18':
+    resolution: {integrity: sha512-m0kDhZANxSNz9ck1ybogFscHabriAsp4eDFNrN/1H5WrgTF7b3VlcPZnhuO3v2+E2KnCbeAc+UUT10BZZHdDKw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@turbo/windows-arm64@2.9.18':
+    resolution: {integrity: sha512-nUdR8WqoomUys9iIQmG45TMiizJ+5BV8egSeLLZba/AWblyp3fVBcIH1kSE58OtK4g2YzbMJEth6Ttv9w5rqMA==}
+    cpu: [arm64]
+    os: [win32]
+
   '@turnkey/api-key-stamper@0.5.0':
     resolution: {integrity: sha512-DcxavFpNO93mJnCSef+g97uuQANYHjxxqK8z+cX7GztSBN+Skfja5656VDZCUITql4gNhhiNyjMiWLutS2DDJg==}
     engines: {node: '>=18.0.0'}
@@ -16226,6 +16259,10 @@ packages:
   tuf-js@4.1.0:
     resolution: {integrity: sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  turbo@2.9.18:
+    resolution: {integrity: sha512-bwabv6PupzeavybzEoArBAkwq5fnzwf8OFnRtpHwnviFWuwJPFxtyH+aVp36TmIqK3aYYgtTJ3J0m2ysxxSzQg==}
+    hasBin: true
 
   typanion@3.14.0:
     resolution: {integrity: sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug==}
@@ -25616,6 +25653,24 @@ snapshots:
     dependencies:
       '@tufjs/canonical-json': 2.0.0
       minimatch: 10.2.5
+
+  '@turbo/darwin-64@2.9.18':
+    optional: true
+
+  '@turbo/darwin-arm64@2.9.18':
+    optional: true
+
+  '@turbo/linux-64@2.9.18':
+    optional: true
+
+  '@turbo/linux-arm64@2.9.18':
+    optional: true
+
+  '@turbo/windows-64@2.9.18':
+    optional: true
+
+  '@turbo/windows-arm64@2.9.18':
+    optional: true
 
   '@turnkey/api-key-stamper@0.5.0':
     dependencies:
@@ -35932,6 +35987,15 @@ snapshots:
       make-fetch-happen: 15.0.5
     transitivePeerDependencies:
       - supports-color
+
+  turbo@2.9.18:
+    optionalDependencies:
+      '@turbo/darwin-64': 2.9.18
+      '@turbo/darwin-arm64': 2.9.18
+      '@turbo/linux-64': 2.9.18
+      '@turbo/linux-arm64': 2.9.18
+      '@turbo/windows-64': 2.9.18
+      '@turbo/windows-arm64': 2.9.18
 
   typanion@3.14.0: {}
 

--- a/scripts/turbo-tasks.cjs
+++ b/scripts/turbo-tasks.cjs
@@ -37,6 +37,8 @@ const extraArgs = process.argv.slice(3);
 // script (which injects node_modules/.bin) or directly as `node scripts/...`.
 const result = spawnSync('pnpm', ['exec', 'turbo', 'run', task, ...filters, ...extraArgs], {
   stdio: 'inherit',
+  // On Windows pnpm is a .cmd wrapper that spawnSync can't resolve without the shell.
+  shell: process.platform === 'win32',
 });
 
 if (result.error) {

--- a/scripts/turbo-tasks.cjs
+++ b/scripts/turbo-tasks.cjs
@@ -33,7 +33,9 @@ if (!task) {
 const filters = (EXCLUSIONS[task] ?? []).flatMap((pkg) => ['--filter', `!${pkg}`]);
 const extraArgs = process.argv.slice(3);
 
-const result = spawnSync('turbo', ['run', task, ...filters, ...extraArgs], {
+// Invoke via `pnpm exec` so turbo resolves whether this runs through a pnpm
+// script (which injects node_modules/.bin) or directly as `node scripts/...`.
+const result = spawnSync('pnpm', ['exec', 'turbo', 'run', task, ...filters, ...extraArgs], {
   stdio: 'inherit',
 });
 

--- a/scripts/turbo-tasks.cjs
+++ b/scripts/turbo-tasks.cjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+const { spawnSync } = require('node:child_process');
+
+// Centralizes per-task workspace exclusions for the Turbo-orchestrated root
+// scripts. Turbo has no "exclude package from a task" field in turbo.json —
+// package selection is CLI-only — so the exclusion lists live here instead of
+// inline in package.json, keeping the root scripts thin. Turbo still owns task
+// ordering, caching, inputs, and outputs; this only selects which workspaces run.
+//
+// - Gradle/native packages (kmp-*) are excluded from JS tasks and run via their
+//   dedicated kmp:* scripts.
+// - build/types exclusions mirror the pre-Turbo `pnpm -r --filter "!..."` scopes.
+const EXCLUSIONS = {
+  build: [
+    '@selfxyz/contracts',
+    '@selfxyz/circuits',
+    'mobile-sdk-demo',
+    '@selfxyz/kmp-sdk',
+    '@selfxyz/kmp-sdk-test-app',
+  ],
+  types: ['@selfxyz/contracts', '@selfxyz/common', '@selfxyz/mobile-app'],
+  test: ['@selfxyz/kmp-sdk', '@selfxyz/kmp-sdk-test-app'],
+  lint: ['@selfxyz/kmp-sdk', '@selfxyz/kmp-sdk-test-app'],
+};
+
+const task = process.argv[2];
+if (!task) {
+  console.error('usage: turbo-tasks.cjs <task> [extra turbo args]');
+  process.exit(1);
+}
+
+const filters = (EXCLUSIONS[task] ?? []).flatMap((pkg) => ['--filter', `!${pkg}`]);
+const extraArgs = process.argv.slice(3);
+
+const result = spawnSync('turbo', ['run', task, ...filters, ...extraArgs], {
+  stdio: 'inherit',
+});
+
+if (result.error) {
+  console.error(result.error);
+  process.exit(1);
+}
+process.exit(result.status ?? 1);

--- a/specs/projects/sdk/workstreams/monorepo-tooling/SPEC.md
+++ b/specs/projects/sdk/workstreams/monorepo-tooling/SPEC.md
@@ -73,7 +73,23 @@ ordering, inputs, and outputs.
 
 Every cacheable build task declares explicit `outputs`, and `globalDependencies`
 cover shared root config such as root `tsconfig*`, `pnpm-lock.yaml`, and env
-templates.
+templates. (As implemented in MT-3, the repo has no root `tsconfig*` or env
+template, so `globalDependencies` is `pnpm-lock.yaml`, `pnpm-workspace.yaml`,
+`.npmrc`.)
+
+**Implemented in MT-3/MT-4 — read before MT-5 (CI):**
+
+- Per-task exclusions live in `scripts/turbo-tasks.cjs` (Turbo has no per-task
+  package-exclude in `turbo.json`); root scripts call
+  `node scripts/turbo-tasks.cjs <task>`.
+- Gradle/native packages (`@selfxyz/kmp-sdk`, `@selfxyz/kmp-sdk-test-app`) are
+  excluded from every Turbo task (SPEC keeps gradle/swift out of Turbo). As a
+  result `pnpm test` and `pnpm lint` no longer cover the kmp packages — they are
+  covered by the dedicated `kmp:test`/`kmp:lint` (and `native-shell:*`) scripts.
+  **MT-5 must invoke kmp/native coverage explicitly**, not via bare `pnpm test`/
+  `pnpm lint`.
+- `pnpm format` stays on `scripts/format-monorepo.cjs` (bespoke gradle/swift +
+  env orchestration); it is not migrated to `turbo run format`.
 
 ### pnpm Hardening
 

--- a/specs/projects/sdk/workstreams/monorepo-tooling/plans/MT-3-turbo-foundation.md
+++ b/specs/projects/sdk/workstreams/monorepo-tooling/plans/MT-3-turbo-foundation.md
@@ -135,12 +135,13 @@ ls packages/webview-app/dist
 - 2026-06-17: Implemented alongside MT-4 (one PR). `turbo@^2.5.0` added to root
   devDependencies (resolves to 2.9.18). `turbo.json` defines build/types/test/
   lint/format with `dependsOn`/`inputs` (`$TURBO_DEFAULT$`)/`outputs`.
-  - **Outputs deviations from the plan's "`dist/**`" default** (MT-20 cache
-    correctness): `@selfxyz/rn-sdk#build` adds `assets/self-wallet/**` (it copies
-    the webview-app bundle there) and depends on `@selfxyz/webview-app#build`;
-    `@selfxyz/core#build` adds `src/typechain-types/**` (typechain codegen);
-    `@selfxyz/rn-sdk-test-app#build` is `tsc --noEmit` (build = `pnpm types`) so
-    `outputs: []` — without this turbo warns "no output files found".
+  - Output overrides (MT-20 cache correctness). The generic build task declares
+    `outputs: ["dist/**"]`; these packages emit elsewhere and override it:
+    - `@selfxyz/rn-sdk#build` adds `assets/self-wallet` outputs (it copies the
+      webview-app bundle there) and depends on `@selfxyz/webview-app#build`.
+    - `@selfxyz/core#build` adds `src/typechain-types` outputs (typechain codegen).
+    - `@selfxyz/rn-sdk-test-app#build` is `tsc --noEmit` (build = `pnpm types`),
+      so it declares no outputs — without this, turbo warns "no output files found".
   - `app#test` depends on `@selfxyz/mobile-sdk-alpha#build` (jest → dist/cjs);
     verified in the dry-run graph.
   - **globalDependencies deviation:** the plan listed "root `tsconfig*` and env

--- a/specs/projects/sdk/workstreams/monorepo-tooling/plans/MT-3-turbo-foundation.md
+++ b/specs/projects/sdk/workstreams/monorepo-tooling/plans/MT-3-turbo-foundation.md
@@ -5,9 +5,9 @@
 
 - Workstream: monorepo-tooling
 - Backlog IDs: MT-3
-- Owner: TBD
-- Branch: TBD
-- PR: TBD
+- Owner: Justin Hernandez
+- Branch: justin/mt-3-and-4
+- PR: TBD (shipped together with MT-4)
 
 ### Why
 
@@ -132,3 +132,30 @@ ls packages/webview-app/dist
 ### Status Log
 
 - 2026-05-13: Plan created.
+- 2026-06-17: Implemented alongside MT-4 (one PR). `turbo@^2.5.0` added to root
+  devDependencies (resolves to 2.9.18). `turbo.json` defines build/types/test/
+  lint/format with `dependsOn`/`inputs` (`$TURBO_DEFAULT$`)/`outputs`.
+  - **Outputs deviations from the plan's "`dist/**`" default** (MT-20 cache
+    correctness): `@selfxyz/rn-sdk#build` adds `assets/self-wallet/**` (it copies
+    the webview-app bundle there) and depends on `@selfxyz/webview-app#build`;
+    `@selfxyz/core#build` adds `src/typechain-types/**` (typechain codegen);
+    `@selfxyz/rn-sdk-test-app#build` is `tsc --noEmit` (build = `pnpm types`) so
+    `outputs: []` — without this turbo warns "no output files found".
+  - `app#test` depends on `@selfxyz/mobile-sdk-alpha#build` (jest → dist/cjs);
+    verified in the dry-run graph.
+  - **globalDependencies deviation:** the plan listed "root `tsconfig*` and env
+    templates" but the repo has neither at root (tsconfigs are per-package; only
+    `contracts/.env.example` exists, package-local). Used `pnpm-lock.yaml`,
+    `pnpm-workspace.yaml`, `.npmrc` — the actual repo-wide invalidation inputs.
+  - **Lockfile hygiene note:** a plain `pnpm install` to add turbo re-resolves
+    peers and rewrites ~1.7k lines (threads `supports-color` through every
+    `@babel/core` peer key — versions unchanged, only peer-key identity). The
+    committed lockfile predates this normalization and only survives because
+    `--frozen-lockfile` skips re-resolution. To keep this PR's lockfile diff
+    turbo-only (64 lines), turbo's isolated entries were grafted onto the clean
+    committed lockfile; `pnpm install --frozen-lockfile` accepts the result. The
+    broader peer-renormalization is pre-existing drift and belongs to pnpm
+    hygiene (MT-13/MT-6), not here.
+  - Validation: cold `turbo run build` → warm "FULL TURBO" (11/11 cached);
+    `pnpm --filter @selfxyz/mobile-app test` 70 pass / 0 fail; `pnpm types` and
+    `pnpm lint` green via the new turbo-backed scripts.

--- a/specs/projects/sdk/workstreams/monorepo-tooling/plans/MT-4-root-script-migration.md
+++ b/specs/projects/sdk/workstreams/monorepo-tooling/plans/MT-4-root-script-migration.md
@@ -5,9 +5,9 @@
 
 - Workstream: monorepo-tooling
 - Backlog IDs: MT-4
-- Owner: TBD
-- Branch: TBD
-- PR: TBD
+- Owner: Justin Hernandez
+- Branch: justin/mt-3-and-4
+- PR: TBD (shipped together with MT-3)
 
 ### Why
 
@@ -103,3 +103,31 @@ Additionally:
 ### Status Log
 
 - 2026-05-13: Plan created.
+- 2026-06-17: Implemented alongside MT-3 (one PR). Root `build`/`types`/`test`/
+  `lint` now drive Turbo. Deviations from the plan's "bare `turbo run <task>`"
+  mapping, all to preserve pre-Turbo semantics:
+  - **Exclusions are required.** The pre-Turbo scripts carried `--filter "!..."`
+    scopes that must survive: `build` excludes contracts/circuits/mobile-sdk-demo/
+    kmp-sdk/kmp-sdk-test-app; `types` excludes contracts/common/mobile-app.
+    Turbo has no "exclude package from a task" field in `turbo.json` (selection
+    is CLI-only), so the lists live in a new `scripts/turbo-tasks.cjs` wrapper
+    (matches the "complex logic belongs in `scripts/*.cjs`" invariant and keeps
+    root scripts thin). Root scripts call `node scripts/turbo-tasks.cjs <task>`.
+  - **`lint` keeps its prefix steps:** `lint:pnpm-version && lint:ci-sentinel &&
+    lint:headers` run before the turbo fan-out, unchanged.
+  - **`format` is NOT migrated.** Unlike the plan's table, the root `format`
+    script was never a `pnpm -r` fan-out — it is `node scripts/format-monorepo.cjs`,
+    a bespoke orchestrator that sets `SKIP_BUILD_DEPS`/`GRADLE_USER_HOME` and
+    sequences gradle (kmp) + swift (native-shell) formatting. The invariant says
+    such logic stays in `scripts/*.cjs`, and SPEC out-of-scope forbids gradle/
+    swift through Turbo. Kept as-is. (`format` is still defined in `turbo.json`
+    per MT-3 for JS-only use, but `pnpm format` remains the canonical entrypoint.)
+  - **Behavior change to flag for MT-5/CI:** `pnpm test` and `pnpm lint` no longer
+    run the Gradle kmp packages (`@selfxyz/kmp-sdk`, `@selfxyz/kmp-sdk-test-app`)
+    — SPEC out-of-scope keeps gradle out of Turbo and those are JS-task no-ops/
+    heavy gradle. They remain covered by the dedicated `kmp:test`/`kmp:lint`
+    (and `native-shell:*`) scripts. The CI migration (MT-5) must invoke kmp
+    coverage explicitly rather than relying on bare `pnpm test`/`pnpm lint`.
+  - Validation: `pnpm build` (cold → warm FULL TURBO 11/11), `pnpm types`,
+    `pnpm lint` all green; RN gate `pnpm --filter @selfxyz/mobile-app test`
+    70 pass / 0 fail.

--- a/specs/projects/sdk/workstreams/monorepo-tooling/plans/MT-4-root-script-migration.md
+++ b/specs/projects/sdk/workstreams/monorepo-tooling/plans/MT-4-root-script-migration.md
@@ -113,8 +113,8 @@ Additionally:
     is CLI-only), so the lists live in a new `scripts/turbo-tasks.cjs` wrapper
     (matches the "complex logic belongs in `scripts/*.cjs`" invariant and keeps
     root scripts thin). Root scripts call `node scripts/turbo-tasks.cjs <task>`.
-  - **`lint` keeps its prefix steps:** `lint:pnpm-version && lint:ci-sentinel &&
-    lint:headers` run before the turbo fan-out, unchanged.
+  - `lint` keeps its prefix steps: `lint:pnpm-version`, `lint:ci-sentinel`, and
+    `lint:headers` run before the turbo fan-out, unchanged.
   - **`format` is NOT migrated.** Unlike the plan's table, the root `format`
     script was never a `pnpm -r` fan-out — it is `node scripts/format-monorepo.cjs`,
     a bespoke orchestrator that sets `SKIP_BUILD_DEPS`/`GRADLE_USER_HOME` and

--- a/turbo.json
+++ b/turbo.json
@@ -15,7 +15,8 @@
     "test": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$"],
-      "outputs": []
+      "outputs": [],
+      "env": ["FULL_TEST_SUITE"]
     },
     "lint": {
       "dependsOn": [],

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["pnpm-lock.yaml", "pnpm-workspace.yaml", ".npmrc"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$"],
+      "outputs": ["dist/**"]
+    },
+    "types": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$"],
+      "outputs": []
+    },
+    "test": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$"],
+      "outputs": []
+    },
+    "lint": {
+      "dependsOn": [],
+      "inputs": ["$TURBO_DEFAULT$"],
+      "outputs": []
+    },
+    "format": {
+      "cache": false
+    },
+    "@selfxyz/mobile-app#test": {
+      "dependsOn": ["^build", "@selfxyz/mobile-sdk-alpha#build"],
+      "inputs": ["$TURBO_DEFAULT$"],
+      "outputs": []
+    },
+    "@selfxyz/rn-sdk#build": {
+      "dependsOn": ["^build", "@selfxyz/webview-app#build"],
+      "inputs": ["$TURBO_DEFAULT$"],
+      "outputs": ["dist/**", "assets/self-wallet/**"]
+    },
+    "@selfxyz/rn-sdk-test-app#build": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$"],
+      "outputs": []
+    },
+    "@selfxyz/core#build": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$"],
+      "outputs": ["dist/**", "src/typechain-types/**"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Introduce **Turborepo** as local build-graph orchestration (MT-3) and rewire the root `build`/`test`/`lint`/`types` scripts to drive it (MT-4). Leaf workspace scripts are unchanged — Turbo only owns ordering, caching, inputs, and outputs.
- Per-task workspace exclusions (and the Gradle/native carve-out) live in a small `scripts/turbo-tasks.cjs` wrapper so root scripts stay thin; `format` stays on the existing bespoke `scripts/format-monorepo.cjs` orchestrator.
- The lockfile change is **turbo-only (64 lines)** — turbo's entries were grafted onto the committed lockfile to avoid an unrelated ~1.7k-line peer renormalization; `pnpm install --frozen-lockfile` validates the result.
- **CI wiring (MT-5) is intentionally deferred** — no `.github/workflows/` changes in this PR.

## Changes

### Build orchestration (Turborepo)

- Add `turbo` (`^2.5.0`) to root devDependencies and a new `turbo.json` defining `build`/`types`/`test`/`lint`/`format` with `dependsOn`/`inputs`/`outputs` and `globalDependencies` (`pnpm-lock.yaml`, `pnpm-workspace.yaml`, `.npmrc` — the repo has no root `tsconfig*`/env templates).
- Build tasks declare `outputs: ["dist/**"]`, with package overrides where output lands elsewhere (MT-20 cache correctness): `rn-sdk` adds `assets/self-wallet` + depends on `webview-app#build`; `core` adds `src/typechain-types`; `rn-sdk-test-app` is `tsc --noEmit` so it declares no outputs.
- `@selfxyz/mobile-app#test` depends on `@selfxyz/mobile-sdk-alpha#build` (jest resolves the built `dist/cjs`).
- `.turbo/` added to `.gitignore`.

### Root scripts (`package.json`)

- `build`/`types`/`test`/`lint` now call `node scripts/turbo-tasks.cjs <task>`; `lint` keeps its `lint:pnpm-version` → `lint:ci-sentinel` → `lint:headers` prefix.
- New `scripts/turbo-tasks.cjs` centralizes per-task exclusions — Turbo has no per-task package-exclude in `turbo.json` — preserving the pre-Turbo scopes (`build` excludes contracts/circuits/mobile-sdk-demo/kmp-\*; `types` excludes contracts/common/mobile-app). Invokes turbo via `pnpm exec` so it works from a pnpm script *and* a direct `node scripts/...` call.
- `format` unchanged (bespoke gradle/swift/env orchestration belongs in `scripts/*.cjs` per SPEC).

### ⚠️ Behavior change for MT-5/CI to account for

- `pnpm test` and `pnpm lint` no longer cover the Gradle kmp packages (`@selfxyz/kmp-sdk`, `@selfxyz/kmp-sdk-test-app`) — kept out of Turbo per the SPEC out-of-scope rule. They remain covered by the dedicated `kmp:test` / `kmp:lint` / `native-shell:*` scripts, which **CI (MT-5) must invoke explicitly** rather than relying on bare `pnpm test`/`pnpm lint`.

### Docs / specs

- MT-3 and MT-4 plan Status Logs updated with the implemented deviations; `SPEC.md` records the kmp/native carve-out and the `globalDependencies` reality.

## Test Plan

- [x] `pnpm install --frozen-lockfile` — lockfile delta is turbo-only (64 lines)
- [x] Cold `turbo run build` → warm **FULL TURBO** (11/11 cached)
- [x] RN gate: `pnpm --filter @selfxyz/mobile-app test` → 70 pass / 0 fail
- [x] `pnpm types` green (16/16) and `pnpm lint` green (11/11) via the new turbo-backed scripts
- [x] Dry-run graph: per-task exclusions correct; `app#test → mobile-sdk-alpha#build` edge present
- [x] `scripts/turbo-tasks.cjs` works via `pnpm run <task>` and direct `node scripts/turbo-tasks.cjs <task>`
- [ ] CI green on the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Upgraded monorepo build system to Turborepo for improved incremental build performance, intelligent caching, and faster development workflows.
  * Updated git configuration to exclude Turborepo cache and temporary files from version control.
  * Migrated root workspace build, lint, test, and type-checking scripts to Turborepo task orchestration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->