### PR TITLE
fix: display connected wallet address in ProofHistoryDetailScreen

### DIFF
--- a/app/src/screens/home/ProofHistoryDetailScreen.tsx
+++ b/app/src/screens/home/ProofHistoryDetailScreen.tsx
@@ -28,6 +28,7 @@ import {
 
 import type { ProofHistory } from '@/stores/proofTypes';
 import { ProofStatus } from '@/stores/proofTypes';
+import { formatUserId } from '@/utils/formatUserId';
 
 type ProofHistoryDetailScreenProps = {
   route: {
@@ -138,9 +139,10 @@ const ProofHistoryDetailScreen: React.FC<ProofHistoryDetailScreenProps> = ({
     return { uri: base64String };
   }, [data.logoBase64]);
 
+  // SelfAppBuilder strips the 0x prefix from hex userIds, so accept both forms.
   const isEthereumAddress = useMemo(() => {
     return (
-      /^0x[a-fA-F0-9]+$/.test(data.userId) &&
+      /^(0x)?[a-fA-F0-9]{40}$/.test(data.userId) &&
       (data.endpointType === 'staging_celo' || data.endpointType === 'celo') &&
       data.userIdType === 'hex'
     );
@@ -285,7 +287,7 @@ const ProofHistoryDetailScreen: React.FC<ProofHistoryDetailScreenProps> = ({
                       fontWeight="500"
                       ellipsizeMode="tail"
                     >
-                      {data.userId.slice(0, 2)}...{data.userId.slice(-4)}
+                      {formatUserId(data.userId, data.userIdType)}
                     </Text>
                   )}
                 </XStack>


### PR DESCRIPTION
## Summary

<!-- Brief description of changes -->

## Test plan

<!-- How was this tested? -->

---

### Native code checklist

<!-- Only if this PR touches Kotlin/Swift or the React Native module bridge. Delete this section otherwise. -->

Run each command and check the box only after it passes. Paste failures into the Test plan.

- [ ] `pnpm lint && pnpm types` pass
- [ ] Bridge contract tests pass: `cd app && pnpm jest:run` and `pnpm --filter @selfxyz/rn-sdk-test-app test`
- [ ] If `packages/mobile-sdk-alpha` touched: `pnpm --filter @selfxyz/mobile-sdk-alpha test && pnpm --filter @selfxyz/mobile-sdk-alpha types` pass
- [ ] Diff of `.kt`/`.swift` reviewed - no business logic added (only hardware/OS access; logic lives in TypeScript)
- [ ] NativeModules bridge contract (method names, payload keys, error codes) unchanged, or the change is intentional and described in the summary

**Cannot be verified by an agent - flag for human QA:**

- [ ] Native builds (app + RN test app, iOS + Android) - relying on CI, or needs a human local build
- [ ] On-device smoke test of the affected flow (e.g. NFC passport read, MRZ camera scan) - **needs human**, or N/A if no runtime behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how connected wallet/user identifiers are displayed for a cleaner, more consistent view.
  * Tightened Ethereum address detection so valid addresses are recognized more reliably, including cases with or without the `0x` prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->