### PR TITLE
useSafeAreaInsets in BottomActionBar

### DIFF
--- a/app/src/components/proof-request/BottomActionBar.tsx
+++ b/app/src/components/proof-request/BottomActionBar.tsx
@@ -4,11 +4,11 @@
 
 import React from 'react';
 import { ActivityIndicator, Pressable, StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Text, View, XStack, YStack } from 'tamagui';
 
 import { slate500 as trueSlate500 } from '@selfxyz/mobile-sdk-alpha/constants/colors';
 import { dinot } from '@selfxyz/mobile-sdk-alpha/constants/fonts';
-import { useSafeBottomPadding } from '@selfxyz/mobile-sdk-alpha/hooks';
 import type { Perk } from '@selfxyz/mobile-sdk-alpha/onboarding/perks';
 
 import { proofRequestColors } from '@/components/proof-request/designTokens';
@@ -63,8 +63,8 @@ export const BottomActionBar: React.FC<BottomActionBarProps> = ({
   const topPadding = 4;
 
   const basePadding = 4;
-  const safeAreaPadding = useSafeBottomPadding(basePadding);
-  const dynamicPadding = safeAreaPadding;
+  const insets = useSafeAreaInsets();
+  const dynamicPadding = Math.max(insets.bottom, 12) + basePadding;
 
   return (
     <View


### PR DESCRIPTION
## Summary

<!-- Brief description of changes -->
Replace the screen height heuristic with real safe-area insets so the approve button doesn't sit against the gesture bar on the document selector

## Test plan

<!-- How was this tested? -->

---

### Native code checklist

<!-- Only if this PR touches Kotlin/Swift or the React Native module bridge. Delete this section otherwise. -->

Run each command and check the box only after it passes. Paste failures into the Test plan.

- [ ] `pnpm lint && pnpm types` pass
- [ ] Bridge contract tests pass: `cd app && pnpm jest:run` and `pnpm --filter @selfxyz/rn-sdk-test-app test`
- [ ] If `packages/mobile-sdk-alpha` touched: `pnpm --filter @selfxyz/mobile-sdk-alpha test && pnpm --filter @selfxyz/mobile-sdk-alpha types` pass
- [ ] Diff of `.kt`/`.swift` reviewed - no business logic added (only hardware/OS access; logic lives in TypeScript)
- [ ] NativeModules bridge contract (method names, payload keys, error codes) unchanged, or the change is intentional and described in the summary

**Cannot be verified by an agent - flag for human QA:**

- [ ] Native builds (app + RN test app, iOS + Android) - relying on CI, or needs a human local build
- [ ] On-device smoke test of the affected flow (e.g. NFC passport read, MRZ camera scan) - **needs human**, or N/A if no runtime behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bottom spacing in the proof request action bar to better respect device safe-area insets.
  * The bottom padding now has a minimum buffer, helping prevent buttons from sitting too close to the screen edge on some devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->