### PR TITLE
fix(aadhaar): parse UIDAI timestamp as IST

### DIFF
--- a/packages/mobile-sdk-alpha/src/flows/onboarding/import-aadhaar.ts
+++ b/packages/mobile-sdk-alpha/src/flows/onboarding/import-aadhaar.ts
@@ -34,14 +34,16 @@ export function useAadhaar() {
 
   const validateAAdhaarTimestamp = useCallback(
     async (timestamp: string): Promise<{ isValid: boolean; ageDays: number }> => {
-      //timestamp is in YYYY-MM-DD HH:MM format
-      const currentTimestamp = new Date().getTime();
-      const timestampTimestamp = new Date(timestamp).getTime();
-      const diffMinutes = (currentTimestamp - timestampTimestamp) / (1000 * 60);
+      // UIDAI QR timestamp is IST, format "YYYY-MM-DD HH:MM"; parse as IST so the
+      // check is device-timezone independent and matches the on-chain window.
+      const timestampMs = new Date(timestamp.replace(' ', 'T') + '+05:30').getTime();
+      const diffMinutes = (Date.now() - timestampMs) / (1000 * 60);
       const ageDays = parseFloat((diffMinutes / (60 * 24)).toFixed(2));
 
+      // Mirror the on-chain symmetric ±window (RegisterProofVerifierLib) so a fresh
+      // QR is not rejected client-side for clock skew in either direction.
       const allowedWindow = await getAadharRegistrationWindow();
-      const isValid = Number.isFinite(diffMinutes) && diffMinutes >= 0 && diffMinutes <= allowedWindow;
+      const isValid = Number.isFinite(diffMinutes) && Math.abs(diffMinutes) <= allowedWindow;
 
       return { isValid, ageDays };
     },


### PR DESCRIPTION
  ## Problem

  The client-side Aadhaar QR freshness check in `import-aadhaar.ts` (`validateAAdhaarTimestamp`) had two issues:

  1. **Timezone-dependent parsing.** The UIDAI QR timestamp string (`"YYYY-MM-DD HH:MM"`) is **IST**, but `new
  Date(timestamp)` parses a space-separated, offset-less string as **device-local** time. On a non-IST device
  (travelers/NRIs, or a phone left on another timezone) a *fresh* QR is misread by up to 5h30m, producing a bogus age
  and a false `QRCODE_EXPIRED`.
  2. **Asymmetric window.** `diffMinutes >= 0 && diffMinutes <= allowedWindow` rejected any future-looking timestamp. A
  device clock that's even slightly slow makes a fresh QR look like it's in the future and gets falsely rejected —
  stricter than the protocol.

  The authoritative check lives on-chain in `RegisterProofVerifierLib.sol` and is a **symmetric ±window** around
  `block.timestamp`, comparing an absolute epoch derived from QR bytes (timezone-independent). So the on-chain path was
  always fine; only this client pre-check was wrong, and it blocked users before they could even submit.

  ## Fix

  - Parse the IST string explicitly as `...T<HH:MM>+05:30` → an absolute instant, independent of device timezone.
  - Use `Math.abs(diffMinutes) <= allowedWindow` to mirror the on-chain symmetric window and tolerate clock skew in both
  directions.

  `ageDays` semantics are unchanged (QR age in days, decimal).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Aadhaar QR timestamp validation to be consistent across time zones.
  * Updated validity checking to tolerate minor timestamp drift in both directions, improving reliability for slightly out-of-sync clocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->