### PR TITLE
chore: align version files with store reality (2.9.27, android 165)

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -159,7 +159,7 @@ android {
         applicationId "com.proofofpassportapp"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 164
+        versionCode 165
         versionName "2.9.27"
         manifestPlaceholders = [appAuthRedirectScheme: 'com.proofofpassportapp']
         // Tesseract OCR fallback when ML Kit yields no check-digit-valid MRZ (SELF-3447).

--- a/app/ios/Self/Info.plist
+++ b/app/ios/Self/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.9.26</string>
+	<string>2.9.27</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/app/version.json
+++ b/app/version.json
@@ -4,7 +4,7 @@
     "lastDeployed": "2026-06-17T18:14:31.922Z"
   },
   "android": {
-    "build": 164,
-    "lastDeployed": "2026-07-06T07:02:44.386Z"
+    "build": 165,
+    "lastDeployed": "2026-07-09T14:20:30.752Z"
   }
 }


### PR DESCRIPTION
## Why

The 2026-07-09 staging deploy (#2209) failed on iOS: `Info.plist` hardcodes `CFBundleShortVersionString = 2.9.26`, a released/closed App Store train, so the IPA was rejected regardless of the bumped `MARKETING_VERSION` ([failed run](https://github.com/selfxyz/self/actions/runs/29022791872/job/86134356552)). Android uploaded fine, but as user-facing "2.9.27" (hardcoded `versionName`) — CI's intended 2.9.28 never shipped anywhere.

## What

Aligns the version files with what's actually in the stores:

- `Info.plist`: `CFBundleShortVersionString` `2.9.26` → `2.9.27` (matches Android's live versionName)
- `build.gradle`: `versionCode` `164` → `165` (shipped to Play internal on 2026-07-09)
- `version.json`: android build → 165 with the actual deploy timestamp; iOS untouched (233 — no iOS build shipped)

Supersedes #2210 (records an unshipped 2.9.28) — close it unmerged.

## Next steps

1. Merge this, close #2210
2. Dispatch Mobile Deploy from `dev` with `platform: ios`, `upload: internal`, `version_bump: build` → uploads **2.9.27 (234)**, a fresh train
3. Follow-up PR: make `version-manager.cjs` own `versionName` and wire `CFBundleShortVersionString` to `$(MARKETING_VERSION)` so hardcoded drift can't recur

🤖 Generated with [Claude Code](https://claude.com/claude-code)