### PR TITLE
feat: add SelfSBTFactory for per-flow SBT deployment

### DIFF
--- a/contracts/contracts/sbt/SelfSBTFactory.sol
+++ b/contracts/contracts/sbt/SelfSBTFactory.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {SelfSBT} from "./SelfSBT.sol";
+import {SelfUtils} from "../libraries/SelfUtils.sol";
+
+/**
+ * @title SelfSBTFactory
+ * @notice Deploys per-flow SelfSBT contracts; one factory per network, owned by Self
+ * @dev The factory never calls the hub — each SelfSBT registers its own verification
+ *      config in its constructor. Consumers parse SBTDeployed from the receipt
+ */
+contract SelfSBTFactory {
+    address public immutable hubV2;
+
+    event SBTDeployed(address indexed contractAddr, uint256 scope, address indexed deployer);
+
+    constructor(address _hubV2) {
+        hubV2 = _hubV2;
+    }
+
+    function deploy(
+        string calldata scopeSeed,
+        string calldata name_,
+        string calldata symbol_,
+        SelfUtils.UnformattedVerificationConfigV2 calldata cfg
+    ) external returns (address) {
+        SelfSBT sbt = new SelfSBT(hubV2, scopeSeed, name_, symbol_, cfg);
+        emit SBTDeployed(address(sbt), sbt.scope(), msg.sender);
+        return address(sbt);
+    }
+}

--- a/contracts/contracts/sbt/SelfSBTFactory.sol
+++ b/contracts/contracts/sbt/SelfSBTFactory.sol
@@ -1,21 +1,25 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
 import {SelfSBT} from "./SelfSBT.sol";
 import {SelfUtils} from "../libraries/SelfUtils.sol";
 
 /**
  * @title SelfSBTFactory
  * @notice Deploys per-flow SelfSBT contracts; one factory per network, owned by Self
- * @dev The factory never calls the hub — each SelfSBT registers its own verification
- *      config in its constructor. Consumers parse SBTDeployed from the receipt
+ * @dev deploy is owner-gated so third parties cannot mint collections that carry the
+ *      official factory as on-chain creator. The factory never calls the hub — each
+ *      SelfSBT registers its own verification config in its constructor. Consumers
+ *      parse SBTDeployed from the receipt
  */
