### PR TITLE
chore: align app version to 2.9.28 (iOS 2.9.27 train closed)

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -159,8 +159,8 @@ android {
         applicationId "com.proofofpassportapp"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 165
-        versionName "2.9.27"
+        versionCode 166
+        versionName "2.9.28"
         manifestPlaceholders = [appAuthRedirectScheme: 'com.proofofpassportapp']
         // Tesseract OCR fallback when ML Kit yields no check-digit-valid MRZ (SELF-3447).
         buildConfigField "boolean", "TESSERACT_MRZ_FALLBACK", "true"

--- a/app/app.json
+++ b/app/app.json
@@ -4,7 +4,7 @@
   "expo": {
     "name": "Self App",
     "slug": "self-app",
-    "version": "2.9.27",
+    "version": "2.9.28",
     "platforms": ["ios", "android"],
     "ios": {
       "bundleIdentifier": "com.proofofpassportapp"

--- a/app/ios/Self.xcodeproj/project.pbxproj
+++ b/app/ios/Self.xcodeproj/project.pbxproj
@@ -619,7 +619,7 @@
 					"$(PROJECT_DIR)",
 					"$(PROJECT_DIR)/MoproKit/Libs",
 				);
-				MARKETING_VERSION = 2.9.27;
+				MARKETING_VERSION = 2.9.28;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -764,7 +764,7 @@
 					"$(PROJECT_DIR)",
 					"$(PROJECT_DIR)/MoproKit/Libs",
 				);
-				MARKETING_VERSION = 2.9.27;
+				MARKETING_VERSION = 2.9.28;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/app/ios/Self/Info.plist
+++ b/app/ios/Self/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.9.27</string>
+	<string>2.9.28</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@selfxyz/mobile-app",
-  "version": "2.9.27",
+  "version": "2.9.28",
   "private": true,
   "type": "module",
   "main": "index.js",

--- a/app/version.json
+++ b/app/version.json
@@ -4,7 +4,7 @@
     "lastDeployed": "2026-07-09T16:30:29.722Z"
   },
   "android": {
-    "build": 165,
+    "build": 166,
     "lastDeployed": "2026-07-09T14:20:30.752Z"
   }
 }


### PR DESCRIPTION
iOS App Store closed the `2.9.27` pre-release train after prod release, so internal builds on 2.9.27 hit `409 Invalid Pre-Release Train`. Bumps marketing version to **2.9.28** across all version files.

- Version strings → 2.9.28: `package.json`, pbxproj `MARKETING_VERSION` (x2), `Info.plist` `CFBundleShortVersionString`, `build.gradle` `versionName`
- Android build → **166** (versionCode 166 already shipped to Play internal; next build bump lands on 167)
- iOS build left at **234** (235 was rejected at upload, never registered)

Deploy with the default `build` bump (no `version:` label) → iOS 2.9.28(235), Android 2.9.28(167).

Note: marketing version is set manually in each file because it is not wired end-to-end (`Info.plist` hardcodes the version instead of `$(MARKETING_VERSION)`; `version-manager.cjs` never updates `versionName`). Supersedes auto bump PR #2226.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the app version to **2.9.28**.
  * Incremented iOS and Android build numbers to **166**.
  * Updated version metadata across the Android build, iOS build settings, iOS app info, and the app manifests to match **2.9.28**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->