### PR TITLE
chore(release): bump legacy SDK versions for the deprecation release

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@selfxyz/common",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Constants and utils for self sdks",
   "license": "MIT",
   "author": "@Selfxyz Team",

--- a/sdk/core/package.json
+++ b/sdk/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@selfxyz/core",
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0-beta.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/selfxyz/self"

--- a/sdk/qrcode-angular/package.json
+++ b/sdk/qrcode-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@selfxyz/qrcode-angular",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Angular QR code wrapper SDK for Self passport verification",
   "keywords": [
     "angular",

--- a/sdk/qrcode/package.json
+++ b/sdk/qrcode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@selfxyz/qrcode",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "repository": {
     "type": "git",
     "url": "https://github.com/selfxyz/self"

--- a/sdk/sdk-common/package.json
+++ b/sdk/sdk-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@selfxyz/sdk-common",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "keywords": [],
   "license": "ISC",


### PR DESCRIPTION
## Summary
Version bumps so the `NPM Publish` workflow (fires on push to `dev`, publishes only on `package.json` version change) ships the deprecation release: the one-time console.warn and the `@deprecated` JSDoc tags ported in #2252. Per @aymanmohammed: bump + merge to dev, no tags needed.

**Merge order: #2252 first, then this** — publishing these versions before the deprecation code lands on dev would ship a no-op release.

## Changes
| Package | Current | Bump to |
|---|---|---|
| `common` | 0.0.9 | 0.0.10 |
| `sdk/core` | 1.2.0-beta.1 | 1.2.0-beta.2 |
| `sdk/qrcode` | 1.0.24 | 1.0.25 |
| `sdk/qrcode-angular` | 1.0.4 | 1.0.5 |
| `sdk/sdk-common` | 1.0.0 | 1.0.1 |

## Testing
- Version-only changes; after merge, verify `npm view @selfxyz/core versions` shows 1.2.0-beta.2 and the published `dist/index.d.ts` carries `@deprecated`
- Note: `sdk/sdk-common` is NOT covered by the publish workflow — publish 1.0.1 manually alongside (it's where `@selfxyz/qrcode` re-exports `SelfAppBuilder`/`getUniversalLink` from)

Fixes SELF-3764

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package versions across multiple modules for release management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->