### PR TITLE
fix(gate): Google USAT — route to selector for eligible alternatives + endpoint-agnostic match (SELF-3667)

### DIFF
--- a/app/src/hooks/useEarnPointsFlow.ts
+++ b/app/src/hooks/useEarnPointsFlow.ts
@@ -19,7 +19,7 @@ import {
 } from '@/services/points';
 import useUserStore from '@/stores/userStore';
 import { useVerificationGateStore } from '@/stores/verificationGateStore';
-import { evaluateGoogleUsatGate } from '@/utils/googleUsatGate';
+import { evaluateGoogleUsatEntryGate } from '@/utils/googleUsatGate';
 import { registerModalCallbacks } from '@/utils/modalCallbackRegistry';
 
 type UseEarnPointsFlowParams = {
@@ -40,7 +40,7 @@ export const useEarnPointsFlow = ({
 
   const navigateToPointsProof = useCallback(async () => {
     const selfApp = await pointsSelfApp();
-    const gate = await evaluateGoogleUsatGate(selfClient, selfApp);
+    const gate = await evaluateGoogleUsatEntryGate(selfClient, selfApp);
     if (gate === 'block') {
       selfClient.trackEvent(ProofEvents.GOOGLE_USAT_BLOCKED, {
         entry_point: 'earn_points',

--- a/app/src/navigation/deeplinks.ts
+++ b/app/src/navigation/deeplinks.ts
@@ -17,7 +17,7 @@ import useUserStore from '@/stores/userStore';
 import { useVerificationGateStore } from '@/stores/verificationGateStore';
 import { IS_DEV_MODE, IS_WIA_ENABLED } from '@/utils/devUtils';
 import {
-  evaluateGoogleUsatGate,
+  evaluateGoogleUsatEntryGate,
   isGoogleUsatForceEnabledForTesting,
 } from '@/utils/googleUsatGate';
 
@@ -184,7 +184,7 @@ export const handleUrl = async (selfClient: SelfClient, uri: string) => {
   if (selfAppStr) {
     try {
       const selfAppJson = JSON.parse(selfAppStr);
-      const gate = await evaluateGoogleUsatGate(selfClient, selfAppJson);
+      const gate = await evaluateGoogleUsatEntryGate(selfClient, selfAppJson);
       if (gate === 'block') {
         selfClient.trackEvent(ProofEvents.GOOGLE_USAT_BLOCKED, {
           entry_point: 'deeplink',

--- a/app/src/screens/verification/QRCodeViewFinderScreen.tsx
+++ b/app/src/screens/verification/QRCodeViewFinderScreen.tsx
@@ -38,7 +38,7 @@ import type { RootStackParamList } from '@/navigation';
 import { parseAndValidateUrlParams } from '@/navigation/deeplinks';
 import { useVerificationGateStore } from '@/stores/verificationGateStore';
 import {
-  evaluateGoogleUsatGate,
+  evaluateGoogleUsatEntryGate,
   isGoogleUsatForceEnabledForTesting,
 } from '@/utils/googleUsatGate';
 
@@ -83,7 +83,10 @@ const QRCodeViewFinderScreen: React.FC = () => {
         if (selfApp) {
           try {
             const selfAppJson = JSON.parse(selfApp);
-            const gate = await evaluateGoogleUsatGate(selfClient, selfAppJson);
+            const gate = await evaluateGoogleUsatEntryGate(
+              selfClient,
+              selfAppJson,
+            );
             if (gate === 'block') {
               selfClient.trackEvent(ProofEvents.GOOGLE_USAT_BLOCKED, {
                 entry_point: 'qr_scan',

--- a/app/src/utils/googleUsatGate.ts
+++ b/app/src/utils/googleUsatGate.ts
@@ -7,6 +7,7 @@ import type { DocumentCatalog, IDDocument } from '@selfxyz/common/utils/types';
 import {
   getAllDocuments,
   GOOGLE_USAT_FAUCET_POLICY,
+  hasEligibleAlternativeDocumentForPolicy,
   isDocumentEligibleForPolicy,
   isGoogleUsatProofRequest,
   type SelfClient,
@@ -92,6 +93,62 @@ export async function evaluateGoogleUsatGate(
       selectedDocumentId,
       docs,
     );
+  } catch {
+    // Fail open: this gate is a UX guard, not a security boundary. Faucet
+    // eligibility is enforced server-side. A transient local-storage failure
+    // must not permanently block the proof session.
+    return 'allow';
+  }
+}
+
+/**
+ * Entry-point variant of the gate: blocks ONLY when the selected document is
+ * ineligible AND no other registered document is eligible. When an eligible
+ * alternative exists it returns 'allow' so the caller proceeds to
+ * ProvingScreenRouter, which forces the document selector (see
+ * ProvingScreenRouter.tsx alternative-document handling). Unlike
+ * evaluateGoogleUsatGate — a selected-doc-only contract ProvingScreenRouter
+ * relies on — this is the guard the pre-navigation entry points should use so a
+ * user with e.g. a KYC doc selected but an eligible Aadhaar registered is routed
+ * to the selector instead of hard-blocked.
+ */
+export async function evaluateGoogleUsatEntryGate(
+  selfClient: SelfClient,
+  app: SelfApp,
+  context: GoogleUsatGateContext = {},
+): Promise<GoogleUsatGateResult> {
+  if (!shouldTreatAsGoogleUsat(app)) {
+    return 'allow';
+  }
+
+  try {
+    const catalog = context.catalog ?? (await selfClient.loadDocumentCatalog());
+    const selectedDocumentId = catalog.selectedDocumentId;
+
+    if (!selectedDocumentId) {
+      // No selection yet — defer to downstream selection checks.
+      return 'allow';
+    }
+
+    const docs = context.docs ?? (await getAllDocuments(selfClient));
+    const selected = await evaluateGoogleUsatGateForDocument(
+      selfClient,
+      app,
+      selectedDocumentId,
+      docs,
+    );
+    if (selected === 'allow') {
+      return 'allow';
+    }
+
+    // Selected doc is ineligible; only block if there is no eligible alternative.
+    return hasEligibleAlternativeDocumentForPolicy(
+      GOOGLE_USAT_FAUCET_POLICY,
+      docs,
+      selectedDocumentId,
+    )
+      ? 'allow'
+      : 'block';
   } catch {
     // Fail open: this gate is a UX guard, not a security boundary. Faucet
     // eligibility is enforced server-side. A transient local-storage failure

--- a/app/tests/src/hooks/useEarnPointsFlow.test.ts
+++ b/app/tests/src/hooks/useEarnPointsFlow.test.ts
@@ -20,7 +20,7 @@ import {
   POINTS_SELF_APP_NAME,
 } from '@/services/points/constants';
 import useUserStore from '@/stores/userStore';
-import { evaluateGoogleUsatGate } from '@/utils/googleUsatGate';
+import { evaluateGoogleUsatEntryGate } from '@/utils/googleUsatGate';
 import { getModalCallbacks } from '@/utils/modalCallbackRegistry';
 
 jest.mock('@react-navigation/native', () => ({
@@ -45,7 +45,7 @@ jest.mock('@/services/points', () => ({
 }));
 
 jest.mock('@/utils/googleUsatGate', () => ({
-  evaluateGoogleUsatGate: jest.fn(),
+  evaluateGoogleUsatEntryGate: jest.fn(),
 }));
 
 // userStore is used as-is, no mock needed
@@ -71,12 +71,15 @@ const mockHasUserDoneThePointsDisclosure =
 const mockPointsSelfApp = pointsSelfApp as jest.MockedFunction<
   typeof pointsSelfApp
 >;
-const mockEvaluateGoogleUsatGate =
-  evaluateGoogleUsatGate as jest.MockedFunction<typeof evaluateGoogleUsatGate>;
+const mockEvaluateGoogleUsatEntryGate =
+  evaluateGoogleUsatEntryGate as jest.MockedFunction<
+    typeof evaluateGoogleUsatEntryGate
+  >;
 
 describe('useEarnPointsFlow', () => {
   const mockSetSelfApp = jest.fn();
   const mockSelfClient = {
+    trackEvent: jest.fn(),
     getSelfAppState: jest.fn(() => ({
       setSelfApp: mockSetSelfApp,
     })),
@@ -98,7 +101,7 @@ describe('useEarnPointsFlow', () => {
     } as any);
 
     mockUseSelfClient.mockReturnValue(mockSelfClient as any);
-    mockEvaluateGoogleUsatGate.mockResolvedValue('allow');
+    mockEvaluateGoogleUsatEntryGate.mockResolvedValue('allow');
 
     mockUseRegisterReferral.mockReturnValue({
       registerReferral: mockRegisterReferral,
@@ -289,6 +292,45 @@ describe('useEarnPointsFlow', () => {
       expect(mockNavigate).toHaveBeenCalledWith('ProvingScreenRouter', {
         entryPoint: 'earn_points',
       });
+    });
+
+    it('does not start the proof when the gate blocks (no eligible document)', async () => {
+      mockHasUserAnIdentityDocumentRegistered.mockResolvedValue(true);
+      mockHasUserDoneThePointsDisclosure.mockResolvedValue(false);
+      mockPointsSelfApp.mockResolvedValue(mockSelfApp as any);
+      mockEvaluateGoogleUsatEntryGate.mockResolvedValue('block');
+
+      const { result } = renderHook(() =>
+        useEarnPointsFlow({
+          hasReferrer: false,
+          isReferralConfirmed: undefined,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.onEarnPointsPress();
+      });
+
+      const pointsInfoCallbackId = mockNavigate.mock.calls[0][1].callbackId;
+      await act(async () => {
+        await getModalCallbacks(pointsInfoCallbackId)!.onButtonPress();
+      });
+
+      const disclosureCallbackId = mockNavigate.mock.calls[1][1].callbackId;
+      await act(async () => {
+        await getModalCallbacks(disclosureCallbackId)!.onButtonPress();
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(100);
+      });
+
+      // Blocked path must not start proving or route to ProvingScreenRouter.
+      expect(mockSetSelfApp).not.toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalledWith(
+        'ProvingScreenRouter',
+        expect.anything(),
+      );
     });
 
     it('should clear referrer when points disclosure modal is dismissed with referrer', async () => {

--- a/app/tests/src/navigation/deeplinks.test.ts
+++ b/app/tests/src/navigation/deeplinks.test.ts
@@ -12,7 +12,7 @@ import {
 } from '@/navigation/deeplinks';
 import { useVerificationGateStore } from '@/stores/verificationGateStore';
 import {
-  evaluateGoogleUsatGate,
+  evaluateGoogleUsatEntryGate,
   isGoogleUsatForceEnabledForTesting,
 } from '@/utils/googleUsatGate';
 
@@ -56,7 +56,7 @@ jest.mock('@/stores/userStore', () => {
 });
 
 jest.mock('@/utils/googleUsatGate', () => ({
-  evaluateGoogleUsatGate: jest.fn(),
+  evaluateGoogleUsatEntryGate: jest.fn(),
   isGoogleUsatForceEnabledForTesting: jest.fn(() => false),
 }));
 
@@ -69,8 +69,10 @@ const mockUserStore = jest.requireMock('@/stores/userStore') as {
 };
 
 let setDeepLinkUserDetails: jest.Mock;
-const mockEvaluateGoogleUsatGate =
-  evaluateGoogleUsatGate as jest.MockedFunction<typeof evaluateGoogleUsatGate>;
+const mockEvaluateGoogleUsatEntryGate =
+  evaluateGoogleUsatEntryGate as jest.MockedFunction<
+    typeof evaluateGoogleUsatEntryGate
+  >;
 const mockIsGoogleUsatForceEnabledForTesting =
   isGoogleUsatForceEnabledForTesting as jest.MockedFunction<
     typeof isGoogleUsatForceEnabledForTesting
@@ -91,7 +93,7 @@ describe('deeplinks', () => {
       setDeepLinkUserDetails,
     });
     mockPlatform.OS = 'ios';
-    mockEvaluateGoogleUsatGate.mockResolvedValue('allow');
+    mockEvaluateGoogleUsatEntryGate.mockResolvedValue('allow');
     mockIsGoogleUsatForceEnabledForTesting.mockReturnValue(false);
     mockGateStoreGetState.mockReturnValue({ open: jest.fn() });
 
@@ -134,7 +136,7 @@ describe('deeplinks', () => {
     it('opens gate and resets off Splash when selfApp is blocked on cold launch', async () => {
       const open = jest.fn();
       mockGateStoreGetState.mockReturnValue({ open });
-      mockEvaluateGoogleUsatGate.mockResolvedValue('block');
+      mockEvaluateGoogleUsatEntryGate.mockResolvedValue('block');
 
       const selfApp = { sessionId: 'abc', appName: 'TestApp' };
       const url = `scheme://open?selfApp=${encodeURIComponent(JSON.stringify(selfApp))}`;
@@ -172,7 +174,7 @@ describe('deeplinks', () => {
     it('does not navigate on warm launch when selfApp is blocked', async () => {
       const open = jest.fn();
       mockGateStoreGetState.mockReturnValue({ open });
-      mockEvaluateGoogleUsatGate.mockResolvedValue('block');
+      mockEvaluateGoogleUsatEntryGate.mockResolvedValue('block');
       (MockNavigationRef.getCurrentRoute as jest.Mock).mockReturnValue({
         name: 'SettingsScreen',
       });

--- a/app/tests/src/utils/googleUsatGate.test.ts
+++ b/app/tests/src/utils/googleUsatGate.test.ts
@@ -8,6 +8,7 @@ import {
 } from '@selfxyz/mobile-sdk-alpha';
 
 import {
+  evaluateGoogleUsatEntryGate,
   evaluateGoogleUsatGate,
   evaluateGoogleUsatGateForDocument,
   FORCE_GOOGLE_USAT_FOR_TESTING,
@@ -204,5 +205,117 @@ describe('evaluateGoogleUsatGate', () => {
       evaluateGoogleUsatGateForDocument(selfClient, app, 'selected', docs),
     ).resolves.toBe('allow');
     expect(mockGetAllDocuments).not.toHaveBeenCalled();
+  });
+});
+
+describe('evaluateGoogleUsatEntryGate', () => {
+  const selfClient = {
+    loadDocumentCatalog: jest.fn(),
+  } as any;
+  const app = {
+    sessionId: 'session-id',
+    endpointType: 'celo',
+    chainID: 42220,
+    endpoint: '0xabc',
+  } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsGoogleUsatProofRequest.mockReturnValue(false);
+    mockGetAllDocuments.mockResolvedValue({});
+    selfClient.loadDocumentCatalog.mockResolvedValue({});
+  });
+
+  it('allows non Google USAT requests without loading documents', async () => {
+    await expect(evaluateGoogleUsatEntryGate(selfClient, app)).resolves.toBe(
+      'allow',
+    );
+    expect(selfClient.loadDocumentCatalog).not.toHaveBeenCalled();
+  });
+
+  it('allows when no document is selected (defers to downstream selection)', async () => {
+    mockIsGoogleUsatProofRequest.mockReturnValue(true);
+    selfClient.loadDocumentCatalog.mockResolvedValue({});
+    await expect(evaluateGoogleUsatEntryGate(selfClient, app)).resolves.toBe(
+      'allow',
+    );
+  });
+
+  it('allows when the selected document is eligible', async () => {
+    mockIsGoogleUsatProofRequest.mockReturnValue(true);
+    selfClient.loadDocumentCatalog.mockResolvedValue({
+      selectedDocumentId: 'b',
+    });
+    mockGetAllDocuments.mockResolvedValue({
+      b: { data: { documentCategory: 'passport', mock: false } } as any,
+    });
+    await expect(evaluateGoogleUsatEntryGate(selfClient, app)).resolves.toBe(
+      'allow',
+    );
+  });
+
+  it('allows (defers to selector) when selected is kyc but an eligible alternative exists', async () => {
+    mockIsGoogleUsatProofRequest.mockReturnValue(true);
+    selfClient.loadDocumentCatalog.mockResolvedValue({
+      selectedDocumentId: 'a',
+    });
+    mockGetAllDocuments.mockResolvedValue({
+      a: { data: { documentCategory: 'kyc', mock: false } } as any,
+      b: { data: { documentCategory: 'aadhaar', mock: false } } as any,
+    });
+    await expect(evaluateGoogleUsatEntryGate(selfClient, app)).resolves.toBe(
+      'allow',
+    );
+  });
+
+  it('blocks when selected is kyc and no eligible alternative exists', async () => {
+    mockIsGoogleUsatProofRequest.mockReturnValue(true);
+    selfClient.loadDocumentCatalog.mockResolvedValue({
+      selectedDocumentId: 'a',
+    });
+    mockGetAllDocuments.mockResolvedValue({
+      a: { data: { documentCategory: 'kyc', mock: false } } as any,
+    });
+    await expect(evaluateGoogleUsatEntryGate(selfClient, app)).resolves.toBe(
+      'block',
+    );
+  });
+
+  it('blocks when the only alternative is a mock document', async () => {
+    mockIsGoogleUsatProofRequest.mockReturnValue(true);
+    selfClient.loadDocumentCatalog.mockResolvedValue({
+      selectedDocumentId: 'a',
+    });
+    mockGetAllDocuments.mockResolvedValue({
+      a: { data: { documentCategory: 'kyc', mock: false } } as any,
+      b: { data: { documentCategory: 'passport', mock: true } } as any,
+    });
+    await expect(evaluateGoogleUsatEntryGate(selfClient, app)).resolves.toBe(
+      'block',
+    );
+  });
+
+  it('allows (defers) when the selected document is missing but an eligible alternative exists', async () => {
+    mockIsGoogleUsatProofRequest.mockReturnValue(true);
+    selfClient.loadDocumentCatalog.mockResolvedValue({
+      selectedDocumentId: 'missing',
+    });
+    mockGetAllDocuments.mockResolvedValue({
+      b: { data: { documentCategory: 'passport', mock: false } } as any,
+    });
+    await expect(evaluateGoogleUsatEntryGate(selfClient, app)).resolves.toBe(
+      'allow',
+    );
+  });
+
+  it('fails open when getAllDocuments throws', async () => {
+    mockIsGoogleUsatProofRequest.mockReturnValue(true);
+    selfClient.loadDocumentCatalog.mockResolvedValue({
+      selectedDocumentId: 'a',
+    });
+    mockGetAllDocuments.mockRejectedValue(new Error('network down'));
+    await expect(evaluateGoogleUsatEntryGate(selfClient, app)).resolves.toBe(
+      'allow',
+    );
   });
 });

--- a/packages/mobile-sdk-alpha/src/constants/restrictedApps.ts
+++ b/packages/mobile-sdk-alpha/src/constants/restrictedApps.ts
@@ -14,6 +14,11 @@ import { GOOGLE_USAT_FAUCET_APP_NAME, GOOGLE_USAT_FAUCET_ENDPOINT, GOOGLE_USAT_F
  * Add entries to RESTRICTED_APP_REGISTRY to apply the same UX gate to a new
  * partner without changing call-site code. The gate is a UX guard, not a
  * security boundary — server-side checks remain authoritative.
+ *
+ * TEMPORARY(SELF-3667): the `endpoint` field of `match` is currently ignored by
+ * findRestrictedAppPolicy (matches on scope + appName only) so the gate survives
+ * faucet endpoint rotation without an app release. It will be matched again once
+ * the endpoint is driven by Remote Config.
  */
 export interface RestrictedAppPolicy {
   /** Stable identifier used in analytics and modal copy lookup. */

--- a/packages/mobile-sdk-alpha/src/utils/restrictedApps.ts
+++ b/packages/mobile-sdk-alpha/src/utils/restrictedApps.ts
@@ -7,23 +7,30 @@ import type { DocumentCategory } from '@selfxyz/common/utils/types';
 
 import { RESTRICTED_APP_REGISTRY, type RestrictedAppPolicy } from '../constants/restrictedApps';
 
-function normalizeEndpoint(value: string | undefined): string {
-  return value?.trim().toLowerCase() ?? '';
-}
+// TEMPORARY(SELF-3667): the endpoint clause is disabled so the Google USAT gate
+// keeps matching when the faucet's endpoint rotates, without shipping an app
+// release each time. Restore `normalizeEndpoint`, the `endpoint` local, and the
+// endpoint clause below once the endpoint is driven by Remote Config. SELF-3667.
+// function normalizeEndpoint(value: string | undefined): string {
+//   return value?.trim().toLowerCase() ?? '';
+// }
 
 /**
  * Returns the RestrictedAppPolicy whose identity matches the given SelfApp,
- * or null if none match. Endpoint comparison is trim+lowercase normalized on
- * both sides; scope and appName are exact (case-sensitive) matches.
+ * or null if none match. scope and appName are exact (case-sensitive) matches.
+ *
+ * TEMPORARY(SELF-3667): endpoint is intentionally excluded from the match; only
+ * scope + appName are compared. See the note above.
  */
 export function findRestrictedAppPolicy(
   app: SelfApp,
   registry: ReadonlyArray<RestrictedAppPolicy> = RESTRICTED_APP_REGISTRY,
 ): RestrictedAppPolicy | null {
-  const endpoint = normalizeEndpoint(app.endpoint);
+  // TEMPORARY(SELF-3667): endpoint check disabled — see note above.
+  // const endpoint = normalizeEndpoint(app.endpoint);
   for (const policy of registry) {
     if (
-      endpoint === normalizeEndpoint(policy.match.endpoint) &&
+      // endpoint === normalizeEndpoint(policy.match.endpoint) &&
       app.scope === policy.match.scope &&
       app.appName === policy.match.appName
     ) {

--- a/packages/mobile-sdk-alpha/tests/utils/googleUsat.test.ts
+++ b/packages/mobile-sdk-alpha/tests/utils/googleUsat.test.ts
@@ -46,10 +46,18 @@ describe('isGoogleUsatProofRequest', () => {
     expect(isGoogleUsatProofRequest(buildApp({ scope: 'some-other-scope' }))).toBe(false);
   });
 
-  it('returns false when endpoint differs', () => {
-    expect(isGoogleUsatProofRequest(buildApp({ endpoint: 'https://example.com/api/verify' }))).toBe(false);
+  // TEMPORARY(SELF-3667): endpoint is excluded from the identity match, so a
+  // differing endpoint (with matching scope+appName) now matches. Restore the
+  // original `toBe(false)` assertion (and rename back to "returns false when
+  // endpoint differs") when endpoint matching is re-enabled via Remote Config.
+  it('matches even when endpoint differs (endpoint excluded from match)', () => {
+    expect(isGoogleUsatProofRequest(buildApp({ endpoint: 'https://example.com/api/verify' }))).toBe(true);
   });
 
+  // TEMPORARY(SELF-3667): the following endpoint-normalization cases still pass
+  // but no longer exercise endpoint matching (endpoint is currently excluded
+  // from the match). They become meaningful again once endpoint matching is
+  // restored via Remote Config; kept here so that restoration re-covers them.
   it('is case-insensitive on the endpoint host and tolerates surrounding whitespace', () => {
     const variant = ` ${GOOGLE_USAT_FAUCET_ENDPOINT.toUpperCase()} `;
     expect(isGoogleUsatProofRequest(buildApp({ endpoint: variant }))).toBe(true);


### PR DESCRIPTION
Two related fixes to the Google USAT faucet verification gate.

## 1. Route to the document selector when an eligible alternative exists
**Bug:** A user with a KYC document *selected* but an eligible document (e.g. Aadhaar) *also registered* was shown the "High-security ID required" block modal when the faucet was opened via **deeplink** (and, identically, via **QR scan** and **earn-points**).

**Cause:** the three entry points pre-checked the gate with `evaluateGoogleUsatGate`, which only inspects the *selected* document, and hard-blocked — even though `ProvingScreenRouter` (where they all navigate) already knows how to steer users with an eligible alternative to the document selector.

**Fix:** new `evaluateGoogleUsatEntryGate` helper that blocks only when there is *no* eligible document at all; otherwise it defers to `ProvingScreenRouter`, which opens the selector. The three entry points now use it. `evaluateGoogleUsatGate` is left unchanged (its selected-doc-only contract is relied on by `ProvingScreenRouter` and covered by an existing test).

Tests: new `evaluateGoogleUsatEntryGate` unit suite; repointed deeplink + earn-points mocks; added an earn-points block test.

## 2. Temporarily match the faucet by scope + appName only (SELF-3667)
The gate identity match hard-codes the faucet `endpoint`, so an endpoint rotation silently disables the gate until an app release updates the constant. As a stopgap (remote-config is deferred, see SELF-3667), the `endpoint` clause in `findRestrictedAppPolicy` is commented out — matching on `scope` + `appName` only — so the gate survives endpoint rotation without a release.

Contained to the Google USAT gate (only policy in the registry). No security regression: all identity fields are verifier-controlled JSON, so endpoint never provided spoof resistance; the gate is a UX guard with server-side eligibility enforcement and fails open. All temporary edits are marked `TEMPORARY(SELF-3667)` for easy revert.

Follow-up to restore endpoint matching via Remote Config: **SELF-3667**.

## Validation
- `app` `tsc` clean; SDK `tsc` clean.
- `eslint` clean on all changed files.
- `jest`: googleUsatGate + deeplinks + useEarnPointsFlow + ProvingScreenRouter suites pass (92 tests).
- `vitest`: SDK restrictedApps + googleUsat suites pass (26 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Google USAT entry checks across points earning, QR code, and deeplink flows.
  - Users are now allowed to continue when an eligible alternative document is available.
  - Blocked users are consistently shown the verification prompt instead of being sent into an incomplete flow.
  - Google USAT access checks remain available during faucet endpoint changes, reducing unnecessary access blocks.

- **Tests**
  - Added coverage for eligible alternatives, missing documents, blocked access, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->