### PR TITLE
feat(core): warn once per process that SelfBackendVerifier is deprecated

### DIFF
--- a/.github/actions/cache-core-sdk-build/action.yml
+++ b/.github/actions/cache-core-sdk-build/action.yml
@@ -8,7 +8,7 @@ inputs:
   cache-version:
     description: Cache version string
     required: false
-    default: v1
+    default: v2
   fail-on-cache-miss:
     description: Fail if cache not found (restore mode only)
     required: false
@@ -29,6 +29,7 @@ runs:
         path: |
           common/dist
           sdk/core/dist
+          sdk/core/src/typechain-types
         key: core-sdk-build-${{ inputs.cache-version }}-${{ github.sha }}
         fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}
     - id: save
@@ -38,4 +39,5 @@ runs:
         path: |
           common/dist
           sdk/core/dist
+          sdk/core/src/typechain-types
         key: core-sdk-build-${{ inputs.cache-version }}-${{ github.sha }}

--- a/.github/workflows/core-sdk-ci.yml
+++ b/.github/workflows/core-sdk-ci.yml
@@ -73,7 +73,7 @@ jobs:
         uses: ./.github/actions/cache-core-sdk-build
         with:
           mode: save
-          cache-version: v1
+          cache-version: v2
 
   lint:
     runs-on: ubuntu-latest
@@ -90,7 +90,7 @@ jobs:
         uses: ./.github/actions/cache-core-sdk-build
         with:
           mode: restore
-          cache-version: v1
+          cache-version: v2
           fail-on-cache-miss: false
       - name: Install Dependencies
         uses: ./.github/actions/pnpm-install
@@ -117,7 +117,7 @@ jobs:
         uses: ./.github/actions/cache-core-sdk-build
         with:
           mode: restore
-          cache-version: v1
+          cache-version: v2
           fail-on-cache-miss: false
       - name: Install Dependencies
         uses: ./.github/actions/pnpm-install
@@ -144,7 +144,7 @@ jobs:
         uses: ./.github/actions/cache-core-sdk-build
         with:
           mode: restore
-          cache-version: v1
+          cache-version: v2
           fail-on-cache-miss: false
       - name: Install Dependencies
         uses: ./.github/actions/pnpm-install

--- a/sdk/core/src/SelfBackendVerifier.ts
+++ b/sdk/core/src/SelfBackendVerifier.ts
@@ -33,9 +33,7 @@ const CELO_TESTNET_RPC_URL = 'https://forno.celo-sepolia.celo-testnet.org';
 const IDENTITY_VERIFICATION_HUB_ADDRESS = '0xe57F4773bd9c9d8b6Cd70431117d353298B9f5BF';
 const IDENTITY_VERIFICATION_HUB_ADDRESS_STAGING = '0x16ECBA51e18a4a7e61fdC417f0d47AFEeDfbed74';
 
