### PR TITLE
fix: pass native build env through Turbo and relink CI deps

### DIFF
--- a/.github/workflows/mobile-bundle-analysis.yml
+++ b/.github/workflows/mobile-bundle-analysis.yml
@@ -92,12 +92,18 @@ jobs:
         env:
           SELFXYZ_APP_TOKEN: ${{ steps.github-token.outputs.token }}
       - name: Check for duplicate dependency versions
-        # Run under NODE_ENV=development so the dedupe reconcile keeps hoisted
-        # devDeps (typescript, turbo, ...) linked. Under the workflow's global
-        # NODE_ENV=production, dedupe prunes them to node_modules/.ignored and a
-        # frozen-lockfile reinstall won't relink them, breaking later build steps.
         shell: bash
-        run: NODE_ENV=development pnpm dedupe --check
+        run: pnpm dedupe --check
+      - name: Relink dependencies
+        # `pnpm dedupe --check` reconciles node_modules and relocates hoisted
+        # packages it treats as foreign (typescript, turbo, ...) to
+        # node_modules/.ignored. A plain frozen reinstall reports "Already up to
+        # date" and leaves them stranded, so --force is required to rebuild the
+        # hoisted layout from the lockfile. NODE_ENV=development + --no-prod
+        # mirrors mobile-setup so the global NODE_ENV=production doesn't drop
+        # root devDeps.
+        shell: bash
+        run: NODE_ENV=development pnpm install --frozen-lockfile --no-prod --force
       - name: Build dependencies
         shell: bash
         run: pnpm --filter @selfxyz/common build
@@ -183,12 +189,18 @@ jobs:
         env:
           SELFXYZ_APP_TOKEN: ${{ steps.github-token.outputs.token }}
       - name: Check for duplicate dependency versions
-        # Run under NODE_ENV=development so the dedupe reconcile keeps hoisted
-        # devDeps (typescript, turbo, ...) linked. Under the workflow's global
-        # NODE_ENV=production, dedupe prunes them to node_modules/.ignored and a
-        # frozen-lockfile reinstall won't relink them, breaking later build steps.
         shell: bash
-        run: NODE_ENV=development pnpm dedupe --check
+        run: pnpm dedupe --check
+      - name: Relink dependencies
+        # `pnpm dedupe --check` reconciles node_modules and relocates hoisted
+        # packages it treats as foreign (typescript, turbo, ...) to
+        # node_modules/.ignored. A plain frozen reinstall reports "Already up to
+        # date" and leaves them stranded, so --force is required to rebuild the
+        # hoisted layout from the lockfile. NODE_ENV=development + --no-prod
+        # mirrors mobile-setup so the global NODE_ENV=production doesn't drop
+        # root devDeps.
+        shell: bash
+        run: NODE_ENV=development pnpm install --frozen-lockfile --no-prod --force
       - name: Build dependencies
         shell: bash
         run: pnpm --filter @selfxyz/common build

--- a/.github/workflows/mobile-bundle-analysis.yml
+++ b/.github/workflows/mobile-bundle-analysis.yml
@@ -91,19 +91,6 @@ jobs:
           workspace: ${{ env.WORKSPACE }}
         env:
           SELFXYZ_APP_TOKEN: ${{ steps.github-token.outputs.token }}
-      - name: Check for duplicate dependency versions
-        shell: bash
-        run: pnpm dedupe --check
-      - name: Relink dependencies
-        # `pnpm dedupe --check` reconciles node_modules and relocates hoisted
-        # packages it treats as foreign (typescript, turbo, ...) to
-        # node_modules/.ignored. A plain frozen reinstall reports "Already up to
-        # date" and leaves them stranded, so --force is required to rebuild the
-        # hoisted layout from the lockfile. NODE_ENV=development + --no-prod
-        # mirrors mobile-setup so the global NODE_ENV=production doesn't drop
-        # root devDeps.
-        shell: bash
-        run: NODE_ENV=development pnpm install --frozen-lockfile --no-prod --force
       - name: Build dependencies
         shell: bash
         run: pnpm --filter @selfxyz/common build
@@ -188,19 +175,6 @@ jobs:
           workspace: ${{ env.WORKSPACE }}
         env:
           SELFXYZ_APP_TOKEN: ${{ steps.github-token.outputs.token }}
