### PR TITLE
don't compile all architectures

### DIFF
--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -390,7 +390,7 @@ jobs:
           build_attempt() {
             (
               cd app/android &&
-              E2E_BUILD=true ./gradlew assembleDebug -PbundleInDebug=true --quiet --build-cache --no-configuration-cache
+              E2E_BUILD=true ./gradlew assembleDebug -PbundleInDebug=true -PreactNativeArchitectures=x86_64 --quiet --build-cache --no-configuration-cache
             )
           }
 

--- a/app/package.json
+++ b/app/package.json
@@ -9,7 +9,7 @@
     "analyze:bundle:ios": "pnpm build:deps && node ./scripts/bundle-analyze-ci.cjs ios",
     "analyze:tree-shaking": "node ./scripts/analyze-tree-shaking.cjs imports",
     "analyze:tree-shaking:web": "pnpm web:build && node ./scripts/analyze-tree-shaking.cjs web",
-    "android": "pnpm build:deps && pnpm setup:android-deps && react-native run-android",
+    "android": "pnpm build:deps && pnpm setup:android-deps && react-native run-android --active-arch-only",
     "android:ci": "./scripts/mobile-ci-build-android.sh",
     "build:deps": "pnpm -r --filter @selfxyz/mobile-app... run build",
     "bump-version:major": "npm version major && pnpm sync-versions",


### PR DESCRIPTION
## Summary

<!-- Brief description of changes -->

## Test plan

<!-- How was this tested? -->

---

### Native code checklist

<!-- Only if this PR touches Kotlin/Swift or the React Native module bridge. Delete this section otherwise. -->

Run each command and check the box only after it passes. Paste failures into the Test plan.

- [ ] `pnpm lint && pnpm types` pass
- [ ] Bridge contract tests pass: `cd app && pnpm jest:run` and `pnpm --filter @selfxyz/rn-sdk-test-app test`
- [ ] If `packages/mobile-sdk-alpha` touched: `pnpm --filter @selfxyz/mobile-sdk-alpha test && pnpm --filter @selfxyz/mobile-sdk-alpha types` pass
- [ ] Diff of `.kt`/`.swift` reviewed - no business logic added (only hardware/OS access; logic lives in TypeScript)
- [ ] NativeModules bridge contract (method names, payload keys, error codes) unchanged, or the change is intentional and described in the summary

**Cannot be verified by an agent - flag for human QA:**

- [ ] Native builds (app + RN test app, iOS + Android) - relying on CI, or needs a human local build
- [ ] On-device smoke test of the affected flow (e.g. NFC passport read, MRZ camera scan) - **needs human**, or N/A if no runtime behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Android bundle analysis workflow to run against the active architecture only, improving result consistency.
* **Chores**
  * Adjusted the Android E2E build to explicitly constrain the React Native architecture used during Gradle debug builds, ensuring more predictable test builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->