-// Warn once per process, not per instantiation, so servers constructing a
-// verifier per request don't flood their logs.
-let deprecationWarned = false;
+const DEPRECATION_WARNED_KEY = Symbol.for('selfxyz.core.deprecation-warned');
 
 export class SelfBackendVerifier {
   protected scope: string;
@@ -53,8 +51,8 @@ export class SelfBackendVerifier {
     configStorage: IConfigStorage,
     userIdentifierType: UserIdType
   ) {
-    if (!deprecationWarned) {
-      deprecationWarned = true;
+    if (!(globalThis as Record<symbol, unknown>)[DEPRECATION_WARNED_KEY]) {
+      (globalThis as Record<symbol, unknown>)[DEPRECATION_WARNED_KEY] = true;
       console.warn(
         '[@selfxyz/core] SelfBackendVerifier is deprecated — new integrations must use @selfxyz/enterprise-sdk. Migration guide: https://docs.self.xyz/docs/self-enterprise/migration/from-self-pass-sdk/'
       );

--- a/sdk/core/src/SelfBackendVerifier.ts
+++ b/sdk/core/src/SelfBackendVerifier.ts
@@ -33,6 +33,10 @@ const CELO_TESTNET_RPC_URL = 'https://forno.celo-sepolia.celo-testnet.org';
 const IDENTITY_VERIFICATION_HUB_ADDRESS = '0xe57F4773bd9c9d8b6Cd70431117d353298B9f5BF';
 const IDENTITY_VERIFICATION_HUB_ADDRESS_STAGING = '0x16ECBA51e18a4a7e61fdC417f0d47AFEeDfbed74';
 
+// Warn once per process, not per instantiation, so servers constructing a
+// verifier per request don't flood their logs.
+let deprecationWarned = false;
+
 export class SelfBackendVerifier {
   protected scope: string;
   protected identityVerificationHubContract: IdentityVerificationHubImpl;
@@ -49,6 +53,12 @@ export class SelfBackendVerifier {
     configStorage: IConfigStorage,
     userIdentifierType: UserIdType
   ) {
+    if (!deprecationWarned) {
+      deprecationWarned = true;
+      console.warn(
+        '[@selfxyz/core] SelfBackendVerifier is deprecated — new integrations must use @selfxyz/enterprise-sdk. Migration guide: https://docs.self.xyz/docs/self-enterprise/migration/from-self-pass-sdk/'
+      );
+    }
     const rpcUrl = mockPassport ? CELO_TESTNET_RPC_URL : CELO_MAINNET_RPC_URL;
     const provider = new ethers.JsonRpcProvider(rpcUrl);
     const identityVerificationHubAddress = mockPassport

--- a/sdk/core/tests/deprecationWarning.test.ts
+++ b/sdk/core/tests/deprecationWarning.test.ts
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { SelfBackendVerifier } from '../src/SelfBackendVerifier.js';
+import { AttestationId } from '../src/types/types.js';
+
+const configStorage = {
+  getConfig: async () => ({ olderThan: 18, excludedCountries: [], ofac: false }),
+  getActionId: async () => 'test',
+  setConfig: async () => false,
+};
+
+const construct = () =>
+  new SelfBackendVerifier(
+    'test-scope',
+    'https://example.com/api/verify',
+    true,
+    new Map<AttestationId, boolean>([[1, true]]),
+    configStorage,
+    'uuid'
+  );
+
+test('constructor warns about deprecation exactly once per process', () => {
+  const warnings: string[] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.map(String).join(' '));
+  };
+  try {
+    construct();
+    construct();
+  } finally {
+    console.warn = originalWarn;
+  }
+
+  const deprecationWarnings = warnings.filter((w) => w.includes('deprecated'));
+  assert.equal(deprecationWarnings.length, 1);
+  assert.ok(deprecationWarnings[0].includes('@selfxyz/enterprise-sdk'));
+  assert.ok(
+    deprecationWarnings[0].includes(
+      'https://docs.self.xyz/docs/self-enterprise/migration/from-self-pass-sdk/'
+    )
+  );
+});


### PR DESCRIPTION
## Summary
Adds a one-time `console.warn` to the `SelfBackendVerifier` constructor telling integrators the open-source SDK is deprecated and pointing at the `@selfxyz/enterprise-sdk` migration guide. Developers (and AI agents) read dev-server logs — this catches anyone who got past the npm install output, editor hints, and docs. Warns once per process, not per instantiation, so servers constructing a verifier per request don't flood logs.

## Changes
- Module-level guard + `console.warn` in the `SelfBackendVerifier` constructor (`sdk/core/src/SelfBackendVerifier.ts`)
- `tests/deprecationWarning.test.ts`: asserts exactly one warning across two constructions, containing the enterprise-sdk name and migration-guide URL

## Testing
- `pnpm test` in `sdk/core`: 4/4 pass (node 22, per `.nvmrc`)
- `pnpm lint` (prettier): clean; gitleaks + license-header pre-commit hooks pass

Fixes SELF-3760

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a deprecation warning for the backend verification component. The notification displays once per process to avoid redundant alerts and includes documentation to guide users through the migration process.
  * Updated build caching to improve preservation of generated SDK types and maintain consistent CI builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->