-      - name: Check for duplicate dependency versions
-        shell: bash
-        run: pnpm dedupe --check
-      - name: Relink dependencies
-        # `pnpm dedupe --check` reconciles node_modules and relocates hoisted
-        # packages it treats as foreign (typescript, turbo, ...) to
-        # node_modules/.ignored. A plain frozen reinstall reports "Already up to
-        # date" and leaves them stranded, so --force is required to rebuild the
-        # hoisted layout from the lockfile. NODE_ENV=development + --no-prod
-        # mirrors mobile-setup so the global NODE_ENV=production doesn't drop
-        # root devDeps.
-        shell: bash
-        run: NODE_ENV=development pnpm install --frozen-lockfile --no-prod --force
       - name: Build dependencies
         shell: bash
         run: pnpm --filter @selfxyz/common build

--- a/.github/workflows/mobile-bundle-analysis.yml
+++ b/.github/workflows/mobile-bundle-analysis.yml
@@ -94,6 +94,13 @@ jobs:
       - name: Check for duplicate dependency versions
         shell: bash
         run: pnpm dedupe --check
+      - name: Relink dependencies
+        # `pnpm dedupe --check` heals node_modules and moves hoisted devDeps
+        # (typescript, turbo, ...) to .ignored; reinstall to relink them.
+        # NODE_ENV=development + --no-prod mirrors mobile-setup so the global
+        # NODE_ENV=production doesn't drop root devDeps again.
+        shell: bash
+        run: NODE_ENV=development pnpm install --frozen-lockfile --no-prod
       - name: Build dependencies
         shell: bash
         run: pnpm --filter @selfxyz/common build
@@ -181,6 +188,13 @@ jobs:
       - name: Check for duplicate dependency versions
         shell: bash
         run: pnpm dedupe --check
+      - name: Relink dependencies
+        # `pnpm dedupe --check` heals node_modules and moves hoisted devDeps
+        # (typescript, turbo, ...) to .ignored; reinstall to relink them.
+        # NODE_ENV=development + --no-prod mirrors mobile-setup so the global
+        # NODE_ENV=production doesn't drop root devDeps again.
+        shell: bash
+        run: NODE_ENV=development pnpm install --frozen-lockfile --no-prod
       - name: Build dependencies
         shell: bash
         run: pnpm --filter @selfxyz/common build

--- a/.github/workflows/mobile-bundle-analysis.yml
+++ b/.github/workflows/mobile-bundle-analysis.yml
@@ -92,15 +92,12 @@ jobs:
         env:
           SELFXYZ_APP_TOKEN: ${{ steps.github-token.outputs.token }}
       - name: Check for duplicate dependency versions
+        # Run under NODE_ENV=development so the dedupe reconcile keeps hoisted
+        # devDeps (typescript, turbo, ...) linked. Under the workflow's global
+        # NODE_ENV=production, dedupe prunes them to node_modules/.ignored and a
+        # frozen-lockfile reinstall won't relink them, breaking later build steps.
         shell: bash
-        run: pnpm dedupe --check
-      - name: Relink dependencies
-        # `pnpm dedupe --check` heals node_modules and moves hoisted devDeps
-        # (typescript, turbo, ...) to .ignored; reinstall to relink them.
-        # NODE_ENV=development + --no-prod mirrors mobile-setup so the global
-        # NODE_ENV=production doesn't drop root devDeps again.
-        shell: bash
-        run: NODE_ENV=development pnpm install --frozen-lockfile --no-prod
+        run: NODE_ENV=development pnpm dedupe --check
       - name: Build dependencies
         shell: bash
         run: pnpm --filter @selfxyz/common build
@@ -186,15 +183,12 @@ jobs:
         env:
           SELFXYZ_APP_TOKEN: ${{ steps.github-token.outputs.token }}
       - name: Check for duplicate dependency versions
+        # Run under NODE_ENV=development so the dedupe reconcile keeps hoisted
+        # devDeps (typescript, turbo, ...) linked. Under the workflow's global
+        # NODE_ENV=production, dedupe prunes them to node_modules/.ignored and a
+        # frozen-lockfile reinstall won't relink them, breaking later build steps.
         shell: bash
-        run: pnpm dedupe --check
-      - name: Relink dependencies
-        # `pnpm dedupe --check` heals node_modules and moves hoisted devDeps
-        # (typescript, turbo, ...) to .ignored; reinstall to relink them.
-        # NODE_ENV=development + --no-prod mirrors mobile-setup so the global
-        # NODE_ENV=production doesn't drop root devDeps again.
-        shell: bash
-        run: NODE_ENV=development pnpm install --frozen-lockfile --no-prod
+        run: NODE_ENV=development pnpm dedupe --check
       - name: Build dependencies
         shell: bash
         run: pnpm --filter @selfxyz/common build

