### PR TITLE
Self 3447 - Update OCR  

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -162,6 +162,9 @@ android {
         versionCode 163
         versionName "2.9.27"
         manifestPlaceholders = [appAuthRedirectScheme: 'com.proofofpassportapp']
+        // Tesseract OCR fallback when ML Kit yields no check-digit-valid MRZ
+        // (SELF-3447); flip to gate a future Tesseract-primary mode.
+        buildConfigField "boolean", "TESSERACT_MRZ_FALLBACK", "true"
         externalNativeBuild {
             cmake {
                 cppFlags += "-fexceptions -frtti -std=c++11"

--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -162,9 +162,11 @@ android {
         versionCode 163
         versionName "2.9.27"
         manifestPlaceholders = [appAuthRedirectScheme: 'com.proofofpassportapp']
-        // Tesseract OCR fallback when ML Kit yields no check-digit-valid MRZ
-        // (SELF-3447); flip to gate a future Tesseract-primary mode.
+        // Tesseract OCR fallback when ML Kit yields no check-digit-valid MRZ (SELF-3447).
         buildConfigField "boolean", "TESSERACT_MRZ_FALLBACK", "true"
+        // Route every frame through Tesseract; ML Kit runs only as the MRZ band locator.
+        // Test/rollout mode — keep false until field telemetry justifies the flip.
+        buildConfigField "boolean", "TESSERACT_MRZ_PRIMARY", "false"
         externalNativeBuild {
             cmake {
                 cppFlags += "-fexceptions -frtti -std=c++11"

--- a/app/android/app/src/main/java/com/proofofpassportapp/ui/PassportCameraView.kt
+++ b/app/android/app/src/main/java/com/proofofpassportapp/ui/PassportCameraView.kt
@@ -119,7 +119,7 @@ class PassportCameraView(context: Context) : FrameLayout(context) {
 
     MRZUtil.cleanStorage()
     frameProcessor = textProcessor
-    if (BuildConfig.TESSERACT_MRZ_FALLBACK && tesseractProcessor == null) {
+    if (isTesseractEnabled && tesseractProcessor == null) {
       val processor = TesseractMrzProcessor(context)
       tesseractProcessor = processor
       disposable.add(
@@ -238,6 +238,12 @@ class PassportCameraView(context: Context) : FrameLayout(context) {
             return
           }
           try {
+            if (BuildConfig.TESSERACT_MRZ_PRIMARY) {
+              if (!maybeStartTesseractFallback(results, bitmap, timeRequired)) {
+                mrzListener.onMRZReadFailure(timeRequired)
+              }
+              return
+            }
             val callback =
                 object : OcrUtils.MRZCallback by mrzListener {
                   override fun onMRZReadFailure(timeRequired: Long) {
@@ -327,7 +333,7 @@ class PassportCameraView(context: Context) : FrameLayout(context) {
    * is ever dispatched.
    */
   private fun maybeStartTesseractFallback(results: Text, bitmap: Bitmap?, timeRequired: Long): Boolean {
-    if (!BuildConfig.TESSERACT_MRZ_FALLBACK) return false
+    if (!isTesseractEnabled) return false
     val processor = tesseractProcessor ?: return false
     if (bitmap == null || passportDispatched.get()) return false
     if (!TesseractMrzProcessor.looksLikeMrz(results)) return false
@@ -458,6 +464,9 @@ class PassportCameraView(context: Context) : FrameLayout(context) {
   private companion object {
     // Bounds a stuck native recognition so the tesseractInFlight gate can't wedge the scan loop.
     const val TESSERACT_TIMEOUT_SECONDS = 3L
+
+    val isTesseractEnabled: Boolean
+      get() = BuildConfig.TESSERACT_MRZ_FALLBACK || BuildConfig.TESSERACT_MRZ_PRIMARY
   }
 
   private fun dispatchPassportRead(mrzInfo: org.jmrtd.lds.icao.MRZInfo) {

--- a/app/android/app/src/main/java/com/proofofpassportapp/ui/PassportCameraView.kt
+++ b/app/android/app/src/main/java/com/proofofpassportapp/ui/PassportCameraView.kt
@@ -20,12 +20,15 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.events.Event
+import com.google.mlkit.vision.text.Text
+import com.proofofpassportapp.BuildConfig
 import example.jllarraz.com.passportreader.R
 import example.jllarraz.com.passportreader.databinding.FragmentCameraMrzBinding
 import example.jllarraz.com.passportreader.mlkit.FrameMetadata
 import example.jllarraz.com.passportreader.mlkit.GraphicOverlay
 import example.jllarraz.com.passportreader.mlkit.OcrMrzDetectorProcessor
 import example.jllarraz.com.passportreader.mlkit.VisionProcessorBase
+import example.jllarraz.com.passportreader.tesseract.TesseractMrzProcessor
 import example.jllarraz.com.passportreader.utils.MRZUtil
 import example.jllarraz.com.passportreader.utils.OcrUtils
 import io.fotoapparat.Fotoapparat
@@ -38,10 +41,12 @@ import io.fotoapparat.selector.autoFocus
 import io.fotoapparat.selector.firstAvailable
 import io.fotoapparat.selector.off
 import io.fotoapparat.view.CameraView
+import io.reactivex.Completable
 import io.reactivex.Single
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 class PassportCameraView(context: Context) : FrameLayout(context) {
@@ -57,6 +62,10 @@ class PassportCameraView(context: Context) : FrameLayout(context) {
   private var cameraStarted = false
   private val isDecoding = AtomicBoolean(false)
   private val passportDispatched = AtomicBoolean(false)
+  // isDecoding is force-reset by ocrListener.onCompleted after every ML Kit pass, so the
+  // Tesseract fallback needs its own gate to keep the loop one-frame-at-a-time.
+  private val tesseractInFlight = AtomicBoolean(false)
+  private var tesseractProcessor: TesseractMrzProcessor? = null
   private var rotation: Int = 0
   private var mDist: Float = 0f
 
@@ -110,6 +119,14 @@ class PassportCameraView(context: Context) : FrameLayout(context) {
 
     MRZUtil.cleanStorage()
     frameProcessor = textProcessor
+    if (BuildConfig.TESSERACT_MRZ_FALLBACK && tesseractProcessor == null) {
+      val processor = TesseractMrzProcessor(context)
+      tesseractProcessor = processor
+      disposable.add(
+          Completable.fromAction { processor.warmUp() }
+              .subscribeOn(Schedulers.io())
+              .subscribe({}, { error -> Log.w("PassportCameraView", "Tesseract warm-up failed", error) }))
+    }
     rotation = getRotation(context, LensPosition.Back)
 
     val preview = binding.cameraPreview
@@ -143,6 +160,12 @@ class PassportCameraView(context: Context) : FrameLayout(context) {
     fotoapparat = null
     cameraStarted = false
     isDecoding.set(false)
+    tesseractProcessor?.let { processor ->
+      // close() blocks until an in-flight recognition drains — keep it off the main thread.
+      Schedulers.io().scheduleDirect { processor.close() }
+    }
+    tesseractProcessor = null
+    tesseractInFlight.set(false)
   }
 
   private fun configureZoom() {
@@ -158,6 +181,9 @@ class PassportCameraView(context: Context) : FrameLayout(context) {
           override fun process(frame: Frame) {
             try {
               if (!mounted || !isAttachedToWindow) {
+                return
+              }
+              if (tesseractInFlight.get()) {
                 return
               }
               if (!isDecoding.compareAndSet(false, true)) {
@@ -212,7 +238,15 @@ class PassportCameraView(context: Context) : FrameLayout(context) {
             return
           }
           try {
-            OcrUtils.processOcr(results = results, timeRequired = timeRequired, callback = mrzListener)
+            val callback =
+                object : OcrUtils.MRZCallback by mrzListener {
+                  override fun onMRZReadFailure(timeRequired: Long) {
+                    if (!maybeStartTesseractFallback(results, bitmap, timeRequired)) {
+                      mrzListener.onMRZReadFailure(timeRequired)
+                    }
+                  }
+                }
+            OcrUtils.processOcr(results = results, timeRequired = timeRequired, callback = callback)
           } catch (e: Exception) {
             mrzListener.onFailure(e, timeRequired)
           }
@@ -284,6 +318,40 @@ class PassportCameraView(context: Context) : FrameLayout(context) {
           mainHandler.post { dispatchError(e, "Something went wrong scanning MRZ with camera") }
         }
       }
+
+  /**
+   * Runs Tesseract (fine-tuned OCR-B model) over the frame when ML Kit found text but no
+   * check-digit-valid MRZ — ML Kit misreads OCR-B confusables like 0/O. Returns true when the
+   * fallback was started; the caller must then skip its own failure handling. Results flow
+   * through the same OcrUtils validation and mrzListener, so only check-digit-valid MRZ data
+   * is ever dispatched.
+   */
+  private fun maybeStartTesseractFallback(results: Text, bitmap: Bitmap?, timeRequired: Long): Boolean {
+    if (!BuildConfig.TESSERACT_MRZ_FALLBACK) return false
+    val processor = tesseractProcessor ?: return false
+    if (bitmap == null || passportDispatched.get()) return false
+    if (!TesseractMrzProcessor.looksLikeMrz(results)) return false
+    if (!tesseractInFlight.compareAndSet(false, true)) return false
+    disposable.add(
+        Single.fromCallable { processor.recognizeMrz(bitmap, results) }
+            .subscribeOn(Schedulers.io())
+            .timeout(TESSERACT_TIMEOUT_SECONDS, TimeUnit.SECONDS, Schedulers.io())
+            .doFinally { tesseractInFlight.set(false) }
+            .subscribe(
+                { rawText ->
+                  if (rawText.isBlank()) {
+                    mrzListener.onMRZReadFailure(timeRequired)
+                  } else {
+                    OcrUtils.processOcr(rawText = rawText, timeRequired = timeRequired, callback = mrzListener)
+                  }
+                },
+                { error ->
+                  Log.w("PassportCameraView", "Tesseract fallback failed", error)
+                  processor.cancelCurrent()
+                  mrzListener.onMRZReadFailure(timeRequired)
+                }))
+    return true
+  }
 
   protected val textProcessor: OcrMrzDetectorProcessor
     get() = OcrMrzDetectorProcessor()
@@ -386,6 +454,11 @@ class PassportCameraView(context: Context) : FrameLayout(context) {
   private fun hasCameraPermission(): Boolean =
       ContextCompat.checkSelfPermission(context, android.Manifest.permission.CAMERA) ==
           PackageManager.PERMISSION_GRANTED
+
+  private companion object {
+    // Bounds a stuck native recognition so the tesseractInFlight gate can't wedge the scan loop.
+    const val TESSERACT_TIMEOUT_SECONDS = 3L
+  }
 
   private fun dispatchPassportRead(mrzInfo: org.jmrtd.lds.icao.MRZInfo) {
     val reactContext = UIManagerHelper.getReactContext(this) as? ReactContext ?: return

--- a/app/docs/TESSERACT_MRZ_FALLBACK.md
+++ b/app/docs/TESSERACT_MRZ_FALLBACK.md
@@ -1,0 +1,21 @@
+# Android Tesseract MRZ fallback (SELF-3447)
+
+ML Kit stays the primary MRZ OCR on Android. When a frame yields text but no
+check-digit-valid MRZ (ML Kit misreads OCR-B confusables — reads `S0A00A92` as
+`SOAOOA92`), `PassportCameraView` runs a second pass with a fine-tuned
+Tesseract OCR-B model, fully on-device.
+
+- Trigger + threading: `app/android/app/src/main/java/com/proofofpassportapp/ui/PassportCameraView.kt`
+  (`maybeStartTesseractFallback`). Gated by the `TESSERACT_MRZ_FALLBACK`
+  build config flag in `app/android/app/build.gradle`; the same flag is the
+  hook for a future Tesseract-primary mode.
+- Recognizer, model asset, and validation live in the private
+  `selfxyz/android-passport-nfc-reader` repo (`:passportreader` module) —
+  see the "Tesseract MRZ fallback" section of its README for design, perf
+  (~200 ms/frame band OCR), and model provenance/sha256.
+- Model training + regeneration pipeline: `services/mrz-vision/tesseract/README.md`.
+- Fail closed: only regex + JMRTD check-digit-valid MRZ results dispatch
+  through the existing `PassportReadEvent` path; the JS payload shape is
+  unchanged.
+- iOS already uses Tesseract for MRZ (QKMRZScanner → SwiftyTesseract), so this
+  brings platform parity.


### PR DESCRIPTION
## Summary

<!-- Brief description of changes -->

## Test plan

<!-- How was this tested? -->

---

### Native code checklist

<!-- Only if this PR touches Kotlin/Swift or the React Native module bridge. Delete this section otherwise. -->

Run each command and check the box only after it passes. Paste failures into the Test plan.

- [ ] `pnpm lint && pnpm types` pass
- [ ] Bridge contract tests pass: `cd app && pnpm jest:run` and `pnpm --filter @selfxyz/rn-sdk-test-app test`
- [ ] If `packages/mobile-sdk-alpha` touched: `pnpm --filter @selfxyz/mobile-sdk-alpha test && pnpm --filter @selfxyz/mobile-sdk-alpha types` pass
- [ ] Diff of `.kt`/`.swift` reviewed - no business logic added (only hardware/OS access; logic lives in TypeScript)
- [ ] NativeModules bridge contract (method names, payload keys, error codes) unchanged, or the change is intentional and described in the summary

**Cannot be verified by an agent - flag for human QA:**

- [ ] Native builds (app + RN test app, iOS + Android) - relying on CI, or needs a human local build
- [ ] On-device smoke test of the affected flow (e.g. NFC passport read, MRZ camera scan) - **needs human**, or N/A if no runtime behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional on-device fallback for passport MRZ scanning on Android to improve reads when the primary scan misses or misreads a machine-readable zone.
  * Introduced configuration flags to control when the fallback path is enabled.

* **Bug Fixes**
  * Improved scan reliability by preventing invalid MRZ results from being accepted.
  * Reduced duplicate processing during fallback scanning by keeping frame handling single-threaded.

* **Documentation**
  * Added guidance on the Android MRZ fallback behavior and how it is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->