### PR TITLE
feat(sdk): add @deprecated JSDoc to legacy Self Pass SDK exports

### DIFF
--- a/common/src/utils/appType.ts
+++ b/common/src/utils/appType.ts
@@ -49,6 +49,12 @@ export interface SelfAppDisclosureConfig {
   minimumAge?: number;
 }
 
+/**
+ * @deprecated The open-source Self Pass SDK is legacy. New integrations must use
+ * `@selfxyz/enterprise-sdk`: create a session with `SelfClient` and redirect the user
+ * to the hosted `verificationUrl` instead of building a Self app config.
+ * Migration guide: https://docs.self.xyz/docs/self-enterprise/migration/from-self-pass-sdk/
+ */
 export class SelfAppBuilder {
   private config: SelfApp;
 
@@ -126,6 +132,12 @@ export class SelfAppBuilder {
   }
 }
 
+/**
+ * @deprecated The open-source Self Pass SDK is legacy. New integrations must use
+ * `@selfxyz/enterprise-sdk` and redirect the user to the hosted `verificationUrl`
+ * returned by `SelfClient` instead of constructing a universal link.
+ * Migration guide: https://docs.self.xyz/docs/self-enterprise/migration/from-self-pass-sdk/
+ */
 export function getUniversalLink(selfApp: SelfApp): string {
   return `${REDIRECT_URL}?selfApp=${encodeURIComponent(JSON.stringify(selfApp))}`;
 }

--- a/sdk/core/src/SelfBackendVerifier.ts
+++ b/sdk/core/src/SelfBackendVerifier.ts
@@ -33,6 +33,11 @@ const CELO_TESTNET_RPC_URL = 'https://forno.celo-sepolia.celo-testnet.org';
 const IDENTITY_VERIFICATION_HUB_ADDRESS = '0xe57F4773bd9c9d8b6Cd70431117d353298B9f5BF';
 const IDENTITY_VERIFICATION_HUB_ADDRESS_STAGING = '0x16ECBA51e18a4a7e61fdC417f0d47AFEeDfbed74';
 
+/**
+ * @deprecated The open-source Self Pass SDK is legacy. New integrations must use
+ * `SelfClient` from `@selfxyz/enterprise-sdk` — the managed verifier replaces this class.
+ * Migration guide: https://docs.self.xyz/docs/self-enterprise/migration/from-self-pass-sdk/
+ */
 export class SelfBackendVerifier {
   protected scope: string;
   protected identityVerificationHubContract: IdentityVerificationHubImpl;

--- a/sdk/qrcode-angular/src/lib/common.ts
+++ b/sdk/qrcode-angular/src/lib/common.ts
@@ -567,6 +567,12 @@ export function validateUserId(userId: string, type: UserIdType): boolean {
   }
 }
 
+/**
+ * @deprecated The open-source Self Pass SDK is legacy. New integrations must use
+ * `@selfxyz/enterprise-sdk`: create a session with `SelfClient` and redirect the user
+ * to the hosted `verificationUrl` instead of building a Self app config.
+ * Migration guide: https://docs.self.xyz/docs/self-enterprise/migration/from-self-pass-sdk/
+ */
 export class SelfAppBuilder {
   private config: SelfApp;
 
@@ -643,6 +649,12 @@ export class SelfAppBuilder {
   }
 }
 
+/**
+ * @deprecated The open-source Self Pass SDK is legacy. New integrations must use
+ * `@selfxyz/enterprise-sdk` and redirect the user to the hosted `verificationUrl`
+ * returned by `SelfClient` instead of constructing a universal link.
+ * Migration guide: https://docs.self.xyz/docs/self-enterprise/migration/from-self-pass-sdk/
+ */
 export function getUniversalLink(selfApp: SelfApp): string {
   return `${REDIRECT_URL}?selfApp=${encodeURIComponent(JSON.stringify(selfApp))}`;
 }

--- a/sdk/qrcode-angular/src/lib/components/self-qrcode/self-qrcode.component.ts
+++ b/sdk/qrcode-angular/src/lib/components/self-qrcode/self-qrcode.component.ts
@@ -30,6 +30,12 @@ export interface SelfQRcodeProps {
   darkMode?: boolean;
 }
 