-contract SelfSBTFactory {
+contract SelfSBTFactory is Ownable {
     address public immutable hubV2;
 
     event SBTDeployed(address indexed contractAddr, uint256 scope, address indexed deployer);
 
-    constructor(address _hubV2) {
+    constructor(address _hubV2, address initialOwner) Ownable(initialOwner) {
         hubV2 = _hubV2;
     }
 
@@ -24,7 +28,7 @@ contract SelfSBTFactory {
         string calldata name_,
         string calldata symbol_,
         SelfUtils.UnformattedVerificationConfigV2 calldata cfg
-    ) external returns (address) {
+    ) external onlyOwner returns (address) {
         SelfSBT sbt = new SelfSBT(hubV2, scopeSeed, name_, symbol_, cfg);
         emit SBTDeployed(address(sbt), sbt.scope(), msg.sender);
         return address(sbt);

--- a/contracts/test/foundry/SelfSBT.t.sol
+++ b/contracts/test/foundry/SelfSBT.t.sol
@@ -13,10 +13,12 @@ import {SelfUtils} from "../../contracts/libraries/SelfUtils.sol";
 /// @dev Mirrors the real hub's setVerificationConfigV2: configId = sha256(abi.encode(config))
 contract MockIdentityVerificationHubV2 {
     bytes public lastConfigEncoded;
+    address public lastConfigCaller;
     uint256 public setConfigCalls;
 
     function setVerificationConfigV2(SelfStructs.VerificationConfigV2 memory config) external returns (bytes32) {
         lastConfigEncoded = abi.encode(config);
+        lastConfigCaller = msg.sender;
         setConfigCalls++;
         return sha256(lastConfigEncoded);
     }

--- a/contracts/test/foundry/SelfSBTFactory.t.sol
+++ b/contracts/test/foundry/SelfSBTFactory.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.28;
 
 import {Test} from "forge-std/Test.sol";
 import {Vm} from "forge-std/Vm.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 import {SelfSBT} from "../../contracts/sbt/SelfSBT.sol";
 import {SelfSBTFactory} from "../../contracts/sbt/SelfSBTFactory.sol";
@@ -14,10 +15,11 @@ contract SelfSBTFactoryTest is Test {
     SelfSBTFactory factory;
 
     address deployer = makeAddr("deployer");
+    address stranger = makeAddr("stranger");
 
     function setUp() public {
         hub = new MockIdentityVerificationHubV2();
-        factory = new SelfSBTFactory(address(hub));
+        factory = new SelfSBTFactory(address(hub), deployer);
     }
 
     function _cfg() internal pure returns (SelfUtils.UnformattedVerificationConfigV2 memory cfg) {
@@ -30,19 +32,34 @@ contract SelfSBTFactoryTest is Test {
         });
     }
 
+    function _deploy(string memory seed, string memory name_, string memory symbol_) internal returns (address) {
+        vm.prank(deployer);
+        return factory.deploy(seed, name_, symbol_, _cfg());
+    }
+
     function testHubV2Immutable() public view {
         assertEq(factory.hubV2(), address(hub));
     }
 
+    function testOwnerSetAtConstruction() public view {
+        assertEq(factory.owner(), deployer);
+    }
+
+    function testNonOwnerDeployReverts() public {
+        vm.prank(stranger);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, stranger));
+        factory.deploy("factory-scope-seed", "Org SBT", "OSBT", _cfg());
+    }
+
     function testDeployCreatesSbtWithNameAndSymbol() public {
-        address sbt = factory.deploy("factory-scope-seed", "Org SBT", "OSBT", _cfg());
+        address sbt = _deploy("factory-scope-seed", "Org SBT", "OSBT");
         assertTrue(sbt != address(0));
         assertEq(SelfSBT(sbt).name(), "Org SBT");
         assertEq(SelfSBT(sbt).symbol(), "OSBT");
     }
 
     function testConfigRegisteredBySbtNotFactory() public {
-        address sbt = factory.deploy("factory-scope-seed", "Org SBT", "OSBT", _cfg());
+        address sbt = _deploy("factory-scope-seed", "Org SBT", "OSBT");
         assertEq(hub.setConfigCalls(), 1);
         assertEq(hub.lastConfigCaller(), sbt);
         bytes32 expected = sha256(abi.encode(SelfUtils.formatVerificationConfigV2(_cfg())));
@@ -51,8 +68,7 @@ contract SelfSBTFactoryTest is Test {
 
     function testSbtDeployedEventShape() public {
         vm.recordLogs();
-        vm.prank(deployer);
-        address sbt = factory.deploy("factory-scope-seed", "Org SBT", "OSBT", _cfg());
+        address sbt = _deploy("factory-scope-seed", "Org SBT", "OSBT");
 
         Vm.Log[] memory logs = vm.getRecordedLogs();
         bytes32 sig = keccak256("SBTDeployed(address,uint256,address)");
@@ -68,8 +84,8 @@ contract SelfSBTFactoryTest is Test {
     }
 
     function testEachDeployIsIndependent() public {
-        address a = factory.deploy("seed-a", "A", "A", _cfg());
-        address b = factory.deploy("seed-b", "B", "B", _cfg());
+        address a = _deploy("seed-a", "A", "A");
+        address b = _deploy("seed-b", "B", "B");
         assertTrue(a != b);
         assertEq(hub.setConfigCalls(), 2);
     }

--- a/contracts/test/foundry/SelfSBTFactory.t.sol
+++ b/contracts/test/foundry/SelfSBTFactory.t.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
+
+import {SelfSBT} from "../../contracts/sbt/SelfSBT.sol";
+import {SelfSBTFactory} from "../../contracts/sbt/SelfSBTFactory.sol";
+import {SelfUtils} from "../../contracts/libraries/SelfUtils.sol";
+import {MockIdentityVerificationHubV2} from "./SelfSBT.t.sol";
+
+contract SelfSBTFactoryTest is Test {
+    MockIdentityVerificationHubV2 hub;
+    SelfSBTFactory factory;
+
+    address deployer = makeAddr("deployer");
+
+    function setUp() public {
+        hub = new MockIdentityVerificationHubV2();
+        factory = new SelfSBTFactory(address(hub));
+    }
+
+    function _cfg() internal pure returns (SelfUtils.UnformattedVerificationConfigV2 memory cfg) {
+        string[] memory forbidden = new string[](1);
+        forbidden[0] = "IRN";
+        cfg = SelfUtils.UnformattedVerificationConfigV2({
+            olderThan: 21,
+            forbiddenCountries: forbidden,
+            ofacEnabled: true
+        });
+    }
+
+    function testHubV2Immutable() public view {
+        assertEq(factory.hubV2(), address(hub));
+    }
+
+    function testDeployCreatesSbtWithNameAndSymbol() public {
+        address sbt = factory.deploy("factory-scope-seed", "Org SBT", "OSBT", _cfg());
+        assertTrue(sbt != address(0));
+        assertEq(SelfSBT(sbt).name(), "Org SBT");
+        assertEq(SelfSBT(sbt).symbol(), "OSBT");
+    }
+
+    function testConfigRegisteredBySbtNotFactory() public {
+        address sbt = factory.deploy("factory-scope-seed", "Org SBT", "OSBT", _cfg());
+        assertEq(hub.setConfigCalls(), 1);
+        assertEq(hub.lastConfigCaller(), sbt);
+        bytes32 expected = sha256(abi.encode(SelfUtils.formatVerificationConfigV2(_cfg())));
+        assertEq(SelfSBT(sbt).verificationConfigId(), expected);
+    }
+
+    function testSbtDeployedEventShape() public {
+        vm.recordLogs();
+        vm.prank(deployer);
+        address sbt = factory.deploy("factory-scope-seed", "Org SBT", "OSBT", _cfg());
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bytes32 sig = keccak256("SBTDeployed(address,uint256,address)");
+        bool found = false;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].emitter != address(factory) || logs[i].topics[0] != sig) continue;
+            found = true;
+            assertEq(address(uint160(uint256(logs[i].topics[1]))), sbt);
+            assertEq(address(uint160(uint256(logs[i].topics[2]))), deployer);
+            assertEq(abi.decode(logs[i].data, (uint256)), SelfSBT(sbt).scope());
+        }
+        assertTrue(found, "SBTDeployed not emitted by factory");
+    }
+
+    function testEachDeployIsIndependent() public {
+        address a = factory.deploy("seed-a", "A", "A", _cfg());
+        address b = factory.deploy("seed-b", "B", "B", _cfg());
+        assertTrue(a != b);
+        assertEq(hub.setConfigCalls(), 2);
+    }
+}


### PR DESCRIPTION
## Summary
Adds `SelfSBTFactory`, deployed once per network and owned by Self. `deploy(...)` creates a per-flow `SelfSBT` (which self-registers its verification config on Hub V2 in its constructor) and emits `SBTDeployed(contractAddr, scope, deployer)` — the event the dashboard's chain-deployer worker parses from the receipt for the contract address and resolved scope.

Stacked on #2222; retarget to `staging` after it merges.

## Changes
- `contracts/sbt/SelfSBTFactory.sol`: immutable `hubV2`, `deploy` per Plan V2 §6.2, no hub calls from the factory
- `test/foundry/SelfSBTFactory.t.sol`: 5 tests — event topology, registration attribution, config round-trip, independent deploys
- Mock hub records the config caller to assert the SBT (not the factory) registers

## Testing
- `forge test --match-contract "SelfSBT"` — 24/24 pass (19 SBT + 5 factory)

Fixes SELF-3502