--- a/turbo.json
+++ b/turbo.json
@@ -1,22 +1,11 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": ["pnpm-lock.yaml", "pnpm-workspace.yaml", ".npmrc"],
-  "globalPassThroughEnv": [
-    "SELFXYZ_APP_TOKEN",
-    "SELFXYZ_INTERNAL_REPO_PAT",
-    "ANDROID_HOME",
-    "ANDROID_SDK_ROOT",
-    "JAVA_HOME",
-    "GRADLE_USER_HOME",
-    "GRADLE_OPTS",
-    "DEBUG_SETUP"
-  ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$"],
-      "outputs": ["dist/**"],
-      "env": ["CI", "DRY_RUN"]
+      "outputs": ["dist/**"]
     },
     "types": {
       "dependsOn": ["^build"],
@@ -41,6 +30,22 @@
       "dependsOn": ["^build", "@selfxyz/mobile-sdk-alpha#build"],
       "inputs": ["$TURBO_DEFAULT$"],
       "outputs": []
+    },
+    "@selfxyz/mobile-sdk-alpha#build": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$"],
+      "outputs": ["dist/**"],
+      "env": ["CI", "DRY_RUN"],
+      "passThroughEnv": [
+        "SELFXYZ_APP_TOKEN",
+        "SELFXYZ_INTERNAL_REPO_PAT",
+        "ANDROID_HOME",
+        "ANDROID_SDK_ROOT",
+        "JAVA_HOME",
+        "GRADLE_USER_HOME",
+        "GRADLE_OPTS",
+        "DEBUG_SETUP"
+      ]
     },
     "@selfxyz/rn-sdk#build": {
       "dependsOn": ["^build", "@selfxyz/webview-app#build"],

--- a/turbo.json
+++ b/turbo.json
@@ -1,11 +1,22 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": ["pnpm-lock.yaml", "pnpm-workspace.yaml", ".npmrc"],
+  "globalPassThroughEnv": [
+    "SELFXYZ_APP_TOKEN",
+    "SELFXYZ_INTERNAL_REPO_PAT",
+    "ANDROID_HOME",
+    "ANDROID_SDK_ROOT",
+    "JAVA_HOME",
+    "GRADLE_USER_HOME",
+    "GRADLE_OPTS",
+    "DEBUG_SETUP"
+  ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$"],
-      "outputs": ["dist/**"]
+      "outputs": ["dist/**"],
+      "env": ["CI", "DRY_RUN"]
     },
     "types": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary

- Pass native build environment through to Turborepo tasks so cached/orchestrated builds can see the Android SDK, Java, Gradle, and auth tokens they need.
- Declare cache-relevant env vars (`CI`, `DRY_RUN`) on the `build` task so Turbo invalidates correctly instead of serving stale outputs across CI/local environments.
- Heal node_modules in the mobile bundle-analysis workflow after `pnpm dedupe --check`, which moves hoisted devDeps (`typescript`, `turbo`, …) to `.ignored`.

## Changes

### Config/infra

- `turbo.json`: add `globalPassThroughEnv` for native toolchain and secrets — `SELFXYZ_APP_TOKEN`, `SELFXYZ_INTERNAL_REPO_PAT`, `ANDROID_HOME`, `ANDROID_SDK_ROOT`, `JAVA_HOME`, `GRADLE_USER_HOME`, `GRADLE_OPTS`, `DEBUG_SETUP`.
- `turbo.json`: add `env: ["CI", "DRY_RUN"]` to the `build` task so these inputs participate in cache keying.
- `.github/workflows/mobile-bundle-analysis.yml`: add a "Relink dependencies" step after `pnpm dedupe --check` in both jobs, running `NODE_ENV=development pnpm install --frozen-lockfile --no-prod` to relink devDeps the dedupe check moves to `.ignored` (mirrors `mobile-setup` so the global `NODE_ENV=production` doesn't drop root devDeps).

## Test Plan

- [ ] `pnpm lint && pnpm types` passes
- [ ] Mobile bundle-analysis workflow succeeds in CI (devDeps relinked; `turbo` resolves)
- [ ] Native build tasks orchestrated through Turbo see `ANDROID_HOME`/`JAVA_HOME`/`GRADLE_*` and produce correct artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the mobile bundle analysis workflow to add a “relink dependencies” step after the duplicate-dependency check, ensuring consistent dependency rebuilding for both Android and iOS.
  * Improved the mobile SDK build configuration to explicitly manage environment variables (including CI/testing flags) and forward additional configuration needed during the build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->