+/**
+ * @deprecated The open-source Self Pass SDK is legacy. New integrations must use
+ * `@selfxyz/enterprise-sdk`: redirect the user to the hosted `verificationUrl` —
+ * you no longer render your own QR code.
+ * Migration guide: https://docs.self.xyz/docs/self-enterprise/migration/from-self-pass-sdk/
+ */
 @Component({
   selector: 'lib-self-qrcode',
   standalone: true,

--- a/sdk/qrcode/components/SelfQRcode.tsx
+++ b/sdk/qrcode/components/SelfQRcode.tsx
@@ -28,6 +28,12 @@ interface SelfQRcodeProps {
   variant?: 'hybrid' | 'desktop' | 'mobile';
 }
 
+/**
+ * @deprecated The open-source Self Pass SDK is legacy. New integrations must use
+ * `@selfxyz/enterprise-sdk`: redirect the user to the hosted `verificationUrl` —
+ * you no longer render your own QR code.
+ * Migration guide: https://docs.self.xyz/docs/self-enterprise/migration/from-self-pass-sdk/
+ */
 const SelfQRcodeWrapper = (props: SelfQRcodeProps) => {
   const [isClient, setIsClient] = useState(false);
   useEffect(() => {
@@ -40,6 +46,12 @@ const SelfQRcodeWrapper = (props: SelfQRcodeProps) => {
   return <SelfQRcode {...props} />;
 };
 
+/**
+ * @deprecated The open-source Self Pass SDK is legacy. New integrations must use
+ * `@selfxyz/enterprise-sdk`: redirect the user to the hosted `verificationUrl` —
+ * you no longer render your own QR code.
+ * Migration guide: https://docs.self.xyz/docs/self-enterprise/migration/from-self-pass-sdk/
+ */
 const SelfQRcode = ({
   selfApp,
   onSuccess,

--- a/sdk/sdk-common/index.ts
+++ b/sdk/sdk-common/index.ts
@@ -567,6 +567,12 @@ export function validateUserId(userId: string, type: UserIdType): boolean {
   }
 }
 
+/**
+ * @deprecated The open-source Self Pass SDK is legacy. New integrations must use
+ * `@selfxyz/enterprise-sdk`: create a session with `SelfClient` and redirect the user
+ * to the hosted `verificationUrl` instead of building a Self app config.
+ * Migration guide: https://docs.self.xyz/docs/self-enterprise/migration/from-self-pass-sdk/
+ */
 export class SelfAppBuilder {
   private config: SelfApp;
 
@@ -643,6 +649,12 @@ export class SelfAppBuilder {
   }
 }
 
+/**
+ * @deprecated The open-source Self Pass SDK is legacy. New integrations must use
+ * `@selfxyz/enterprise-sdk` and redirect the user to the hosted `verificationUrl`
+ * returned by `SelfClient` instead of constructing a universal link.
+ * Migration guide: https://docs.self.xyz/docs/self-enterprise/migration/from-self-pass-sdk/
+ */
 export function getUniversalLink(selfApp: SelfApp): string {
   return `${REDIRECT_URL}?selfApp=${encodeURIComponent(JSON.stringify(selfApp))}`;
 }


### PR DESCRIPTION
## Summary
Tags every user-facing export of the legacy Self Pass SDK with `@deprecated` JSDoc pointing at `@selfxyz/enterprise-sdk` and the migration guide. This hits three channels at once: TypeScript surfaces it on hover/completion, editors strike the symbols through, and AI agents grepping `.d.ts` files see it directly. The published typings carry zero `@deprecated` tags today.

## Changes
- `SelfBackendVerifier` (sdk/core) — points at `SelfClient` from the enterprise SDK
- `SelfAppBuilder` + `getUniversalLink` in **both** sources: `common/src/utils/appType.ts` (re-exported by `@selfxyz/core`) and `sdk/sdk-common/index.ts` (re-exported by `@selfxyz/qrcode`)
- `SelfQRcodeWrapper` + `SelfQRcode` (sdk/qrcode) — hosted `verificationUrl` replaces self-rendered QR
- Same two symbols in `sdk/qrcode-angular`'s duplicated copy (also published)

## Testing
- Built `@selfxyz/common`, `@selfxyz/core`, `@selfxyz/sdk-common`, `@selfxyz/qrcode` — `@deprecated` present in every emitted `.d.ts`, including core's rolled-up `dist/index.d.ts`
- Prettier lint clean on all touched packages; `sdk/core` tests 3/3
- Note: publish a patch release of these packages after merge (pairs with the console.warn in #2249) so the tags reach npm

Fixes SELF-3761

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Marked legacy verification and QR code integration APIs as deprecated.
  * Added guidance directing new integrations to the Enterprise SDK and hosted verification URL flows.
  * Linked to migration documentation for transitioning existing integrations.
  * No runtime behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->