### PR TITLE
fix(rn-sdk-test-app): drop unused SelfSdkSwift SPM ref breaking iOS build

### DIFF
--- a/packages/rn-sdk-test-app/ios/SelfRNTestApp.xcodeproj/project.pbxproj
+++ b/packages/rn-sdk-test-app/ios/SelfRNTestApp.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		761780ED2CA45674006654EE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761780EC2CA45674006654EE /* AppDelegate.swift */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
-		DF76ACFC36E520F1BDE48DAD /* SelfSdkSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 190485A56864EA3A6D20A3F5 /* SelfSdkSwift */; };
 		F99B38F1555059F271D690CE /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */; };
 /* End PBXBuildFile section */
 
@@ -26,7 +25,6 @@
 		5DCACB8F33CDC322A6C60F78 /* libPods-SelfRNTestApp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SelfRNTestApp.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		761780EC2CA45674006654EE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = SelfRNTestApp/AppDelegate.swift; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = SelfRNTestApp/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		A24CD5BDE9DB27CBD118098E /* self-sdk-swift */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "self-sdk-swift"; path = "../../self-sdk-swift"; sourceTree = "<group>"; };
 		BFB0C0F12EA8C47500DBA670 /* SelfRNTestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = SelfRNTestApp.entitlements; path = SelfRNTestApp/SelfRNTestApp.entitlements; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
@@ -37,7 +35,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				0C80B921A6F3F58F76C31292 /* libPods-SelfRNTestApp.a in Frameworks */,
-				DF76ACFC36E520F1BDE48DAD /* SelfSdkSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -61,7 +58,6 @@
 		2D16E6871FA4F8E400B85C8A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				A24CD5BDE9DB27CBD118098E /* self-sdk-swift */,
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
 				5DCACB8F33CDC322A6C60F78 /* libPods-SelfRNTestApp.a */,
 			);
@@ -127,9 +123,6 @@
 			dependencies = (
 			);
 			name = SelfRNTestApp;
-			packageProductDependencies = (
-				190485A56864EA3A6D20A3F5 /* SelfSdkSwift */,
-			);
 			productName = SelfRNTestApp;
 			productReference = 13B07F961A680F5B00A75B9A /* SelfRNTestApp.app */;
 			productType = "com.apple.product-type.application";
@@ -156,9 +149,6 @@
 				Base,
 			);
 			mainGroup = 83CBB9F61A601CBA00E9B192;
-			packageReferences = (
-				F2DAD3AC3DB719E5F97F0454 /* XCLocalSwiftPackageReference "self-sdk-swift" */,
-			);
 			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -518,20 +508,6 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
-
-/* Begin XCLocalSwiftPackageReference section */
-		F2DAD3AC3DB719E5F97F0454 /* XCLocalSwiftPackageReference "self-sdk-swift" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = "../../self-sdk-swift";
-		};
-/* End XCLocalSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		190485A56864EA3A6D20A3F5 /* SelfSdkSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = SelfSdkSwift;
-		};
-/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 83CBB9F71A601CBA00E9B192 /* Project object */;
 }


### PR DESCRIPTION
## Problem

`RN SDK Test App CI` → `ios-build` fails on PRs into staging with Xcode exit 65:

example failing pipeline:
https://github.com/selfxyz/self/actions/runs/30756248972/job/91518783258?pr=2239

```
error: Multiple commands produce '.../SelfRNTestApp.app/Frameworks/OpenSSL.framework'
  note: Target 'SelfRNTestApp' has copy command from SourcePackages/checkouts/OpenSSL/...
  warning: duplicate output file ... on task: PhaseScriptExecution [CP] Embed Pods Frameworks
```

OpenSSL enters the app bundle from two package managers at once:

1. **SPM** — `SelfRNTestApp.xcodeproj` carries an `XCLocalSwiftPackageReference` to `../../self-sdk-swift` (added in #1821), which depends on `selfxyz/NFCPassportReader` → `krzyzanowskim/OpenSSL 1.1.2301`.
2. **CocoaPods** — `selfxyz-rn-nfc-passport` (autolinked via `@selfxyz/rn-sdk`, introduced in #2220) depends on `OpenSSL-Universal ~> 1.1.2301`, embedded by `[CP] Embed Pods Frameworks`.

Same output path, two producers → Xcode refuses to build.

## Fix

Remove the SPM reference. **No source file in SelfRNTestApp imports `SelfSdkSwift`** — the only consumers of that package are `kmp-sdk-test-app` and `kmp-minipay-sample`. It was a dead edge that existed purely as collision fuel.

This also makes the harness model what it claims to: a third-party `@selfxyz/rn-sdk` integrator installing via CocoaPods, not a hybrid CocoaPods + local SPM integration nobody ships.

Deleted (6 references, 24 lines):
- `PBXBuildFile` / `PBXFrameworksBuildPhase` entry for `SelfSdkSwift in Frameworks`
- `PBXFileReference` + `Frameworks` group child for `self-sdk-swift`
- `packageProductDependencies` on the `SelfRNTestApp` target
- `packageReferences` on the project
- `XCLocalSwiftPackageReference` and `XCSwiftPackageProductDependency` sections

## Scope

Narrow release unblocker. **No production impact** — `app/` (Self Wallet) is CocoaPods-only, has its own single OpenSSL provider (`OpenSSL-Universal ~> 1.1.1900` + the Didit AutoDetection variant pin), and does not link this project.

Deliberately **not** bundled here, tracked as follow-ups:
- Commit `packages/rn-sdk-test-app/ios/Podfile.lock` so the pod graph stops floating per CI run.
- Reconcile the `OpenSSL-Universal` pin split (`app/ios` `~> 1.1.1900` vs `rn-nfc-passport.podspec` `~> 1.1.2301`) before `app/` migrates onto the RN SDK native modules — those two cannot co-resolve in one Podfile today.
- `self-sdk-swift` tracks `NFCPassportReader` at `branch: main`, pinned only by a `Package.resolved` revision.
- Widen the `ios-build` trigger (gated to staging/main + `test-ios` label by #2110) — #2220 landed the OpenSSL pod dep on a dev PR that never ran `ios-build`, so this only surfaced at the release PR.

## Validation

- `plutil -lint project.pbxproj` → OK
- `xcodebuild -list -project SelfRNTestApp.xcodeproj` → target/scheme intact
- No remaining `SelfSdkSwift` / `self-sdk-swift` references in the project file
- `test-ios` label applied so `ios-build` runs on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the local Swift package from the iOS test app project.
  * Updated project configuration to eliminate its associated framework and package references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->